### PR TITLE
Manager API fix about treatments on SplitView

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+## 9.3.1 (Jul 27, 2017)
+
+* Bugfixing - Fixed a bug on Manager API which was not retrieving the right treatments for a Split on some cases.
+
 ## 9.3.0 (Jul 25, 2017)
 
 Several new matchers have been released:

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,3 +1,7 @@
+## 9.3.1 (Jul 27, 2017)
+
+* Bugfixing - Fixed a bug on Manager API which was not retrieving the right treatments for a Split on some cases.
+
 ## 9.3.0 (Jul 25, 2017)
 
 Several new matchers have been released:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "9.3.0",
+  "version": "9.3.1-canary.0",
   "description": "Split SDK",
   "files": [
     "*.md",

--- a/src/manager/__tests__/mocks/input.json
+++ b/src/manager/__tests__/mocks/input.json
@@ -8,6 +8,7 @@
   "changeNumber": 1478881219393,
   "conditions": [
     {
+      "conditionType": "ROLLOUT",
       "matcherGroup": {
         "combiner": "AND",
         "matchers": [
@@ -29,6 +30,10 @@
         {
           "treatment": "on",
           "size": 100
+        },
+        {
+          "treatment": "off",
+          "size": 0
         }
       ]
     }

--- a/src/utils/settings/index.js
+++ b/src/utils/settings/index.js
@@ -71,7 +71,7 @@ const base = {
   debug: false,
 
   // Instance version.
-  version: `${language}-9.3.0`
+  version: `${language}-9.3.1-canary.0`
 };
 
 function fromSecondsToMillis(n) {


### PR DESCRIPTION
Manager - Object-to-View - Getting treatments list from the first rollout condition, instead of just the first condition

[SPLIT-3530](https://splitio.atlassian.net/browse/SPLIT-3530)