### PR TITLE
Logger change

### DIFF
--- a/karma/ci.karma.conf.js
+++ b/karma/ci.karma.conf.js
@@ -11,6 +11,6 @@ module.exports = function(config) {
 
     // level of logging
     // possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
-    logLevel: config.LOG_DEBUG
+    logLevel: config.LOG_INFO
   }));
 };

--- a/karma/ci.karma.conf.js
+++ b/karma/ci.karma.conf.js
@@ -11,6 +11,6 @@ module.exports = function(config) {
 
     // level of logging
     // possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
-    logLevel: config.LOG_INFO
+    logLevel: config.LOG_DEBUG
   }));
 };

--- a/karma/config.js
+++ b/karma/config.js
@@ -38,7 +38,14 @@ module.exports = {
     // devtool: 'cheap-module-inline-source-map',
     module: {
       loaders: [
-        { test: /\.js$/, exclude: /node_modules/, loader: 'babel' },
+        {
+          test: /\.js$/,
+          include: [
+            /src/,
+            /node_modules\/logplease/
+          ],
+          loader: 'babel'
+        },
         { test: /\.json$/, exclude: /node_modules/, loader: 'json' }
       ]
     },

--- a/karma/config.js
+++ b/karma/config.js
@@ -40,10 +40,7 @@ module.exports = {
       loaders: [
         {
           test: /\.js$/,
-          include: [
-            /src/,
-            /node_modules\/logplease/
-          ],
+          exclude: /node_modules\/(?!logplease).*/,
           loader: 'babel'
         },
         { test: /\.json$/, exclude: /node_modules/, loader: 'json' }

--- a/package.json
+++ b/package.json
@@ -80,10 +80,10 @@
     "@types/node": "^7.0.12",
     "babel-runtime": "^6.20.0",
     "core-js": "^2.4.1",
-    "debug": "^2.5.2",
     "ip": "^1.1.4",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.3",
+    "logplease": "^1.2.13",
     "utfx": "^1.0.1",
     "warning": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,9 @@
     "test-node-e2e": "tape -r babel-register \"src/__tests__/node.spec.js\"",
     "pretest-node-redis": "cat ./src/__tests__/mocks/redis_mock.json | ./node_modules/redis-dump/bin/cli/redis-dump --convert | redis-cli",
     "test-node-redis": "tape -r babel-register \"src/__tests__/node_redis.spec.js\"",
+    "pretest-ts-decls": "npm link",
     "test-ts-decls": "./scripts/ts-tests.sh",
+    "posttest-ts-decls": "npm unlink && npm install",
     "canary": "npm run rebuild && npm publish --tag canary",
     "stable": "npm run rebuild && npm publish"
   },

--- a/scripts/ts-tests.sh
+++ b/scripts/ts-tests.sh
@@ -10,8 +10,10 @@ tsc ## Run typescript compiler. No need for flags as we have a tsconfig.json fil
 if [ $? -eq 0 ]
 then
   echo "Successfully compiled TS tests."
+  npm unlink @splitsoftware/splitio
   exit 0
 else
   echo "Error compiling TS tests."
+  npm unlink @splitsoftware/splitio
   exit 1
 fi

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -6,7 +6,7 @@
 // babel-runtime before remove this line of code.
 require('core-js/es6/promise');
 
-const log = require('debug')('splitio-client');
+const log = require('../utils/logger')('splitio-client');
 const Engine = require('../engine');
 
 const TimeTracker = require('../tracker/Timer');
@@ -34,9 +34,9 @@ function getTreatmentAvailable(
   if (evaluation.treatment !== 'control') {
     if (settings.core.labelsEnabled) label = evaluation.label;
 
-    log(`Split ${splitName} key ${matchingKey} evaluation ${treatment}`);
+    log.info(`Split: ${splitName}. Key: ${matchingKey}. Evaluation: ${treatment}`);
   } else {
-    log(`Split ${splitName} doesn't exist`);
+    log.warn(`Split ${splitName} doesn't exist`);
   }
 
   stopLatencyTracker();

--- a/src/engine/combiners/and.js
+++ b/src/engine/combiners/and.js
@@ -18,7 +18,7 @@ limitations under the License.
 'use strict';
 
 const findIndex = require('core-js/library/fn/array/find-index');
-const log = require('debug')('splitio-engine:combiner');
+const log = require('../../utils/logger')('splitio-engine:combiner');
 const thenable = require('../../utils/promise/thenable');
 
 function andResults(results) {
@@ -33,7 +33,7 @@ function andResults(results) {
 
   hasMatchedAll = i === len;
 
-  log(`[andCombiner] is evaluates to ${hasMatchedAll ? 'true' : 'false'}`);
+  log.debug(`[andCombiner] evaluates to ${hasMatchedAll}`);
 
   return hasMatchedAll;
 }

--- a/src/engine/combiners/ifelseif.js
+++ b/src/engine/combiners/ifelseif.js
@@ -18,11 +18,11 @@ limitations under the License.
 'use strict';
 
 const findIndex = require('core-js/library/fn/array/find-index');
-const log = require('debug')('splitio-engine:combiner');
+const log = require('../../utils/logger')('splitio-engine:combiner');
 const thenable = require('../../utils/promise/thenable');
 
 function unexpectedInputHandler() {
-  log('Invalid Split provided, none valid conditions found');
+  log.error('Invalid Split provided, no valid conditions found');
 
   return {
     treatment: 'control',
@@ -37,13 +37,13 @@ function computeTreatment(predicateResults: Array<?Evaluation>): ?Evaluation {
     const evaluation = predicateResults[i];
 
     if (evaluation != undefined) {
-      log('treatment found %s', evaluation.treatment);
+      log.debug(`treatment found: ${evaluation.treatment}`);
 
       return evaluation;
     }
   }
 
-  log('all predicates evaluted, none treatment available');
+  log.debug('all predicates evaluted, no treatment available');
   return undefined;
 }
 

--- a/src/engine/engine/index.js
+++ b/src/engine/engine/index.js
@@ -18,7 +18,7 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-engine');
+const log = require('../../utils/logger')('splitio-engine');
 
 const legacy = require('./legacy');
 const murmur = require('./murmur3');
@@ -44,7 +44,7 @@ const engine = {
 
     const treatment = treatments.getTreatmentFor(bucket);
 
-    log(`[engine] using algo ${algoId !== MURMUR_ID ? 'legacy' : 'murmur'} bucket ${bucket} for ${key} using seed ${seed} - treatment ${treatment}`);
+    log.debug(`[engine] using algo ${algoId !== MURMUR_ID ? 'legacy' : 'murmur'} bucket ${bucket} for key ${key} using seed ${seed} - treatment ${treatment}`);
 
     return treatment;
   },

--- a/src/engine/matchers/all.js
+++ b/src/engine/matchers/all.js
@@ -15,10 +15,10 @@ limitations under the License.
 **/
 'use strict';
 
-const log = require('debug')('splitio-engine:matcher');
+const log = require('../../utils/logger')('splitio-engine:matcher');
 
 function allMatcher(runtimeAttr /*: string */) /*: boolean */ {
-  log('[allMatcher] always true');
+  log.debug('[allMatcher] is always true');
 
   return runtimeAttr != null;
 }

--- a/src/engine/matchers/between.js
+++ b/src/engine/matchers/between.js
@@ -15,14 +15,14 @@ limitations under the License.
 **/
 'use strict';
 
-const log = require('debug')('splitio-engine:matcher');
+const log = require('../../utils/logger')('splitio-engine:matcher');
 
 function betweenMatcherContext(ruleVO /*: betweenObject */) /*: Function */ {
   return function betweenMatcher(runtimeAttr /*: number */) /*: boolean */ {
 
     let isBetween = runtimeAttr >= ruleVO.start && runtimeAttr <= ruleVO.end;
 
-    log(`[betweenMatcher] is ${runtimeAttr} between ${ruleVO.start} and ${ruleVO.end}? ${isBetween}`);
+    log.debug(`[betweenMatcher] is ${runtimeAttr} between ${ruleVO.start} and ${ruleVO.end}? ${isBetween}`);
 
     return isBetween;
   };

--- a/src/engine/matchers/cont_all.js
+++ b/src/engine/matchers/cont_all.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-engine:matcher');
+const log = require('../../utils/logger')('splitio-engine:matcher');
 const intersection = require('lodash/intersection');
 
 function containsAllMatcherContext(ruleAttr /*: array */) /*: Function */ {
@@ -28,7 +28,7 @@ function containsAllMatcherContext(ruleAttr /*: array */) /*: Function */ {
       containsAll = intersection(runtimeAttr, ruleAttr).length === ruleAttr.length;
     }
 
-    log(`[containsAllMatcher] ${runtimeAttr} contains all elements of ${ruleAttr}? ${containsAll}`);
+    log.debug(`[containsAllMatcher] ${runtimeAttr} contains all elements of ${ruleAttr}? ${containsAll}`);
 
     return containsAll;
   };

--- a/src/engine/matchers/cont_any.js
+++ b/src/engine/matchers/cont_any.js
@@ -16,14 +16,14 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-engine:matcher');
+const log = require('../../utils/logger')('splitio-engine:matcher');
 const intersection = require('lodash/intersection');
 
 function containsAnyMatcherContext(ruleAttr /*: array */) /*: Function */ {
   return function containsAnyMatcher(runtimeAttr /*: array */) /*: boolean */ {
     const containsAny = intersection(runtimeAttr, ruleAttr).length > 0;
 
-    log(`[containsAnyMatcher] ${runtimeAttr} contains at least an element of ${ruleAttr}? ${containsAny}`);
+    log.debug(`[containsAnyMatcher] ${runtimeAttr} contains at least an element of ${ruleAttr}? ${containsAny}`);
 
     return containsAny;
   };

--- a/src/engine/matchers/cont_str.js
+++ b/src/engine/matchers/cont_str.js
@@ -16,14 +16,14 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-engine:matcher');
+const log = require('../../utils/logger')('splitio-engine:matcher');
 const includes = require('lodash/includes');
 
 function containsStringMatcherContext(ruleAttr /*: array */) /*: Function */ {
   return function containsStringMatcher(runtimeAttr /*: string */) /*: boolean */ {
     let contains = ruleAttr.some(e => includes(runtimeAttr, e));
 
-    log(`[containsStringMatcher] ${runtimeAttr} ends with ${ruleAttr}? ${contains}`);
+    log.debug(`[containsStringMatcher] ${runtimeAttr} ends with ${ruleAttr}? ${contains}`);
 
     return contains;
   };

--- a/src/engine/matchers/eq.js
+++ b/src/engine/matchers/eq.js
@@ -16,13 +16,13 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-engine:matcher');
+const log = require('../../utils/logger')('splitio-engine:matcher');
 
 function equalToMatcherContext(ruleAttr /*: number */) /*: Function */ {
   return function equalToMatcher(runtimeAttr /*: number */) /*: boolean */ {
     let isEqual = runtimeAttr === ruleAttr;
 
-    log(`[equalToMatcher] is ${runtimeAttr} equal to ${ruleAttr}? ${isEqual}`);
+    log.debug(`[equalToMatcher] is ${runtimeAttr} equal to ${ruleAttr}? ${isEqual}`);
 
     return isEqual;
   };

--- a/src/engine/matchers/eq_set.js
+++ b/src/engine/matchers/eq_set.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-engine:matcher');
+const log = require('../../utils/logger')('splitio-engine:matcher');
 const difference = require('lodash/difference');
 
 function equalToSetMatcherContext(ruleAttr /*: array */) /*: Function */ {
@@ -24,7 +24,7 @@ function equalToSetMatcherContext(ruleAttr /*: array */) /*: Function */ {
     let isEqual = runtimeAttr.length === ruleAttr.length &&
                   difference(ruleAttr, runtimeAttr).length === 0;
 
-    log(`[equalToSetMatcher] is ${runtimeAttr} equal to set ${ruleAttr}? ${isEqual}`);
+    log.debug(`[equalToSetMatcher] is ${runtimeAttr} equal to set ${ruleAttr}? ${isEqual}`);
 
     return isEqual;
   };

--- a/src/engine/matchers/ew.js
+++ b/src/engine/matchers/ew.js
@@ -16,14 +16,14 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-engine:matcher');
+const log = require('../../utils/logger')('splitio-engine:matcher');
 const strEndsWith = require('lodash/endsWith');
 
 function endsWithMatcherContext(ruleAttr /*: array */) /*: Function */ {
   return function endsWithMatcher(runtimeAttr /*: string */) /*: boolean */ {
     let endsWith = ruleAttr.some(e => strEndsWith(runtimeAttr, e));
 
-    log(`[endsWithMatcher] ${runtimeAttr} ends with ${ruleAttr}? ${endsWith}`);
+    log.debug(`[endsWithMatcher] ${runtimeAttr} ends with ${ruleAttr}? ${endsWith}`);
 
     return endsWith;
   };

--- a/src/engine/matchers/gte.js
+++ b/src/engine/matchers/gte.js
@@ -16,13 +16,13 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-engine:matcher');
+const log = require('../../utils/logger')('splitio-engine:matcher');
 
 function greaterThanEqualMatcherContext(ruleAttr /*: number */) /*: Function */ {
   return function greaterThanEqualMatcher(runtimeAttr /*: number */) /*: boolean */ {
     let isGreaterEqualThan = runtimeAttr >= ruleAttr;
 
-    log(`[greaterThanEqualMatcher] is ${runtimeAttr} greater than ${ruleAttr}? ${isGreaterEqualThan}`);
+    log.debug(`[greaterThanEqualMatcher] is ${runtimeAttr} greater than ${ruleAttr}? ${isGreaterEqualThan}`);
 
     return isGreaterEqualThan;
   };

--- a/src/engine/matchers/lte.js
+++ b/src/engine/matchers/lte.js
@@ -16,13 +16,13 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-engine:matcher');
+const log = require('../../utils/logger')('splitio-engine:matcher');
 
 function lessThanEqualMatcherContext(ruleAttr /*: number */) /*: function */ {
   return function lessThanEqualMatcher(runtimeAttr /*: number */) /*: boolean */ {
     let isLessEqualThan = runtimeAttr <= ruleAttr;
 
-    log(`[lessThanEqualMatcher] is ${runtimeAttr} less than ${ruleAttr}? ${isLessEqualThan}`);
+    log.debug(`[lessThanEqualMatcher] is ${runtimeAttr} less than ${ruleAttr}? ${isLessEqualThan}`);
 
     return isLessEqualThan;
   };

--- a/src/engine/matchers/part_of.js
+++ b/src/engine/matchers/part_of.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-engine:matcher');
+const log = require('../../utils/logger')('splitio-engine:matcher');
 const intersection = require('lodash/intersection');
 
 function partOfMatcherContext(ruleAttr /*: array */) /*: Function */ {
@@ -24,7 +24,7 @@ function partOfMatcherContext(ruleAttr /*: array */) /*: Function */ {
     // If the intersection returns all of runtimeAttr elements, it is a part of ruleAttr
     const isPartOf = intersection(runtimeAttr, ruleAttr).length === runtimeAttr.length;
 
-    log(`[partOfMatcher] ${runtimeAttr} is part of ${ruleAttr}? ${isPartOf}`);
+    log.debug(`[partOfMatcher] ${runtimeAttr} is part of ${ruleAttr}? ${isPartOf}`);
 
     return isPartOf;
   };

--- a/src/engine/matchers/segment.js
+++ b/src/engine/matchers/segment.js
@@ -15,7 +15,7 @@ limitations under the License.
 **/
 'use strict';
 
-const log = require('debug')('splitio-engine:matcher');
+const log = require('../../utils/logger')('splitio-engine:matcher');
 const thenable = require('../../utils/promise/thenable');
 
 function matcherSegmentContext(segmentName: string, storage: SplitStorage) {
@@ -25,12 +25,12 @@ function matcherSegmentContext(segmentName: string, storage: SplitStorage) {
 
     if (thenable(isInSegment)) {
       isInSegment.then(result => {
-        log(`[asyncSegmentMatcher] evaluated ${segmentName} / ${key} => ${isInSegment}`);
+        log.debug(`[asyncSegmentMatcher] evaluated ${segmentName} / ${key} => ${isInSegment}`);
 
         return result;
       });
     } else {
-      log(`[segmentMatcher] evaluated ${segmentName} / ${key} => ${isInSegment}`);
+      log.debug(`[segmentMatcher] evaluated ${segmentName} / ${key} => ${isInSegment}`);
     }
 
     return isInSegment;

--- a/src/engine/matchers/sw.js
+++ b/src/engine/matchers/sw.js
@@ -16,14 +16,14 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-engine:matcher');
+const log = require('../../utils/logger')('splitio-engine:matcher');
 const startsWith = require('lodash/startsWith');
 
 function startsWithMatcherContext(ruleAttr /*: array */) /*: Function */ {
   return function startsWithMatcher(runtimeAttr /*: string */) /*: boolean */ {
     let matches = ruleAttr.some(e => startsWith(runtimeAttr, e));
 
-    log(`[startsWithMatcher] ${runtimeAttr} starts with ${ruleAttr}? ${matches}`);
+    log.debug(`[startsWithMatcher] ${runtimeAttr} starts with ${ruleAttr}? ${matches}`);
 
     return matches;
   };

--- a/src/engine/matchers/whitelist.js
+++ b/src/engine/matchers/whitelist.js
@@ -15,13 +15,13 @@ limitations under the License.
 **/
 'use strict';
 
-const log = require('debug')('splitio-engine:matcher');
+const log = require('../../utils/logger')('splitio-engine:matcher');
 
 function whitelistMatcherContext(ruleAttr /*: Set */) /*: Function */ {
   return function whitelistMatcher(runtimeAttr /*: string */) /*: boolean */ {
     let isInWhitelist = ruleAttr.has(runtimeAttr);
 
-    log(`[whitelistMatcher] evaluated ${runtimeAttr} in [${[...ruleAttr].join(',')}] => ${isInWhitelist}`);
+    log.debug(`[whitelistMatcher] evaluated ${runtimeAttr} in [${[...ruleAttr].join(',')}] => ${isInWhitelist}`);
 
     return isInWhitelist;
   };

--- a/src/engine/value/index.js
+++ b/src/engine/value/index.js
@@ -18,7 +18,7 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-engine:value');
+const log = require('../../utils/logger')('splitio-engine:value');
 const sanitizeValue = require('./sanitize');
 
 function parseValue(key: string, attributeName: string, attributes: Object) {
@@ -26,9 +26,9 @@ function parseValue(key: string, attributeName: string, attributes: Object) {
   if (attributeName) {
     if (attributes) {
       value = attributes[attributeName];
-      log('Extracted attribute [%s], [%s] will be used for matching', attributeName, value);
+      log.debug(`Extracted attribute [${attributeName}], [${value}] will be used for matching`);
     } else {
-      log('Defined attribute [%s], no attributes received', attributeName);
+      log.warn(`Defined attribute [${attributeName}], no attributes received`);
     }
   } else {
     value = key;
@@ -48,7 +48,7 @@ function value(key: string, matcherDto: Object, attributes: Object): ?string {
   if (sanitizedValue !== undefined) {
     return sanitizedValue;
   } else {
-    log('Value [%s]' + (attributeName ? ' for attribute [%s]' : + '') + ' doesn\'t match with expected type', valueToMatch, attributeName);
+    log.warn(`Value ${valueToMatch} ${attributeName ? `for attribute ${attributeName} ` : + ''}doesn\'t match with expected type`);
     return;
   }
 }

--- a/src/engine/value/sanitize.js
+++ b/src/engine/value/sanitize.js
@@ -18,7 +18,7 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-engine:sanitize');
+const log = require('../../utils/logger')('splitio-engine:sanitize');
 
 const isArray = require('lodash/isArray');
 const uniq = require('lodash/uniq');
@@ -90,7 +90,7 @@ function sanitizeValue(matcherTypeID: number, value: any, dataType: string): any
     sanitizedValue = processor(sanitizedValue);
   }
 
-  log('Attempted to sanitize [%s] which should be of type [%s]. \n Sanitized value => [%s]', value, dataType, sanitizedValue);
+  log.debug(`Attempted to sanitize [${value}] which should be of type [${dataType}]. \n Sanitized value => [${sanitizedValue}]`);
 
   return sanitizedValue;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ const SettingsFactory = require('./utils/settings');
 const ReadinessGateFacade = require('./readiness');
 
 const keyParser = require('./utils/key/parser');
+const LoggerApi = require('./utils/logger').API;
 
 // cache instances created
 const instances = {};
@@ -131,6 +132,9 @@ function SplitFacade(config: Object) {
     manager(): SplitManager {
       return ManagerFactory(storage.splits);
     },
+
+    // Logger wrapper API
+    Logger: LoggerApi,
 
     // Expose SDK settings
     settings

--- a/src/metrics/index.js
+++ b/src/metrics/index.js
@@ -18,7 +18,7 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-metrics');
+const log = require('../utils/logger')('splitio-metrics');
 
 const repeat = require('../utils/fn/repeat');
 
@@ -34,7 +34,7 @@ const MetricsFactory = (settings: Object, storage: SplitStorage): Startable => {
   const pushMetrics = (): Promise<void> => {
     if (storage.metrics.isEmpty()) return Promise.resolve();
 
-    log('Pushing metrics');
+    log.info('Pushing metrics');
 
     return metricsService(metricsServiceRequest(settings, {
       body: JSON.stringify(metricsDTO.fromGetTreatmentCollector(storage.metrics))
@@ -46,7 +46,7 @@ const MetricsFactory = (settings: Object, storage: SplitStorage): Startable => {
   const pushImpressions = (): Promise<void> => {
     if (storage.impressions.isEmpty()) return Promise.resolve();
 
-    log('Pushing impressions');
+    log.info('Pushing impressions');
 
     return impressionsService(impressionsBulkRequest(settings, {
       body: JSON.stringify(impressionsDTO.fromImpressionsCollector(storage.impressions))

--- a/src/producer/browser/Full.js
+++ b/src/producer/browser/Full.js
@@ -18,7 +18,7 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-producer:updater');
+const log = require('../../utils/logger')('splitio-producer:updater');
 
 const TaskFactory = require('../task');
 
@@ -37,14 +37,14 @@ const FullBrowserProducer = (settings: Object, readiness: ReadinessGate, storage
 
   return {
     start() {
-      log('Starting BROWSER producer');
+      log.info('Starting BROWSER producer');
 
       splitsUpdaterTask.start();
       segmentsUpdaterTask.start();
     },
 
     stop() {
-      log('Stopping BROWSER producer');
+      log.info('Stopping BROWSER producer');
 
       splitsUpdaterTask.stop();
       segmentsUpdaterTask.stop();

--- a/src/producer/node.js
+++ b/src/producer/node.js
@@ -18,7 +18,7 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-producer:updater');
+const log = require('../utils/logger')('splitio-producer:updater');
 const repeat = require('../utils/fn/repeat');
 
 const SplitChangesUpdater = require('./updater/SplitChanges');
@@ -37,9 +37,9 @@ const NodeUpdater = (settings: Object, hub: EventEmitter, storage: SplitStorage)
 
   return {
     start() {
-      log('Starting NODEJS updater');
-      log('Splits will be refreshed each %s millis', settings.scheduler.featuresRefreshRate);
-      log('Segments will be refreshed each %s millis', settings.scheduler.segmentsRefreshRate);
+      log.info('Starting NODEJS updater');
+      log.debug(`Splits will be refreshed each ${settings.scheduler.featuresRefreshRate} millis`);
+      log.debug(`Segments will be refreshed each ${settings.scheduler.segmentsRefreshRate} millis`);
 
       // Schedule incremental update of segments only if needed
       const spinUpSegmentUpdater = () => {
@@ -47,7 +47,7 @@ const NodeUpdater = (settings: Object, hub: EventEmitter, storage: SplitStorage)
           stopSegmentsUpdate = repeat(
             scheduleSegmentsUpdate => {
               if (splitFetchCompleted) {
-                log('Fetching segments');
+                log.debug('Fetching segments');
                 segmentsUpdater().then(() => scheduleSegmentsUpdate());
               } else {
                 scheduleSegmentsUpdate();
@@ -60,7 +60,7 @@ const NodeUpdater = (settings: Object, hub: EventEmitter, storage: SplitStorage)
 
       stopSplitsUpdate = repeat(
         scheduleSplitsUpdate => {
-          log('Fetching splits');
+          log.debug('Fetching splits');
 
           splitsUpdater()
             .then(() => {
@@ -77,7 +77,7 @@ const NodeUpdater = (settings: Object, hub: EventEmitter, storage: SplitStorage)
     },
 
     stop() {
-      log('Stopping NODEJS updater');
+      log.info('Stopping NODEJS updater');
 
       stopSplitsUpdate && stopSplitsUpdate();
       stopSegmentsUpdate && stopSegmentsUpdate();

--- a/src/producer/task.js
+++ b/src/producer/task.js
@@ -18,7 +18,7 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-producer:task');
+const log = require('../utils/logger')('splitio-producer:task');
 const repeat = require('../utils/fn/repeat');
 
 /**
@@ -29,11 +29,11 @@ const TaskFactory = (updater: Function, period: number): Startable => {
 
   return {
     start() {
-      log('Starting %s refreshing each %s', updater.name, period);
+      log.debug(`Starting ${updater.name} refreshing each ${period}`);
 
       stopUpdater = repeat(
         reschedule => {
-          log('Running %s', updater.name);
+          log.debug(`Running ${updater.name}`);
           updater().then(() => reschedule());
         },
         period
@@ -41,7 +41,7 @@ const TaskFactory = (updater: Function, period: number): Startable => {
     },
 
     stop() {
-      log('Stopping %s', updater.name);
+      log.debug(`Stopping ${updater.name}`);
 
       stopUpdater && stopUpdater();
     }

--- a/src/producer/updater/MySegments.js
+++ b/src/producer/updater/MySegments.js
@@ -18,7 +18,7 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-producer:my-segments');
+const log = require('../../utils/logger')('splitio-producer:my-segments');
 const mySegmentsFetcher = require('../fetcher/MySegments');
 
 function MySegmentsUpdaterFactory(settings: Object, readiness: ReadinessGate, storage: SplitStorage) {
@@ -45,7 +45,7 @@ function MySegmentsUpdaterFactory(settings: Object, readiness: ReadinessGate, st
     .catch(error => {
       if (startingUp && settings.startup.retriesOnFailureBeforeReady > retry) {
         retry += 1;
-        log('Retrying download of segments #%s reason %s', retry, error);
+        log.warn(`Retrying download of segments #${retry}. Reason: ${error}`);
         return MySegmentsUpdater(retry);
       } else {
         startingUp = false;

--- a/src/producer/updater/SegmentChanges.js
+++ b/src/producer/updater/SegmentChanges.js
@@ -18,7 +18,7 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-producer:segment-changes');
+const log = require('../../utils/logger')('splitio-producer:segment-changes');
 const segmentChangesFetcher = require('../fetcher/SegmentChanges');
 
 const SegmentChangesUpdaterFactory = (settings: Object, readiness: ReadinessGate, storage: SplitStorage) => {
@@ -27,7 +27,7 @@ const SegmentChangesUpdaterFactory = (settings: Object, readiness: ReadinessGate
   let readyOnAlreadyExistentState = true;
 
   return async function SegmentChangesUpdater() {
-    log('Started segments update');
+    log.debug('Started segments update');
 
     // Async fetchers are collected here.
     const updaters = [];
@@ -38,7 +38,7 @@ const SegmentChangesUpdaterFactory = (settings: Object, readiness: ReadinessGate
     for (let segmentName of segments) {
       const since: number = await storage.segments.getChangeNumber(segmentName);
 
-      log('Processing segment %s', segmentName);
+      log.debug(`Processing segment ${segmentName}`);
 
       updaters.push(segmentChangesFetcher(settings, segmentName, since).then(async function (changes: SegmentChanges) {
         let changeNumber = -1;
@@ -55,7 +55,7 @@ const SegmentChangesUpdaterFactory = (settings: Object, readiness: ReadinessGate
             changeNumber = x.till;
           }
 
-          log('Processed %s with till = %s added %s removed %s', segmentName, x.till, x.added.length, x.removed.length);
+          log.debug(`Processed ${segmentName} with till = ${x.till}. Added: ${x.added.length}. Removed: ${x.removed.length}`);
         }
 
         return changeNumber;

--- a/src/producer/updater/SplitChangesFromObject.js
+++ b/src/producer/updater/SplitChangesFromObject.js
@@ -18,7 +18,7 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-producer:offline');
+const log = require('../../utils/logger')('splitio-producer:offline');
 
 function FromObjectUpdaterFactory(Fetcher: Function, settings: Settings, readiness: ReadinessGate, storage: SplitStorage) {
 
@@ -26,7 +26,7 @@ function FromObjectUpdaterFactory(Fetcher: Function, settings: Settings, readine
     const splits = [];
     const configs = Fetcher(settings);
 
-    log(JSON.stringify(configs));
+    log.debug(JSON.stringify(configs));
 
     // Make use of the killed behavior to prevent loading all the information
     // for a given Split.

--- a/src/services/offline/node.js
+++ b/src/services/offline/node.js
@@ -20,7 +20,7 @@ limitations under the License.
 
 const fs = require('fs');
 const path = require('path');
-const log = require('debug')('splitio:offline');
+const log = require('../../utils/logger')('splitio:offline');
 
 const FILENAME = '.split';
 
@@ -49,7 +49,7 @@ function readSplitConfigFile(path: string): Array<Array<string>> {
   try {
     data = fs.readFileSync(path, 'utf-8');
   } catch (e) {
-    log(e.message);
+    log.error(e.message);
 
     return [];
   }
@@ -58,12 +58,12 @@ function readSplitConfigFile(path: string): Array<Array<string>> {
     let tuple = line.trim();
 
     if (tuple === '' || tuple.charAt(0) === '#') {
-      log(`Ignoring empty line or comment at #${index}`);
+      log.debug(`Ignoring empty line or comment at #${index}`);
     } else {
       tuple = tuple.split(/\s+/);
 
       if (tuple.length !== 2) {
-        log(`Ignoring line since it does not have exactly two columns #${index}`);
+        log.debug(`Ignoring line since it does not have exactly two columns #${index}`);
       } else {
         accum.push(tuple);
       }

--- a/src/services/transport/index.js
+++ b/src/services/transport/index.js
@@ -17,14 +17,14 @@ limitations under the License.
 
 require('isomorphic-fetch');
 
-const log = require('debug')('splitio-services:service');
+const log = require('../../utils/logger')('splitio-services:service');
 
 function Fetcher(request) {
   return fetch(request).then(resp => {
     if (resp.statusText === 'OK') {
       return resp;
     } else {
-      log('throw error because status text is not OK');
+      log.error('throw error because status text is not OK');
 
       throw Error(resp.statusText);
     }

--- a/src/storage/SegmentCache/InLocalStorage/index.js
+++ b/src/storage/SegmentCache/InLocalStorage/index.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-const log = require('debug')('splitio-storage:localstorage');
+const log = require('../../../utils/logger')('splitio-storage:localstorage');
 
 const DEFINED = '1';
 
@@ -20,7 +20,7 @@ class SegmentCacheInLocalStorage {
       localStorage.setItem(segmentKey, DEFINED);
       return true;
     } catch (e) {
-      log(e);
+      log.error(e);
       return false;
     }
   }
@@ -32,7 +32,7 @@ class SegmentCacheInLocalStorage {
       localStorage.removeItem(segmentKey);
       return true;
     } catch (e) {
-      log(e);
+      log.error(e);
       return false;
     }
   }

--- a/src/storage/SplitCache/InLocalStorage.js
+++ b/src/storage/SplitCache/InLocalStorage.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-const log = require('debug')('splitio-storage:localstorage');
+const log = require('../../utils/logger')('splitio-storage:localstorage');
 
 class SplitCacheLocalStorage {
   keys: KeyBuilder;
@@ -16,7 +16,7 @@ class SplitCacheLocalStorage {
       localStorage.setItem(this.keys.buildSplitKey(splitName), split);
       return true;
     } catch (e) {
-      log(e);
+      log.error(e);
       return false;
     }
   }
@@ -36,7 +36,7 @@ class SplitCacheLocalStorage {
       localStorage.removeItem(this.keys.buildSplitKey(splitName));
       return 1;
     } catch(e) {
-      log(e);
+      log.error(e);
       return 0;
     }
   }
@@ -65,7 +65,7 @@ class SplitCacheLocalStorage {
       localStorage.setItem(this.keys.buildSplitsTillKey(), changeNumber + '');
       return true;
     } catch (e) {
-      log(e);
+      log.error(e);
       return false;
     }
   }

--- a/src/utils/__tests__/logger/index.spec.js
+++ b/src/utils/__tests__/logger/index.spec.js
@@ -1,0 +1,31 @@
+/**
+Copyright 2016 Split Software
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+**/
+'use strict';
+
+const tape = require('tape-catch');
+
+const splitLogger = require('../../logger');
+
+tape('SPLIT LOGGER / methods', assert => {
+
+  assert.equal(typeof splitLogger, 'function', 'Importing the module should return a function.');
+
+  assert.equal(typeof splitLogger.API, 'object', 'Our logger should expose an API object.');
+  assert.equal(typeof splitLogger.API.enable, 'function', 'API object should have enable method.');
+  assert.equal(typeof splitLogger.API.disable, 'function', 'API object should have disable method.');
+
+  assert.end();
+});

--- a/src/utils/localstorage/isAvailable.js
+++ b/src/utils/localstorage/isAvailable.js
@@ -1,0 +1,28 @@
+/**
+Copyright 2016 Split Software
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+**/
+
+'use strict';
+
+module.exports = function isLocalStorageAvailable() {
+  var mod = '__SPLITSOFTWARE__';
+  try {
+    localStorage.setItem(mod, mod);
+    localStorage.removeItem(mod);
+    return true;
+  } catch(e) {
+    return false;
+  }
+};

--- a/src/utils/logger/index.js
+++ b/src/utils/logger/index.js
@@ -1,0 +1,35 @@
+/**
+Copyright 2016 Split Software
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+**/
+
+'use strict';
+
+const Logger = require('logplease');
+
+const API = {
+  enable() {
+    Logger.setLogLevel(Logger.LogLevels.DEBUG);
+  },
+  disable() {
+    Logger.setLogLevel(Logger.LogLevels.NONE);
+  }
+};
+// By default it starts disabled.
+API.disable();
+
+// Expose the logger instance creation function as the default export
+exports = module.exports = Logger.create;
+// And our API
+exports.API = API;

--- a/src/utils/logger/index.js
+++ b/src/utils/logger/index.js
@@ -18,6 +18,17 @@ limitations under the License.
 
 const Logger = require('logplease');
 
+const LS_KEY = 'splitio_debug';
+const ENV_VAR_KEY = 'SPLITIO_DEBUG';
+
+const isNode = Boolean(process && process.version);
+
+const initialState = String(
+  isNode ?
+  process.env[ENV_VAR_KEY] :
+  window.localStorage.getItem(LS_KEY)
+);
+
 const API = {
   enable() {
     Logger.setLogLevel(Logger.LogLevels.DEBUG);
@@ -26,10 +37,16 @@ const API = {
     Logger.setLogLevel(Logger.LogLevels.NONE);
   }
 };
-// By default it starts disabled.
-API.disable();
+
+// "enable", "enabled" and "on" are acceptable values
+if (/^(enabled?|on)/i.test(initialState)) {
+  API.enable();
+} else {
+  // By default it starts disabled.
+  API.disable();
+}
 
 // Expose the logger instance creation function as the default export
 exports = module.exports = Logger.create;
-// And our API
+// And our API for programatically usage.
 exports.API = API;

--- a/src/utils/logger/index.js
+++ b/src/utils/logger/index.js
@@ -17,6 +17,7 @@ limitations under the License.
 'use strict';
 
 const Logger = require('logplease');
+const isLocalStorageAvailable = require('../localstorage/isAvailable');
 
 const LS_KEY = 'splitio_debug';
 const ENV_VAR_KEY = 'SPLITIO_DEBUG';
@@ -25,8 +26,9 @@ const isNode = Boolean(process && process.version);
 
 const initialState = String(
   isNode ?
-  process.env[ENV_VAR_KEY] :
-  window.localStorage.getItem(LS_KEY)
+    process.env[ENV_VAR_KEY] :
+    isLocalStorageAvailable() ?
+      localStorage.getItem(LS_KEY) : ''
 );
 
 const API = {

--- a/src/utils/settings/index.js
+++ b/src/utils/settings/index.js
@@ -25,6 +25,7 @@ const runtime: Object = require('./runtime');
 const overridesPerPlatform: Object = require('./defaults');
 const storage: Function = require('./storage');
 const mode: Function = require('./mode');
+const Logger = require('../../utils/logger');
 
 const eventsEndpointMatcher = /\/(testImpressions|metrics)/;
 
@@ -66,12 +67,21 @@ const base = {
     type: 'MEMORY'
   },
 
+  // Defines if the logs are enabled, SDK wide.
+  enableLogs: false,
+
   // Instance version.
   version: `${language}-9.1.0`
 };
 
 function fromSecondsToMillis(n) {
   return Math.round(n * 1000);
+}
+
+function setupLogger(enable) {
+  if (enable) {
+    Logger.API.enable();
+  }
 }
 
 function defaults(custom: Object): Settings {
@@ -93,6 +103,8 @@ function defaults(custom: Object): Settings {
 
   // ensure a valid Storage based on mode defined.
   withDefaults.storage = storage(withDefaults);
+
+  setupLogger(withDefaults.enableLogs);
 
   return withDefaults;
 }

--- a/src/utils/settings/index.js
+++ b/src/utils/settings/index.js
@@ -68,7 +68,7 @@ const base = {
   },
 
   // Defines if the logs are enabled, SDK wide.
-  enableLogs: false,
+  debug: false,
 
   // Instance version.
   version: `${language}-9.1.0`
@@ -104,7 +104,7 @@ function defaults(custom: Object): Settings {
   // ensure a valid Storage based on mode defined.
   withDefaults.storage = storage(withDefaults);
 
-  setupLogger(withDefaults.enableLogs);
+  setupLogger(withDefaults.debug);
 
   return withDefaults;
 }

--- a/src/utils/settings/storage/browser.js
+++ b/src/utils/settings/storage/browser.js
@@ -18,7 +18,7 @@ limitations under the License.
 
 'use strict';
 
-const log = require('debug')('splitio-settings');
+const log = require('../../../utils/logger')('splitio-settings');
 
 // Verify localstorage availability
 function isLocalStorageAvailable(): boolean {
@@ -58,7 +58,7 @@ const ParseStorageSettings = (settings: Settings) => {
   if (type !== 'MEMORY' && type !== 'LOCALSTORAGE' ||
       type === 'LOCALSTORAGE' && !isLocalStorageAvailable()) {
     type = 'MEMORY';
-    log('Fallbacking into MEMORY storage');
+    log.warn('Invalid or unavailable storage. Fallbacking into MEMORY storage');
   }
 
   return {

--- a/src/utils/settings/storage/browser.js
+++ b/src/utils/settings/storage/browser.js
@@ -19,18 +19,7 @@ limitations under the License.
 'use strict';
 
 const log = require('../../../utils/logger')('splitio-settings');
-
-// Verify localstorage availability
-function isLocalStorageAvailable(): boolean {
-  var mod = '__SPLITSOFTWARE__';
-  try {
-    localStorage.setItem(mod, mod);
-    localStorage.removeItem(mod);
-    return true;
-  } catch(e) {
-    return false;
-  }
-}
+const isLocalStorageAvailable = require('../../../utils/localstorage/isAvailable');
 
 const ParseStorageSettings = (settings: Settings) => {
   let {

--- a/ts-tests/index.ts
+++ b/ts-tests/index.ts
@@ -266,7 +266,7 @@ let fullBrowserSettings: SplitIO.IBrowserSettings = {
     type: 'LOCALSTORAGE',
     prefix: 'PREFIX'
   },
-  enableLogs: true
+  debug: true
 };
 fullBrowserSettings.storage.type = 'MEMORY';
 
@@ -288,7 +288,7 @@ let fullNodeSettings: SplitIO.INodeSettings = {
     prefix: 'PREFIX'
   },
   mode: 'standalone',
-  enableLogs: false
+  debug: false
 };
 fullNodeSettings.storage.type = 'MEMORY';
 fullNodeSettings.mode = 'consumer';
@@ -314,5 +314,5 @@ let fullAsyncSettings: SplitIO.INodeAsyncSettings = {
     prefix: 'PREFIX'
   },
   mode: 'standalone',
-  enableLogs: true
+  debug: true
 };

--- a/ts-tests/index.ts
+++ b/ts-tests/index.ts
@@ -156,6 +156,13 @@ asyncClient = AsyncSDK.client();
 asyncClient = AsyncSDK.client('a customer key');
 asyncManager = AsyncSDK.manager();
 
+// Logger
+SDK.Logger.enable();
+SDK.Logger.disable();
+
+AsyncSDK.Logger.enable();
+AsyncSDK.Logger.disable();
+
 /**** Tests for IClient interface ****/
 
 // Events constants we get
@@ -258,7 +265,8 @@ let fullBrowserSettings: SplitIO.IBrowserSettings = {
   storage: {
     type: 'LOCALSTORAGE',
     prefix: 'PREFIX'
-  }
+  },
+  enableLogs: true
 };
 fullBrowserSettings.storage.type = 'MEMORY';
 
@@ -279,7 +287,8 @@ let fullNodeSettings: SplitIO.INodeSettings = {
     type: 'LOCALSTORAGE',
     prefix: 'PREFIX'
   },
-  mode: 'standalone'
+  mode: 'standalone',
+  enableLogs: false
 };
 fullNodeSettings.storage.type = 'MEMORY';
 fullNodeSettings.mode = 'consumer';
@@ -304,5 +313,6 @@ let fullAsyncSettings: SplitIO.INodeAsyncSettings = {
     },
     prefix: 'PREFIX'
   },
-  mode: 'standalone'
+  mode: 'standalone',
+  enableLogs: true
 };

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -61,7 +61,7 @@ interface ISettings {
     events: string,
     sdk: string
   },
-  readonly enableLogs: boolean,
+  readonly debug: boolean,
   readonly version: string,
   features: {
     [featureName: string]: string
@@ -129,10 +129,10 @@ interface ISharedSettings {
   },
   /**
    * Wether the logger should be enabled or disabled by default.
-   * @property {Boolean} enableLogs
+   * @property {Boolean} debug
    * @default false
    */
-  enableLogs?: boolean
+  debug?: boolean
 }
 /**
  * Common settings interface for SDK instances on NodeJS.

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -61,10 +61,29 @@ interface ISettings {
     events: string,
     sdk: string
   },
+  readonly enableLogs: boolean,
   readonly version: string,
   features: {
     [featureName: string]: string
   }
+}
+/**
+ * Logger API
+ * @interface ILoggerAPI
+ */
+interface ILoggerAPI {
+  /**
+   * Enables SDK logging to the console.
+   * @function enable
+   * @returns {void}
+   */
+  enable(): void,
+  /**
+   * Disables SDK logging.
+   * @function disable
+   * @returns {void}
+   */
+  disable(): void
 }
 /**
  * Common settings between Browser and NodeJS settings interface.
@@ -107,7 +126,13 @@ interface ISharedSettings {
      * @default 15
      */
     offlineRefreshRate?: number
-  }
+  },
+  /**
+   * Wether the logger should be enabled or disabled by default.
+   * @property {Boolean} enableLogs
+   * @default false
+   */
+  enableLogs?: boolean
 }
 /**
  * Common settings interface for SDK instances on NodeJS.
@@ -215,7 +240,12 @@ interface IBasicSDK {
    * Current settings of the SDK instance.
    * @property settings
    */
-  settings: ISettings
+  settings: ISettings,
+  /**
+   * Logger API.
+   * @property Logger
+   */
+  Logger: ILoggerAPI
 }
 /****** Exposed namespace ******/
 /**

--- a/types/types.js
+++ b/types/types.js
@@ -285,6 +285,8 @@ declare type Settings = {
     prefix: string
   },
 
+  enableLogs: boolean,
+
   runtime: {
     ip: string,
     hostname: string

--- a/types/types.js
+++ b/types/types.js
@@ -285,7 +285,7 @@ declare type Settings = {
     prefix: string
   },
 
-  enableLogs: boolean,
+  debug: boolean,
 
   runtime: {
     ip: string,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,14 @@ module.exports = {
 
   module: {
     loaders: [
-      { test: /\.js$/, exclude: /node_modules/, loader: 'babel' }
+      {
+        test: /\.js$/,
+        include: [
+          /src/,
+          /node_modules\/logplease/
+        ],
+        loader: 'babel'
+      }
     ]
   },
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,10 +35,7 @@ module.exports = {
     loaders: [
       {
         test: /\.js$/,
-        include: [
-          /src/,
-          /node_modules\/logplease/
-        ],
+        exclude: /node_modules\/(?!logplease).*/,
         loader: 'babel'
       }
     ]


### PR DESCRIPTION
Changed for [logplease](https://github.com/haadcode/logplease) and created a wrapper around (in case we want to add methods or change the library later on).

Turning the logs on by default would be done via the settings of the SDK.
You can turn on or off programatically the logs via sdk.Logger.enable() and sdk.Logger.disable() functions
You can use LS and Environment vars as with the old logger.

https://gist.github.com/NicoZelaya/fc47e1940f1d397944ecd5b4a08741c7

<img width="931" alt="captura de pantalla 2017-04-26 a la s 13 09 03" src="https://cloud.githubusercontent.com/assets/5522668/25444479/adf6c2fe-2a81-11e7-9eff-2007d971c12a.png">
