### PR TITLE
fixed splitio for versions of node bellow 4.x

### DIFF
--- a/src/producer/updater/SegmentChanges.js
+++ b/src/producer/updater/SegmentChanges.js
@@ -20,6 +20,7 @@ limitations under the License.
 
 const log = require('../../utils/logger')('splitio-producer:segment-changes');
 const segmentChangesFetcher = require('../fetcher/SegmentChanges');
+const findIndex = require('core-js/library/fn/array/find-index');
 
 const SegmentChangesUpdaterFactory = (settings: Object, readiness: ReadinessGate, storage: SplitStorage) => {
   const segmentsEventEmitter = readiness.segments;
@@ -63,7 +64,7 @@ const SegmentChangesUpdaterFactory = (settings: Object, readiness: ReadinessGate
     }
 
     return Promise.all(updaters).then(shouldUpdateFlags => {
-      if (shouldUpdateFlags.findIndex(v => v !== -1) !== -1 || readyOnAlreadyExistentState) {
+      if (findIndex(shouldUpdateFlags, v => v !== -1) !== -1 || readyOnAlreadyExistentState) {
         readyOnAlreadyExistentState = false;
         segmentsEventEmitter.emit(segmentsEventEmitter.SDK_SEGMENTS_ARRIVED);
       }


### PR DESCRIPTION
this pr fixes an issue that would prevent splitio from emitting `client.Event.SDK_READY` while initializing the SDK via: 

```javascript
client.on(client.Event.SDK_READY, function() {
    /*...*/
});
```
For versions of node prior to 4.x that does **NOT** support es6 `Array.prototype.findIndex` --- please see: http://node.green/#ES2015-built-ins-typed-arrays--TypedArray--prototype-findIndex

Since the function does not exists in older versions of node (i.e. due to the lack of es6 support) `splitio -> producer -> updater -> SegmentChanges` would cause `SegmentChangesUpdater` to throw [here](https://github.com/splitio/javascript-client/blob/master/src/producer/updater/SegmentChanges.js#L66) causing the promise to reject which will never emit `SDK_SEGMENTS_ARRIVED` which will prevent `READINESS_GATE_CHECK_STATE` to emit change and prevent the client from executing further [here](https://github.com/splitio/javascript-client/blob/master/src/readiness/index.js#L63)

The fix for older versions of node is very simple, anywhere else in the code base specifically at the engine level core-js is used in place rather than expecting the version of node to implement es6 like features.

Please accept this pr to correct this issue for older versions of node. Could you kindly please provide a date where a new npm build could be released?

