### PR TITLE
[SPLIT-2844] Addin try-catch block for key parsing

### DIFF
--- a/src/engine/__tests__/parser/index.spec.js
+++ b/src/engine/__tests__/parser/index.spec.js
@@ -17,6 +17,7 @@ limitations under the License.
 
 const tape = require('tape');
 const parser = require('../../parser');
+const keyParser = require('../../../utils/key/parser');
 
 tape('PARSER / if user is in segment all 100%:on', async function (assert) {
 
@@ -37,7 +38,7 @@ tape('PARSER / if user is in segment all 100%:on', async function (assert) {
     label: 'in segment all'
   }]);
 
-  const evaluation = await evaluator('a key', 31, 100, 31);
+  const evaluation = await evaluator(keyParser('a key'), 31, 100, 31);
 
   assert.equal(typeof evaluator, 'function', 'evaluator should be callable');
   assert.equal(evaluation.treatment, 'on', "evaluator should return treatment 'on'");
@@ -68,7 +69,7 @@ tape('PARSER / if user is in segment all 100%:off', async function (assert) {
     label: 'in segment all'
   }]);
 
-  const evaluation = await evaluator('a key', 31, 100, 31);
+  const evaluation = await evaluator(keyParser('a key'), 31, 100, 31);
 
   assert.true(evaluation.treatment === 'off', "treatment evaluation should throw 'off'");
   assert.true(evaluation.label === 'in segment all', "label evaluation should throw 'in segment all'");
@@ -102,16 +103,16 @@ tape('PARSER / if user is in segment ["u1", "u2", "u3", "u4"] then split 100%:on
     label: 'explicitly included'
   }]);
 
-  let evaluation = await evaluator('a key', 31, 100, 31);
+  let evaluation = await evaluator(keyParser('a key'), 31, 100, 31);
   assert.true(evaluation === undefined, 'evaluation should throw undefined');
 
-  evaluation = await evaluator('u1', 31, 100, 31);
+  evaluation = await evaluator(keyParser('u1'), 31, 100, 31);
   assert.true(evaluation.treatment === 'on', "treatment evaluation should throw 'on'");
 
-  evaluation = await evaluator('u3', 31, 100, 31);
+  evaluation = await evaluator(keyParser('u3'), 31, 100, 31);
   assert.true(evaluation.treatment === 'on', "treatment should be evaluated to 'on'");
 
-  evaluation = await evaluator('u3', 31, 100, 31);
+  evaluation = await evaluator(keyParser('u3'), 31, 100, 31);
   assert.true(evaluation.label === 'explicitly included', "label should be evaluated to 'explicitly included'");
   assert.end();
 
@@ -148,16 +149,16 @@ tape('PARSER / if user.account is in list ["v1", "v2", "v3"] then split 100:on',
     label: 'explicitly included'
   }]);
 
-  let evaluation = await evaluator('test@split.io', 31, 100, 31, {
+  let evaluation = await evaluator(keyParser('test@split.io'), 31, 100, 31, {
     account: 'v1'
   });
   assert.true(evaluation.treatment === 'on', 'v1 is defined in the whitelist');
   assert.true(evaluation.label === 'explicitly included', 'label should be "explicitly included"');
 
-  evaluation = await evaluator('v1', 31, 100, 31);
+  evaluation = await evaluator(keyParser('v1'), 31, 100, 31);
   assert.true(evaluation === undefined, 'we are looking for v1 inside the account attribute');
 
-  evaluation = await evaluator('test@split.io', 31, 100, 31, {
+  evaluation = await evaluator(keyParser('test@split.io'), 31, 100, 31, {
     account: 'v4'
   });
   assert.true(evaluation === undefined, 'v4 is not defined inside the whitelist');
@@ -192,12 +193,12 @@ tape('PARSER / if user.account is in segment all then split 100:on', async funct
     label: 'in segment all'
   }]);
 
-  let evaluation = await evaluator('test@split.io', 31, 100, 31, {
+  let evaluation = await evaluator(keyParser('test@split.io'), 31, 100, 31, {
     account: 'v1'
   });
   assert.true(evaluation.treatment === 'on', 'v1 is defined in segment all');
 
-  assert.true(await evaluator('test@split.io', 31, 100, 31) === undefined, 'missing attribute should evaluates to undefined');
+  assert.true(await evaluator(keyParser('test@split.io'), 31, 100, 31) === undefined, 'missing attribute should evaluates to undefined');
 
   assert.end();
 });
@@ -230,18 +231,18 @@ tape('PARSER / if user.attr is between 10 and 20 then split 100:on', async funct
     }]
   }]);
 
-  let evaluation = await evaluator('test@split.io', 31, 100, 31, {
+  let evaluation = await evaluator(keyParser('test@split.io'), 31, 100, 31, {
     attr: 10
   });
   assert.true(evaluation.treatment === 'on', '10 is between 10 and 20');
 
-  evaluation = await evaluator('test@split.io', 31, 100, 31, {
+  evaluation = await evaluator(keyParser('test@split.io'), 31, 100, 31, {
     attr: 9
   });
   assert.true(evaluation === undefined, '9 is not between 10 and 20');
 
   assert.true(
-    await evaluator('test@split.io', 31, 100, 31) === undefined,
+    await evaluator(keyParser('test@split.io'), 31, 100, 31) === undefined,
     'undefined is not between 10 and 20'
   );
 
@@ -275,23 +276,23 @@ tape('PARSER / if user.attr <= datetime 1458240947021 then split 100:on', async 
     }]
   }]);
 
-  let evaluation = await evaluator('test@split.io', 31, 100, 31, {
+  let evaluation = await evaluator(keyParser('test@split.io'), 31, 100, 31, {
     attr: new Date('2016-03-17T18:55:47.021Z').getTime()
   });
   assert.true(evaluation.treatment === 'on', '1458240947021 is equal');
 
-  evaluation = await evaluator('test@split.io', 31, 100, 31, {
+  evaluation = await evaluator(keyParser('test@split.io'), 31, 100, 31, {
     attr: new Date('2016-03-17T17:55:47.021Z').getTime()
   });
   assert.true(evaluation.treatment === 'on', '1458240947020 is less than 1458240947021');
 
-  evaluation = await evaluator('test@split.io', 31, 100, 31, {
+  evaluation = await evaluator(keyParser('test@split.io'), 31, 100, 31, {
     attr: new Date('2016-03-17T19:55:47.021Z').getTime()
   });
   assert.true(evaluation === undefined, '1458240947022 is not less than 1458240947021');
 
   assert.true(
-    await evaluator('test@split.io', 31, 100, 31) === undefined,
+    await evaluator(keyParser('test@split.io'), 31, 100, 31) === undefined,
     'missing attributes in the parameters list'
   );
 
@@ -325,22 +326,22 @@ tape('PARSER / if user.attr >= datetime 1458240947021 then split 100:on', async 
     }]
   }]);
 
-  let evaluation = await evaluator('test@split.io', 31, 100, 31, {
+  let evaluation = await evaluator(keyParser('test@split.io'), 31, 100, 31, {
     attr: new Date('2016-03-17T18:55:47.021Z').getTime()
   });
   assert.true(evaluation.treatment === 'on', '1458240947021 is equal');
 
-  evaluation = await evaluator('test@split.io', 31, 100, 31, {
+  evaluation = await evaluator(keyParser('test@split.io'), 31, 100, 31, {
     attr: new Date('2016-03-17T17:55:47.021Z').getTime()
   });
   assert.true(evaluation === undefined, '1458240947020 is less than 1458240947021');
 
-  evaluation = await evaluator('test@split.io', 31, 100, 31, {
+  evaluation = await evaluator(keyParser('test@split.io'), 31, 100, 31, {
     attr: new Date('2016-03-17T19:55:47.021Z').getTime()
   });
   assert.true(evaluation.treatment === 'on', '1458240947000 is greater than 1458240947021');
 
-  assert.true(await evaluator('test@split.io', 31, 100, 31) === undefined,
+  assert.true(await evaluator(keyParser('test@split.io'), 31, 100, 31) === undefined,
     'missing attributes in the parameters list'
   );
 
@@ -374,22 +375,22 @@ tape('PARSER / if user.attr = datetime 1458240947021 then split 100:on', async f
     }]
   }]);
 
-  let evaluation = await evaluator('test@split.io', 31, 100, 31, {
+  let evaluation = await evaluator(keyParser('test@split.io'), 31, 100, 31, {
     attr: 1458240947021
   });
   assert.equal(evaluation.treatment, 'on', '2016-03-17T18:55:47.021Z is equal to 2016-03-17T18:55:47.021Z');
 
-  evaluation = await evaluator('test@split.io', 31, 100, 31, {
+  evaluation = await evaluator(keyParser('test@split.io'), 31, 100, 31, {
     attr: 1458240947020
   });
   assert.equal(evaluation.treatment, 'on', '2016-03-17T18:55:47.020Z is considered equal to 2016-03-17T18:55:47.021Z');
 
-  evaluation = await evaluator('test@split.io', 31, 100, 31, {
+  evaluation = await evaluator(keyParser('test@split.io'), 31, 100, 31, {
     attr: 1458240947020
   });
   assert.equal(evaluation.treatment, 'on', '2016-03-17T00:00:00Z is considered equal to 2016-03-17T18:55:47.021Z');
 
-  assert.equal(await evaluator('test@split.io', 31, 100, 31), undefined,
+  assert.equal(await evaluator(keyParser('test@split.io'), 31, 100, 31), undefined,
     'missing attributes should be evaluated to false'
   );
   assert.end();
@@ -418,142 +419,14 @@ tape('PARSER / if user is in segment all then split 20%:A,20%:B,60%:A', async fu
     }]
   }]);
 
-  let evaluation = await evaluator('aaaaa', 31, 100, 31);
+  let evaluation = await evaluator(keyParser('aaaaa'), 31, 100, 31);
   assert.equal(evaluation.treatment, 'A', '20%:A'); // bucket 15
 
-  evaluation = await evaluator('bbbbbbbbbbbbbbbbbbb', 31, 100, 31);
+  evaluation = await evaluator(keyParser('bbbbbbbbbbbbbbbbbbb'), 31, 100, 31);
   assert.equal(evaluation.treatment, 'B', '20%:B'); // bucket 34
 
-  evaluation = await evaluator('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 31, 100, 31);
+  evaluation = await evaluator(keyParser('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'), 31, 100, 31);
   assert.equal(evaluation.treatment, 'A', '60%:A'); // bucket 100
 
-  assert.end();
-});
-
-tape('PARSER / if user is in segment all 100%:on but trafficAllocation is 0%', async function (assert) {
-
-  const evaluator = parser([{
-    conditionType: 'ROLLOUT',
-    matcherGroup: {
-      combiner: 'AND',
-      matchers: [{
-        matcherType: 'ALL_KEYS',
-        negate: false,
-        userDefinedSegmentMatcherData: null,
-        whitelistMatcherData: null
-      }]
-    },
-    partitions: [{
-      treatment: 'on',
-      size: 100
-    }],
-    label: 'in segment all'
-  }]);
-
-  const evaluation = await evaluator('a key', 31, 0, 31);
-
-  assert.equal(evaluation.treatment, undefined, 'treatment should be undefined');
-  assert.equal(evaluation.label, 'not in split', 'label should be fixed string');
-  assert.end();
-});
-
-tape('PARSER / if user is in segment all 100%:on but trafficAllocation is 99% with bucket below 99', async function (assert) {
-
-  const evaluator = parser([{
-    conditionType: 'ROLLOUT',
-    matcherGroup: {
-      combiner: 'AND',
-      matchers: [{
-        matcherType: 'ALL_KEYS',
-        negate: false,
-        userDefinedSegmentMatcherData: null,
-        whitelistMatcherData: null
-      }]
-    },
-    partitions: [{
-      treatment: 'on',
-      size: 100
-    }],
-    label: 'in segment all'
-  }]);
-
-  const evaluation = await evaluator('a key', 31, 99, 31);
-
-  assert.equal(evaluation.treatment, 'on', "evaluator should return treatment 'on' as traffic allocation is bigger than bucket result");
-  assert.equal(evaluation.label, 'in segment all', "evaluator should return label 'in segment all'");
-  assert.end();
-});
-
-tape('PARSER / if user is in segment all 100%:on but trafficAllocation is 99% and bucket returns 100', async function (assert) {
-
-  const evaluator = parser([{
-    conditionType: 'ROLLOUT',
-    matcherGroup: {
-      combiner: 'AND',
-      matchers: [{
-        matcherType: 'ALL_KEYS',
-        negate: false,
-        userDefinedSegmentMatcherData: null,
-        whitelistMatcherData: null
-      }]
-    },
-    partitions: [{
-      treatment: 'on',
-      size: 100
-    }],
-    label: 'in segment all'
-  }]);
-
-  const evaluation = await evaluator('aaaaa', 31, 99, 14);
-
-  assert.equal(evaluation.treatment, undefined, 'treatment should be undefined');
-  assert.equal(evaluation.label, 'not in split', 'label should be fixed string');
-  assert.end();
-});
-
-tape('PARSER / if user is explicitly included and in segment all 100%:off with trafficAllocation as 0%', async function (assert) {
-
-  const evaluator = parser([{
-    conditionType: 'WHITELIST',
-    matcherGroup: {
-      combiner: 'AND',
-      matchers: [{
-        matcherType: 'WHITELIST',
-        negate: false,
-        userDefinedSegmentMatcherData: null,
-        whitelistMatcherData: {
-          whitelist: [
-            'a key'
-          ]
-        }
-      }]
-    },
-    partitions: [{
-      treatment: 'on',
-      size: 100
-    }],
-    label: 'explicitly included'
-  }, {
-    conditionType: 'ROLLOUT',
-    matcherGroup: {
-      combiner: 'AND',
-      matchers: [{
-        matcherType: 'ALL_KEYS',
-        negate: false,
-        userDefinedSegmentMatcherData: null,
-        whitelistMatcherData: null
-      }]
-    },
-    partitions: [{
-      treatment: 'off',
-      size: 100
-    }],
-    label: 'in segment all'
-  }]);
-
-  const evaluation = await evaluator('a key', 31, 0, 31);
-
-  assert.equal(evaluation.treatment, 'on', "evaluator should return treatment 'on' as whitelisting has more priority than traffic allocation");
-  assert.equal(evaluation.label, 'explicitly included', "evaluator should return label 'explicitly included'");
   assert.end();
 });

--- a/src/engine/__tests__/parser/index.spec.js
+++ b/src/engine/__tests__/parser/index.spec.js
@@ -452,7 +452,8 @@ tape('PARSER / if user is in segment all 100%:on but trafficAllocation is 0%', a
 
   const evaluation = await evaluator('a key', 31, 0, 31);
 
-  assert.equal(evaluation, undefined, "evaluation should return undefined as rollout has less priority than traffic allocation, so we don't apply the rollout");
+  assert.equal(evaluation.treatment, undefined, 'treatment should be undefined');
+  assert.equal(evaluation.label, 'not in split', 'label should be fixed string');
   assert.end();
 });
 
@@ -505,7 +506,8 @@ tape('PARSER / if user is in segment all 100%:on but trafficAllocation is 99% an
 
   const evaluation = await evaluator('aaaaa', 31, 99, 14);
 
-  assert.equal(evaluation, undefined, 'evaluation should return undefined as bucket is bigger than traffic allocation and rollout has less priority');
+  assert.equal(evaluation.treatment, undefined, 'treatment should be undefined');
+  assert.equal(evaluation.label, 'not in split', 'label should be fixed string');
   assert.end();
 });
 

--- a/src/engine/__tests__/parser/index.spec.js
+++ b/src/engine/__tests__/parser/index.spec.js
@@ -505,7 +505,7 @@ tape('PARSER / if user is in segment all 100%:on but trafficAllocation is 99% an
 
   const evaluation = await evaluator('aaaaa', 31, 99, 14);
 
-  assert.equal(evaluation, undefined, "evaluation should return undefined as bucket is bigger than traffic allocation and rollout has less priority");
+  assert.equal(evaluation, undefined, 'evaluation should return undefined as bucket is bigger than traffic allocation and rollout has less priority');
   assert.end();
 });
 

--- a/src/engine/__tests__/parser/trafficAllocation.spec.js
+++ b/src/engine/__tests__/parser/trafficAllocation.spec.js
@@ -1,0 +1,148 @@
+/**
+Copyright 2016 Split Software
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+**/
+'use strict';
+
+const tape = require('tape');
+const parser = require('../../parser');
+const keyParser = require('../../../utils/key/parser');
+
+tape('PARSER / if user is in segment all 100%:on but trafficAllocation is 0%', async function (assert) {
+
+  const evaluator = parser([{
+    conditionType: 'ROLLOUT',
+    matcherGroup: {
+      combiner: 'AND',
+      matchers: [{
+        matcherType: 'ALL_KEYS',
+        negate: false,
+        userDefinedSegmentMatcherData: null,
+        whitelistMatcherData: null
+      }]
+    },
+    partitions: [{
+      treatment: 'on',
+      size: 100
+    }],
+    label: 'in segment all'
+  }]);
+
+  const evaluation = await evaluator(keyParser('a key'), 31, 0, 31);
+
+  assert.equal(evaluation.treatment, undefined, 'treatment should be undefined');
+  assert.equal(evaluation.label, 'not in split', 'label should be fixed string');
+  assert.end();
+});
+
+tape('PARSER / if user is in segment all 100%:on but trafficAllocation is 99% with bucket below 99', async function (assert) {
+
+  const evaluator = parser([{
+    conditionType: 'ROLLOUT',
+    matcherGroup: {
+      combiner: 'AND',
+      matchers: [{
+        matcherType: 'ALL_KEYS',
+        negate: false,
+        userDefinedSegmentMatcherData: null,
+        whitelistMatcherData: null
+      }]
+    },
+    partitions: [{
+      treatment: 'on',
+      size: 100
+    }],
+    label: 'in segment all'
+  }]);
+
+  const evaluation = await evaluator(keyParser('a key'), 31, 99, 31);
+
+  assert.equal(evaluation.treatment, 'on', "evaluator should return treatment 'on' as traffic allocation is bigger than bucket result");
+  assert.equal(evaluation.label, 'in segment all', "evaluator should return label 'in segment all'");
+  assert.end();
+});
+
+tape('PARSER / if user is in segment all 100%:on but trafficAllocation is 99% and bucket returns 100', async function (assert) {
+
+  const evaluator = parser([{
+    conditionType: 'ROLLOUT',
+    matcherGroup: {
+      combiner: 'AND',
+      matchers: [{
+        matcherType: 'ALL_KEYS',
+        negate: false,
+        userDefinedSegmentMatcherData: null,
+        whitelistMatcherData: null
+      }]
+    },
+    partitions: [{
+      treatment: 'on',
+      size: 100
+    }],
+    label: 'in segment all'
+  }]);
+
+  const evaluation = await evaluator(keyParser('aaaaa'), 31, 99, 14);
+
+  assert.equal(evaluation.treatment, undefined, 'treatment should be undefined');
+  assert.equal(evaluation.label, 'not in split', 'label should be fixed string');
+  assert.end();
+});
+
+tape('PARSER / if user is explicitly included and in segment all 100%:off with trafficAllocation as 0%', async function (assert) {
+
+  const evaluator = parser([{
+    conditionType: 'WHITELIST',
+    matcherGroup: {
+      combiner: 'AND',
+      matchers: [{
+        matcherType: 'WHITELIST',
+        negate: false,
+        userDefinedSegmentMatcherData: null,
+        whitelistMatcherData: {
+          whitelist: [
+            'a key'
+          ]
+        }
+      }]
+    },
+    partitions: [{
+      treatment: 'on',
+      size: 100
+    }],
+    label: 'explicitly included'
+  }, {
+    conditionType: 'ROLLOUT',
+    matcherGroup: {
+      combiner: 'AND',
+      matchers: [{
+        matcherType: 'ALL_KEYS',
+        negate: false,
+        userDefinedSegmentMatcherData: null,
+        whitelistMatcherData: null
+      }]
+    },
+    partitions: [{
+      treatment: 'off',
+      size: 100
+    }],
+    label: 'in segment all'
+  }]);
+
+  const evaluation = await evaluator(keyParser('a key'), 31, 0, 31);
+
+  assert.equal(evaluation.treatment, 'on', "evaluator should return treatment 'on' as whitelisting has more priority than traffic allocation");
+  assert.equal(evaluation.label, 'explicitly included', "evaluator should return label 'explicitly included'");
+  assert.end();
+});

--- a/src/engine/evaluator/index.js
+++ b/src/engine/evaluator/index.js
@@ -20,6 +20,7 @@ limitations under the License.
 
 const engine = require('../engine');
 const thenable = require('../../utils/promise/thenable');
+const LabelsConstants = require('../../utils/labels');
 
 // Build Evaluation object if and only if matchingResult is true
 function match(matchingResult: boolean, bucketingKey: string, seed: number, treatments: Treatments, label: string, algo: ?number): ?Evaluation {
@@ -43,7 +44,10 @@ function evaluatorContext(matcherEvaluator: Function, treatments: Treatments, la
 
     // Whitelisting has more priority than traffic allocation, so we don't apply this filtering to those conditions.
     if (conditionType === 'ROLLOUT' && !engine.shouldApplyRollout(trafficAllocation, key.bucketingKey, trafficAllocationSeed, algo)) {
-      return;
+      return {
+        treatment: undefined,
+        label: LabelsConstants.NO_IN_SPLIT
+      };
     }
 
     // matcherEvaluator could be Async, this relays on matchers return value, so we need

--- a/src/engine/evaluator/index.js
+++ b/src/engine/evaluator/index.js
@@ -40,13 +40,13 @@ function match(matchingResult: boolean, bucketingKey: string, seed: number, trea
 // Evaluator factory
 function evaluatorContext(matcherEvaluator: Function, treatments: Treatments, label: string, conditionType: string): Function {
 
-  function evaluator(key: SplitKey, seed: number, trafficAllocation: number, trafficAllocationSeed: number, attributes: ?Object, algo: ?number): AsyncValue<?Evaluation> {
+  function evaluator(key: SplitKeyObject, seed: number, trafficAllocation: number, trafficAllocationSeed: number, attributes: ?Object, algo: ?number): AsyncValue<?Evaluation> {
 
     // Whitelisting has more priority than traffic allocation, so we don't apply this filtering to those conditions.
     if (conditionType === 'ROLLOUT' && !engine.shouldApplyRollout(trafficAllocation, key.bucketingKey, trafficAllocationSeed, algo)) {
       return {
         treatment: undefined,
-        label: LabelsConstants.NO_IN_SPLIT
+        label: LabelsConstants.NOT_IN_SPLIT
       };
     }
 

--- a/src/engine/index.js
+++ b/src/engine/index.js
@@ -19,6 +19,7 @@ limitations under the License.
 'use strict';
 
 const parser = require('./parser');
+const keyParser = require('../utils/key/parser');
 
 const thenable = require('../utils/promise/thenable');
 const LabelsConstants = require('../utils/labels');
@@ -63,8 +64,18 @@ Split.prototype.getTreatment = function getTreatment(key: SplitKey, attributes):
     algo
   } = this.baseInfo;
 
+  let parsedKey;
   let treatment;
   let label;
+
+  try {
+    parsedKey = keyParser(key);
+  } catch (e) {
+    return {
+      treatment: 'control',
+      label: LabelsConstants.EXCEPTION
+    };
+  }
 
   if (this.isGarbage()) {
     treatment = 'control';
@@ -74,7 +85,7 @@ Split.prototype.getTreatment = function getTreatment(key: SplitKey, attributes):
     label = LabelsConstants.SPLIT_KILLED;
   } else {
     const evaluation = this.evaluator(
-      key,
+      parsedKey,
       seed,
       trafficAllocation,
       trafficAllocationSeed,

--- a/src/engine/index.js
+++ b/src/engine/index.js
@@ -18,6 +18,8 @@ limitations under the License.
 
 'use strict';
 
+const get = require('lodash/get');
+
 const parser = require('./parser');
 const keyParser = require('../utils/key/parser');
 
@@ -30,6 +32,13 @@ function defaults(inst) {
   if (typeof inst.baseInfo.defaultTreatment !== 'string') {
     inst.baseInfo.defaultTreatment = 'control';
   }
+}
+
+function evaluationResult(result, defaultTreatment) {
+  return {
+    treatment: get(result, 'treatment', defaultTreatment),
+    label: get(result, 'label', LabelsConstants.NO_CONDITION_MATCH)
+  };
 }
 
 function Split(baseInfo: Object, evaluator: Function) {
@@ -96,13 +105,9 @@ Split.prototype.getTreatment = function getTreatment(key: SplitKey, attributes):
     // Evaluation could be async, so we should handle that case checking for a
     // thenable object
     if (thenable(evaluation)) {
-      return evaluation.then(result => ({
-        treatment: result !== undefined ? result.treatment : defaultTreatment,
-        label: result !== undefined ? result.label : LabelsConstants.NO_CONDITION_MATCH
-      }));
+      return evaluation.then(result => evaluationResult(result, defaultTreatment));
     } else {
-      treatment = evaluation !== undefined ? evaluation.treatment : defaultTreatment;
-      label = evaluation !== undefined ? evaluation.label : LabelsConstants.NO_CONDITION_MATCH;
+      return evaluationResult(evaluation, defaultTreatment);
     }
   }
 

--- a/src/utils/key/parser.js
+++ b/src/utils/key/parser.js
@@ -15,9 +15,11 @@ module.exports = (key: any): SplitKeyObject => {
 
   if (isObject(key)) {
     if (!key.bucketingKey || !key.matchingKey) {
-      throw 'key object should has property bucketingKey and matchingKey';
+      throw 'Key object should have properties bucketingKey and matchingKey.';
     }
 
     return key;
   }
+
+  throw 'Key should be an string or an object with bucketingKey and matchingKey as string properties.';
 };

--- a/src/utils/labels/index.js
+++ b/src/utils/labels/index.js
@@ -3,5 +3,6 @@ module.exports = {
   NO_CONDITION_MATCH: 'no rule matched',
   SPLIT_NOT_FOUND: 'rules not found',
   EXCEPTION: 'exception',
-  SPLIT_ARCHIVED: 'archived'
+  SPLIT_ARCHIVED: 'archived',
+  NOT_IN_SPLIT: 'not in split'
 };


### PR DESCRIPTION
We should discuss if there is a need for checking the type of the two properties, in case they are present on the key object.
Also, if we should notify customer in some way of the exception reason (maybe a console.error() ?)

[SPLIT-2844](https://splitio.atlassian.net/browse/SPLIT-2844)