### PR TITLE
services/transport: use `status` rather than `statusText`

### DIFF
--- a/src/services/transport/index.js
+++ b/src/services/transport/index.js
@@ -21,7 +21,7 @@ const log = require('debug')('splitio-services:service');
 
 function Fetcher(request) {
   return fetch(request).then(resp => {
-    if (resp.statusText === 'OK') {
+    if (resp.status === 200) {
       return resp;
     } else {
       log('throw error because status text is not OK');


### PR DESCRIPTION
In HTTP/2, the "reason" (`statusText`) is gone.

> 4.2 '"101" or "101 Switching Protocols"' - AIUI in HTTP/2 the reason
text is gone. The status pseudo header is numeric only.

ref:
http://lists.w3.org/Archives/Public/ietf-http-wg/2014JulSep/2461.html