### PR TITLE
Context "capsule"

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-## 9.3.3 (Aug 14, 2017)
+## 9.3.3 (Aug 15, 2017)
 
 * Improved metrics collection.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+## 9.3.5 (XXX XX, 2017)
+
+* Internal context module added.
+
 ## 9.3.4 (Aug 23, 2017)
 
 * Removed FullStory integration

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,4 @@
-## 9.3.3 (Aug 14, 2017)
+## 9.3.3 (Aug 15, 2017)
 
 * Improved metrics collection. Now we report the complete set of them. (Browser only reports first fetch)
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,3 +1,7 @@
+## 9.3.5 (XXX XX, 2017)
+
+* Internal context module added. The idea was to reduce the amount of parameters flowing through the different functions.
+
 ## 9.3.4 (Aug 23, 2017)
 
 * Removed FullStory integration. It was causing an issue when FS was not yet ready.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "9.3.4",
+  "version": "9.3.5-canary.0",
   "description": "Split SDK",
   "files": [
     "*.md",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "9.3.3-canary.0",
+  "version": "9.3.3",
   "description": "Split SDK",
   "files": [
     "*.md",

--- a/src/client/browser.js
+++ b/src/client/browser.js
@@ -7,11 +7,12 @@ const get = require('lodash/get');
 const ClientFactory = require('./client');
 const keyParser = require('../utils/key/parser');
 
-function FixKey(storage: SplitStorage, metricCollectors, settings: Object): SplitClient {
+function FixKey(context): SplitClient {
+  const settings = context.get(context.constants.SETTINGS);
   // In the browser land, the key is required
   keyParser(get(settings, 'core.key', undefined));
 
-  const client = ClientFactory(storage, metricCollectors);
+  const client = ClientFactory(context);
 
   client.isBrowserClient = true;
   client.getTreatment = client.getTreatment.bind(client, settings.core.key);

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -48,7 +48,9 @@ function getTreatmentAvailable(
   return evaluation.treatment;
 }
 
-function ClientFactory(storage: SplitStorage, metricCollectors): SplitClient {
+function ClientFactory(context): SplitClient {
+  const storage = context.get(context.constants.STORAGE);
+  const metricCollectors = context.get(context.constants.COLLECTORS);
   const impressionsTracker = PassTracker(storage.impressions);
 
   return {

--- a/src/metrics/index.js
+++ b/src/metrics/index.js
@@ -39,7 +39,9 @@ const {
   SDKCollector
 } = require('./Collectors');
 
-const MetricsFactory = (settings: Object, storage: SplitStorage): Startable => {
+const MetricsFactory = (context): Startable => {
+  const settings = context.get(context.constants.SETTINGS);
+  const storage = context.get(context.constants.STORAGE);
   const pushMetrics = (): Promise<void> => {
     if (storage.metrics.isEmpty() && storage.count.isEmpty()) return Promise.resolve();
 

--- a/src/producer/browser/Full.js
+++ b/src/producer/browser/Full.js
@@ -28,9 +28,10 @@ const MySegmentsUpdater = require('../updater/MySegments');
 /**
  * Startup all the background jobs required for a Browser SDK instance.
  */
-const FullBrowserProducer = (settings: Object, readiness: ReadinessGate, storage: SplitStorage, metricCollectors: Object): Startable => {
-  const splitsUpdater = SplitChangesUpdater(settings, readiness, storage, metricCollectors);
-  const segmentsUpdater = MySegmentsUpdater(settings, readiness, storage, metricCollectors);
+const FullBrowserProducer = (context): Startable => {
+  const splitsUpdater = SplitChangesUpdater(context);
+  const segmentsUpdater = MySegmentsUpdater(context);
+  const settings = context.get(context.constants.SETTINGS);
 
   const splitsUpdaterTask = TaskFactory(splitsUpdater, settings.scheduler.featuresRefreshRate);
   const segmentsUpdaterTask = TaskFactory(segmentsUpdater, settings.scheduler.segmentsRefreshRate);

--- a/src/producer/browser/Partial.js
+++ b/src/producer/browser/Partial.js
@@ -24,8 +24,9 @@ const MySegmentsUpdater = require('../updater/MySegments');
 /**
  * Incremental updater to be used to share data in the browser.
  */
-const PartialBrowserProducer = (settings: Object, readiness: ReadinessGate, storage: SplitStorage, metricCollectors: Object): Startable => {
-  const segmentsUpdater = MySegmentsUpdater(settings, readiness, storage, metricCollectors);
+const PartialBrowserProducer = (context): Startable => {
+  const settings = context.get(context.constants.SETTINGS);
+  const segmentsUpdater = MySegmentsUpdater(context);
   const segmentsUpdaterTask = TaskFactory(segmentsUpdater, settings.scheduler.segmentsRefreshRate);
 
   return segmentsUpdaterTask;

--- a/src/producer/node.js
+++ b/src/producer/node.js
@@ -27,9 +27,10 @@ const SegmentChangesUpdater = require('./updater/SegmentChanges');
 /**
  * Expose start / stop mechanism for pulling data from services.
  */
-const NodeUpdater = (settings: Object, hub: EventEmitter, storage: SplitStorage, metricCollectors: Object): Startable => {
-  const splitsUpdater = SplitChangesUpdater(settings, hub, storage, metricCollectors, true /* tell split updater we are in node */);
-  const segmentsUpdater = SegmentChangesUpdater(settings, hub, storage, metricCollectors);
+const NodeUpdater = (context): Startable => {
+  const splitsUpdater = SplitChangesUpdater(context, true /* tell split updater we are in node */);
+  const segmentsUpdater = SegmentChangesUpdater(context);
+  const settings = context.get(context.constants.SETTINGS);
 
   let stopSplitsUpdate = false;
   let stopSegmentsUpdate = false;

--- a/src/producer/offline/browser.js
+++ b/src/producer/offline/browser.js
@@ -21,8 +21,9 @@ limitations under the License.
 const TaskFactory = require('../task');
 const FromFeaturesUpdater = require('../updater/SplitChangesFromFeatures');
 
-const OfflineFeatureProducer = (settings: Object, readiness: ReadinessGate, storage: SplitStorage): Startable => {
-  const updater = FromFeaturesUpdater(settings, readiness, storage);
+const OfflineFeatureProducer = (context): Startable => {
+  const settings = context.get(context.constants.SETTINGS);
+  const updater = FromFeaturesUpdater(context);
   const updaterTask = TaskFactory(updater, settings.scheduler.offlineRefreshRate);
 
   return updaterTask;

--- a/src/producer/offline/node.js
+++ b/src/producer/offline/node.js
@@ -21,8 +21,9 @@ limitations under the License.
 const TaskFactory = require('../task');
 const FromFileSystemUpdater = require('../updater/SplitChangesFromFileSystem');
 
-const OfflineFileSystemProducer = (settings: Object, readiness: ReadinessGate, storage: SplitStorage): Startable => {
-  const updater = FromFileSystemUpdater(settings, readiness, storage);
+const OfflineFileSystemProducer = (context): Startable => {
+  const settings = context.get(context.constants.SETTINGS);
+  const updater = FromFileSystemUpdater(context);
   const updaterTask = TaskFactory(updater, settings.scheduler.offlineRefreshRate);
 
   return updaterTask;

--- a/src/producer/updater/MySegments.js
+++ b/src/producer/updater/MySegments.js
@@ -21,7 +21,14 @@ limitations under the License.
 const log = require('../../utils/logger')('splitio-producer:my-segments');
 const mySegmentsFetcher = require('../fetcher/MySegments');
 
-function MySegmentsUpdaterFactory(settings: Object, readiness: ReadinessGate, storage: SplitStorage, metricCollectors: Object) {
+function MySegmentsUpdaterFactory(context) {
+  const {
+    [context.constants.SETTINGS]: settings,
+    [context.constants.READINESS]: readiness,
+    [context.constants.STORAGE]: storage,
+    [context.constants.COLLECTORS]: metricCollectors
+  } = context.getAll();
+
   const segmentsEventEmitter = readiness.segments;
 
   let readyOnAlreadyExistentState = true;

--- a/src/producer/updater/SegmentChanges.js
+++ b/src/producer/updater/SegmentChanges.js
@@ -22,7 +22,13 @@ const log = require('../../utils/logger')('splitio-producer:segment-changes');
 const segmentChangesFetcher = require('../fetcher/SegmentChanges');
 const findIndex = require('core-js/library/fn/array/find-index');
 
-const SegmentChangesUpdaterFactory = (settings: Object, readiness: ReadinessGate, storage: SplitStorage, metricCollectors: Object) => {
+const SegmentChangesUpdaterFactory = (context) => {
+  const {
+    [context.constants.SETTINGS]: settings,
+    [context.constants.READINESS]: readiness,
+    [context.constants.STORAGE]: storage,
+    [context.constants.COLLECTORS]: metricCollectors
+  } = context.getAll();
   const segmentsEventEmitter = readiness.segments;
 
   let readyOnAlreadyExistentState = true;

--- a/src/producer/updater/SplitChanges.js
+++ b/src/producer/updater/SplitChanges.js
@@ -52,7 +52,13 @@ function computeSplitsMutation(entries: Array<SplitObject>): SplitMutation {
   return computed;
 }
 
-function SplitChangesUpdaterFactory(settings: Object, readiness: ReadinessGate, storage: SplitStorage, metricCollectors: Object, isNode = false) {
+function SplitChangesUpdaterFactory(context, isNode = false) {
+  const {
+    [context.constants.SETTINGS]: settings,
+    [context.constants.READINESS]: readiness,
+    [context.constants.STORAGE]: storage,
+    [context.constants.COLLECTORS]: metricCollectors
+  } = context.getAll();
   const splitsEventEmitter = readiness.splits;
 
   let startingUp = true;

--- a/src/producer/updater/SplitChangesFromObject.js
+++ b/src/producer/updater/SplitChangesFromObject.js
@@ -20,7 +20,12 @@ limitations under the License.
 
 const log = require('../../utils/logger')('splitio-producer:offline');
 
-function FromObjectUpdaterFactory(Fetcher: Function, settings: Settings, readiness: ReadinessGate, storage: SplitStorage) {
+function FromObjectUpdaterFactory(Fetcher, context) {
+  const {
+    [context.constants.SETTINGS]: settings,
+    [context.constants.READINESS]: readiness,
+    [context.constants.STORAGE]: storage
+  } = context.getAll();
 
   return async function ObjectUpdater() {
     const splits = [];

--- a/src/services/impressions/dto.js
+++ b/src/services/impressions/dto.js
@@ -39,9 +39,12 @@ module.exports = {
           if (entry.bucketingKey) keyImpression.bucketingKey = entry.bucketingKey;
 
           // Add Full Story URL if Available
-          const properties = {};
-          if (typeof FS !== 'undefined' && FS) properties.full_story_url = FS.getCurrentSessionURL();
-          keyImpression.properties = JSON.stringify(properties);
+          if (typeof FS !== 'undefined' && FS) {
+            keyImpression.properties = JSON.stringify({
+              full_story_url: FS.getCurrentSessionURL()
+            });
+          }
+
 
           return keyImpression;
         })

--- a/src/utils/__tests__/context/index.spec.js
+++ b/src/utils/__tests__/context/index.spec.js
@@ -88,7 +88,8 @@ tape('CONTEXT / If we store a promise, it should store the value once it is reso
   const promiseToStore = new Promise(res => setTimeout(() => res(itemToStore), 50));
   myContext.put('test', promiseToStore);
 
-  assert.equal(myContext.get('test'), promiseToStore, 'If we\'ve stored a promise, we will receive a promise until it is resolved.');
+  assert.equal(myContext.get('test'), promiseToStore, 'If we\'ve stored a promise, we will receive that promise until it is resolved.');
+  assert.equal(myContext.get('test'), promiseToStore, 'Doesn\'t matter how many times, we should get the same promise.');
 
   promiseToStore.then(() => {
     assert.equal(myContext.get('test'), itemToStore, 'But once the promise is resolved, it should store the value and start returning it instead of the promise.');

--- a/src/utils/__tests__/context/index.spec.js
+++ b/src/utils/__tests__/context/index.spec.js
@@ -46,6 +46,9 @@ tape('CONTEXT / An instance should be able to store an item with a given name an
   assert.equal(myContext.put('test', itemToStore), true, 'Should store an item if a correct name was given.');
   assert.equal(myContext.put('test', anotherItemToStore), false, 'It should fail if we try to step on an existing item.');
   assert.equal(myContext.put(undefined, itemToStore), false, 'It should fail if no name is provided.');
+  assert.equal(myContext.put(null, itemToStore), false, 'It should fail if the name provided is not a string.');
+  assert.equal(myContext.put(false, itemToStore), false, 'It should fail if the name provided is not a string.');
+  assert.equal(myContext.put(new Date, itemToStore), false, 'It should fail if the name provided is not a string.');
   assert.equal(myContext.put('', itemToStore), false, 'It should fail if the name is empty string.');
   assert.equal(myContext.put('test2'), false, 'It should fail if no item is provided.');
   assert.equal(myContext.put('test3', undefined), false, 'It should fail if no item is provided.');

--- a/src/utils/__tests__/context/index.spec.js
+++ b/src/utils/__tests__/context/index.spec.js
@@ -33,8 +33,12 @@ tape('CONTEXT / An instance should be able to store an item with a given name an
   const itemToStore = {
     something: true
   };
+  const anotherItemToStore = {
+    somethingelse: true
+  };
 
   assert.equal(myContext.put('test', itemToStore), true, 'Should store an item if a correct name was given.');
+  assert.equal(myContext.put('test', anotherItemToStore), false, 'It should fail if we try to step on an existing item.');
   assert.equal(myContext.put(undefined, itemToStore), false, 'It should fail if no name is provided.');
   assert.equal(myContext.put('', itemToStore), false, 'It should fail if the name is empty string.');
   assert.equal(myContext.put('test'), false, 'It should fail if no item is provided.');

--- a/src/utils/__tests__/context/index.spec.js
+++ b/src/utils/__tests__/context/index.spec.js
@@ -1,0 +1,77 @@
+/**
+Copyright 2016 Split Software
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+**/
+'use strict';
+
+const tape = require('tape-catch');
+const Context = require('../../context');
+
+tape('CONTEXT / Should have an API for storing and retrieving items', assert => {
+  assert.equal(typeof Context, 'function', 'It should be a class.');
+  const myContext = new Context();
+
+  assert.equal(typeof myContext, 'object', 'When instantiated it should return an object');
+  assert.equal(typeof myContext.put, 'function', 'with a function for storing things');
+  assert.equal(typeof myContext.get, 'function', 'and a function for getting what we previously stored.');
+  assert.end();
+});
+
+tape('CONTEXT / An instance should be able to store an item with a given name and return the result of the operation', assert => {
+  const myContext = new Context();
+  const itemToStore = {
+    something: true
+  };
+
+  assert.equal(myContext.put('test', itemToStore), true, 'Should store an item if a correct name was given.');
+  assert.equal(myContext.put(undefined, itemToStore), false, 'It should fail if no name is provided.');
+  assert.equal(myContext.put('', itemToStore), false, 'It should fail if the name is empty string.');
+  assert.equal(myContext.put('test'), false, 'It should fail if no item is provided.');
+
+  assert.end();
+});
+
+tape('CONTEXT / An instance should be able to retrieve stored items', assert => {
+  const myContext = new Context();
+  const itemToStore = {
+    something: true
+  };
+  myContext.put('test', itemToStore);
+
+  assert.equal(myContext.get('test'), itemToStore, 'It should retrieve an already stored item.');
+  assert.equal(myContext.get('test'), itemToStore, 'Should be able to retrieve the same item as many times as needed.');
+  assert.equal(myContext.get(''), undefined, 'If we pass an incorrect name we should get an "undefined".');
+  assert.equal(myContext.get(null), undefined, 'If we pass an incorrect name we should get an "undefined".');
+
+  assert.end();
+});
+
+
+
+// tape('TIME TRACKER start() / should return the correct type', assert => {
+//   const promise = new Promise(res => {
+//     setTimeout(res, 1000);
+//   });
+//   promise.crap = true;
+//   const startNormal = tracker.start(tracker.TaskNames.SDK_READY);
+//   const startNormalFake = tracker.start('fakeTask3');
+//   const startWithPromise = tracker.start('fakeTask4', false, promise);
+
+//   assert.equal(typeof startNormal, 'function', 'If we call start without a promise, it will return the stop function,');
+//   assert.equal(typeof startNormal.setCollectorForTask, 'function', 'that has a function as well for setting the collector at a defered time, because it has a registered cb but no collector received.');
+//   assert.equal(typeof startNormalFake.setCollectorForTask, 'undefined', 'If no callback is registered for the task, no collectors setup function is attached to returned one.');
+//   assert.equal(typeof startWithPromise.then, 'function', 'But if we pass a promise, we will get a promise back, with the necessary callbacks already handled.');
+
+//   assert.end();
+// });

--- a/src/utils/__tests__/context/index.spec.js
+++ b/src/utils/__tests__/context/index.spec.js
@@ -24,8 +24,9 @@ tape('CONTEXT / Should have an API for storing and retrieving items', assert => 
   const myContext = new Context();
 
   assert.equal(typeof myContext, 'object', 'When instantiated it should return an object');
-  assert.equal(typeof myContext.put, 'function', 'with a function for storing things');
-  assert.equal(typeof myContext.get, 'function', 'and a function for getting what we previously stored.');
+  assert.equal(typeof myContext.put, 'function', 'with a function for storing things,');
+  assert.equal(typeof myContext.get, 'function', 'a function for getting an item we previously stored,');
+  assert.equal(typeof myContext.getAll, 'function', 'and a function for getting all the items that we\'ve previously stored.');
   assert.end();
 });
 
@@ -151,6 +152,25 @@ tape('CONTEXT / If we store a promise, but that promise fails, it should clean u
 
     assert.end();
   });
+});
+
+tape('CONTEXT / Should be able to retrieve all items at once', assert => {
+  const myContext = new Context();
+  const item1 = { some: 'thing' };
+  const item2 = () => {};
+  const item3 = 38;
+
+  myContext.put('test1', item1);
+  myContext.put('test2', item2);
+  myContext.put('test3', item3);
+
+  const { test1, test2, test3 } = myContext.getAll();
+
+  assert.equal(test1, item1, 'It should retrieve all items at once.');
+  assert.equal(test2, item2, 'It should retrieve all items at once.');
+  assert.equal(test3, item3, 'It should retrieve all items at once.');
+
+  assert.end();
 });
 
 tape('CONTEXT / Different instances should have different storing maps', assert => {

--- a/src/utils/__tests__/context/index.spec.js
+++ b/src/utils/__tests__/context/index.spec.js
@@ -74,16 +74,16 @@ tape('CONTEXT / If we store something someone is waiting for, it should resolve 
   };
   const itemPromise = myContext.get('test');
 
+  setTimeout(() => {
+    myContext.put('test', itemToStore);
+  }, 100);
+
   itemPromise.then(item => {
     assert.equal(item, itemToStore, 'Once we store something we generated a promise for, the promise should resolve to the item');
     assert.equal(myContext.get('test'), itemToStore, 'and the next time we ask for the item we will get the value instead of the promise.');
 
     assert.end();
   });
-
-  setTimeout(() => {
-    myContext.put('test', itemToStore);
-  }, 10);
 
   return itemPromise;
 });

--- a/src/utils/__tests__/context/index.spec.js
+++ b/src/utils/__tests__/context/index.spec.js
@@ -17,6 +17,7 @@ limitations under the License.
 
 const tape = require('tape-catch');
 const Context = require('../../context');
+const ContextConsts = require('../../context/constants');
 
 tape('CONTEXT / Should have an API for storing and retrieving items', assert => {
   assert.equal(typeof Context, 'function', 'It should be a class.');
@@ -25,6 +26,14 @@ tape('CONTEXT / Should have an API for storing and retrieving items', assert => 
   assert.equal(typeof myContext, 'object', 'When instantiated it should return an object');
   assert.equal(typeof myContext.put, 'function', 'with a function for storing things');
   assert.equal(typeof myContext.get, 'function', 'and a function for getting what we previously stored.');
+  assert.end();
+});
+
+tape('CONTEXT / Should expose the constants', assert => {
+  const myContext = new Context();
+
+  assert.deepEqual(myContext.constants, ContextConsts, 'Constants should be exposed from the context instance.');
+
   assert.end();
 });
 
@@ -37,7 +46,8 @@ tape('CONTEXT / An instance should be able to store an item with a given name an
   assert.equal(myContext.put('test', anotherItemToStore), false, 'It should fail if we try to step on an existing item.');
   assert.equal(myContext.put(undefined, itemToStore), false, 'It should fail if no name is provided.');
   assert.equal(myContext.put('', itemToStore), false, 'It should fail if the name is empty string.');
-  assert.equal(myContext.put('test'), false, 'It should fail if no item is provided.');
+  assert.equal(myContext.put('test2'), false, 'It should fail if no item is provided.');
+  assert.equal(myContext.put('test3', undefined), false, 'It should fail if no item is provided.');
 
   assert.end();
 });

--- a/src/utils/context/constants.js
+++ b/src/utils/context/constants.js
@@ -1,0 +1,6 @@
+module.exports = {
+  SETTINGS: 'settings',
+  STORAGE: 'storage',
+  READINESS: 'readiness_gate',
+  COLLECTORS: 'metrics_collectors'
+};

--- a/src/utils/context/index.js
+++ b/src/utils/context/index.js
@@ -40,7 +40,7 @@ class Context {
       if (existingItem !== undefined) return false;
     }
     // We are storing a promise, when resolving save the value.
-    if (thenable(item)) item.then((item) => {
+    if (existingItem === undefined && thenable(item)) item.then((item) => {
       this.map[name] = item;
       return item;
     });

--- a/src/utils/context/index.js
+++ b/src/utils/context/index.js
@@ -16,10 +16,14 @@ class Context {
     }
 
     const existingItem = this.map[name];
-    // Item already exists. Don't step on it.
-    if (existingItem) return false;
+
     // Someone is waiting for this item, resolve to it.
-    if (thenable(existingItem) && existingItem.manualResolve) this.map[name].manualResolve(item);
+    if (thenable(existingItem) && existingItem.manualResolve) {
+      existingItem.manualResolve(item);
+    } else {
+      // Item already exists. Don't step on it.
+      if (existingItem !== undefined) return false;
+    }
     // We are storing a promise, when resolving save the value.
     if (thenable(item)) item.then((item) => {
       this.map[name] = item;
@@ -29,10 +33,13 @@ class Context {
     this.map[name] = item;
     return true;
   }
-
+  /**
+   * Gets an item in the context instance.
+   * @param {string} name - The name of the item we want to get
+   */
   get(name) {
     if (typeof name !== 'string' || typeof name === 'string' && !name.length) {
-      return; // We can't store this.
+      return;
     }
     const item = this.map[name];
 
@@ -40,9 +47,10 @@ class Context {
       return item;
     } else {
       let resolve;
-      this.map[name] = new Promise((res) => { resolve = res; });
-      this.map[name].manualResolve = resolve;
-      return this.map[name];
+      const promise = new Promise(res => { resolve = res; });
+      promise.manualResolve = resolve;
+      this.map[name] = promise;
+      return promise;
     }
   }
 }

--- a/src/utils/context/index.js
+++ b/src/utils/context/index.js
@@ -1,5 +1,6 @@
-class Context {
+const thenable = require('../promise/thenable');
 
+class Context {
   constructor() {
     this.map = {};
   }
@@ -14,6 +15,17 @@ class Context {
       return false; // We can't store this.
     }
 
+    const existingItem = this.map[name];
+    // Item already exists. Don't step on it.
+    if (existingItem) return false;
+    // Someone is waiting for this item, resolve to it.
+    if (thenable(existingItem) && existingItem.manualResolve) this.map[name].manualResolve(item);
+    // We are storing a promise, when resolving save the value.
+    if (thenable(item)) item.then((item) => {
+      this.map[name] = item;
+      return item;
+    });
+
     this.map[name] = item;
     return true;
   }
@@ -22,8 +34,16 @@ class Context {
     if (typeof name !== 'string' || typeof name === 'string' && !name.length) {
       return; // We can't store this.
     }
+    const item = this.map[name];
 
-    return this.map[name];
+    if (item !== undefined) {
+      return item;
+    } else {
+      let resolve;
+      this.map[name] = new Promise((res) => { resolve = res; });
+      this.map[name].manualResolve = resolve;
+      return this.map[name];
+    }
   }
 }
 

--- a/src/utils/context/index.js
+++ b/src/utils/context/index.js
@@ -44,6 +44,9 @@ class Context {
     if (thenable(item)) item.then((item) => {
       this.map[name] = item;
       return item;
+    }).catch(err => {
+      this.map[name] = undefined;
+      return err;
     });
 
     this.map[name] = item;
@@ -55,7 +58,7 @@ class Context {
    */
   get(name) {
     if (typeof name !== 'string' || typeof name === 'string' && !name.length) {
-      return;
+      return; // Wrong usage, don't generate value promise.
     }
     const item = this.map[name];
 
@@ -63,7 +66,7 @@ class Context {
       return item;
     } else {
       let resolve;
-      const promise = new Promise(res => { resolve = res; });
+      const promise = new Promise(res => resolve = res);
       promise.manualResolve = resolve;
       this.map[name] = promise;
       return promise;

--- a/src/utils/context/index.js
+++ b/src/utils/context/index.js
@@ -24,6 +24,7 @@ class Context {
   /**
    * Gets an item in the context instance or a promise if the item is not yet stored.
    * @param {string} name - The name of the item we want to get
+   * @return any - The item we want to get.
    */
   get(name) {
     if (typeof name !== 'string' || typeof name === 'string' && !name.length) return; // Wrong usage, don't generate item promise.
@@ -42,10 +43,15 @@ class Context {
     }
   }
   /**
+   * Gets all objects stored in the context.
+   * @return {Object} - A new map of context-stored items.
+   */
+  getAll() { return Object.assign({}, this._map); }
+  /**
    * Stores an item in the context instance.
    * @param {string} name - The name of what we are storing
    * @param {any} item - The item can be of any type.
-   * @return {boolean}
+   * @return {boolean} - The result of the operation
    */
   put(name, item) {
     if (typeof name !== 'string' || (typeof name === 'string' && !name.length) || item === undefined) return false; // We can't store this.

--- a/src/utils/context/index.js
+++ b/src/utils/context/index.js
@@ -32,15 +32,16 @@ class Context {
 
     const existingItem = this.map[name];
 
+    // Item already exists and no one is waiting for the value. Abort and return false.
+    if (existingItem !== undefined && typeof existingItem.manualResolve !== 'function') return false;
+
     // Someone is waiting for this item, resolve to it.
     if (thenable(existingItem) && existingItem.manualResolve) {
       existingItem.manualResolve(item);
-    } else {
-      // Item already exists. Don't step on it.
-      if (existingItem !== undefined) return false;
     }
+
     // We are storing a promise, when resolving save the value.
-    if (existingItem === undefined && thenable(item)) item.then((item) => {
+    if (thenable(item)) item.then((item) => {
       this.map[name] = item;
       return item;
     });

--- a/src/utils/context/index.js
+++ b/src/utils/context/index.js
@@ -1,0 +1,37 @@
+class Context {
+
+  constructor() {
+    this.map = {};
+  }
+  /**
+   * Stores an item in the context instance.
+   * @param {string} name - The name of what we are storing
+   * @param {any} item - The item can be of any type.
+   * @return {boolean}
+   */
+  put(name, item) {
+    if (typeof name !== 'string' || (typeof name === 'string' && !name.length) || item === undefined) {
+      return false; // We can't store this.
+    }
+
+    this.map[name] = item;
+    return true;
+  }
+
+  get(name) {
+    if (typeof name !== 'string' || typeof name === 'string' && !name.length) {
+      return; // We can't store this.
+    }
+
+    return this.map[name];
+  }
+}
+
+
+
+
+
+
+
+
+module.exports = Context;

--- a/src/utils/context/index.js
+++ b/src/utils/context/index.js
@@ -1,3 +1,18 @@
+/**
+Copyright 2016 Split Software
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+**/
 const thenable = require('../promise/thenable');
 
 class Context {
@@ -54,12 +69,5 @@ class Context {
     }
   }
 }
-
-
-
-
-
-
-
 
 module.exports = Context;

--- a/src/utils/settings/index.js
+++ b/src/utils/settings/index.js
@@ -71,7 +71,7 @@ const base = {
   debug: false,
 
   // Instance version.
-  version: `${language}-9.3.3-canary.0`
+  version: `${language}-9.3.3`
 };
 
 function fromSecondsToMillis(n) {

--- a/src/utils/settings/index.js
+++ b/src/utils/settings/index.js
@@ -71,7 +71,7 @@ const base = {
   debug: false,
 
   // Instance version.
-  version: `${language}-9.3.4`
+  version: `${language}-9.3.5-canary.0`
 };
 
 function fromSecondsToMillis(n) {


### PR DESCRIPTION
Implementing a module for concentrating all modules/utilities we need to have on an SDK instance context, without conflicts between them.

The idea is to reduce the parameters overhead and just send the context to any place we may need something instance specific.

The next step would be to work towards removing code overhead caused by us trying to store things in a context, but this will be done at a later time.