### PR TITLE
[SDKS-139] Another iteration of Size Reduction.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 ## coverage info
 /karma/coverage
 
+## stats info
+/stats
+
 ## transpiled code
 /lib
 /es

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 ## 10.4.0 (XXX X, 2018)
 
 * Removed dependency for logging library.
+* Removed dependency on lodash.
 * Added log level support for SDK logs using our own Logger.
 * Added automatic cleanup and data flush for NodeJS on SIGTERM signals.
 * Updated dependency versions.

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,6 +1,7 @@
 ## 10.4.0 (XXX X, 2018)
 
 * Removed dependency for logging library.
+* Removed dependency on lodash.
 * Added log level support for SDK logs using our own Logger implementation. Now besides just enable/disable,
   you can set the log level as a string (more information on our docs or on Detailed-README.md).
   We now support the following log levels:

--- a/karma/local.js
+++ b/karma/local.js
@@ -5,14 +5,5 @@ const merge = require('lodash/merge');
 module.exports = merge({}, require('./config'), {
   browsers: [
     'Chrome'
-  ],
-
-  coverageReporter: {
-    type : 'html',
-    dir : '../karma/coverage/'
-  },
-
-  reporters: [
-    'coverage'
   ]
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.4.0-canary.0",
+  "version": "10.4.0-canary.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5880,7 +5880,8 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
     "lodash.assign": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "scripts": {
     "build-es": "rimraf es && cross-env NODE_ENV=es babel ./src -d es --ignore '__tests__'",
     "postbuild-es": "cross-env NODE_ENV=es node scripts/copy.packages.json.js",
+    "build-umd:stats": "webpack --progress --env production --json > ./stats/stat_results.json",
     "build-cjs": "rimraf lib && cross-env NODE_ENV=cjs babel ./src -d lib --ignore '__tests__'",
     "postbuild-cjs": "cross-env NODE_ENV=cjs node scripts/copy.packages.json.js",
     "build-umd": "cross-env NODE_ENV=development webpack",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.4.0-canary.0",
+  "version": "10.4.0-canary.1",
   "description": "Split SDK",
   "files": [
     "README.md",
@@ -49,6 +49,7 @@
     "karma-webpack": "3.0.2",
     "redis-dump": "0.1.10",
     "redis-server": "1.2.2",
+    "lodash": "4.17.11",
     "rimraf": "2.6.2",
     "sinon": "5.1.1",
     "tape": "4.9.1",
@@ -92,7 +93,6 @@
     "babel-runtime": "6.26.0",
     "events": "3.0.0",
     "ip": "1.1.5",
-    "lodash": "4.17.11",
     "utfx": "1.0.1"
   },
   "optionalDependencies": {

--- a/src/client/browser.js
+++ b/src/client/browser.js
@@ -1,4 +1,4 @@
-import get from 'lodash/get';
+import { get } from '../utils/lang';
 import ClientFactory from './client';
 import { LOCALHOST_MODE } from '../utils/constants';
 

--- a/src/engine/combiners/and.js
+++ b/src/engine/combiners/and.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **/
 
-import findIndex from 'lodash/findIndex';
+import { findIndex } from '../../utils/lang';
 import logFactory from '../../utils/logger';
 const log = logFactory('splitio-engine:combiner');
 import thenable from '../../utils/promise/thenable';

--- a/src/engine/combiners/ifelseif.js
+++ b/src/engine/combiners/ifelseif.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **/
 
-import findIndex from 'lodash/findIndex';
+import { findIndex } from '../../utils/lang';
 import logFactory from '../../utils/logger';
 const log = logFactory('splitio-engine:combiner');
 import thenable from '../../utils/promise/thenable';

--- a/src/engine/evaluator/index.js
+++ b/src/engine/evaluator/index.js
@@ -17,7 +17,7 @@ limitations under the License.
 import Engine from '../';
 import thenable from '../../utils/promise/thenable';
 import LabelsConstants from '../../utils/labels';
-import isString from 'lodash/isString';
+import { isString } from '../../utils/lang';
 import logFactory from '../../utils/logger';
 const log = logFactory('splitio-client');
 
@@ -31,7 +31,7 @@ function splitEvaluator(
   let isSplitNameUnexistence = splitName === null || splitName === undefined;
 
   /**
-   * If split name is null or undefined or is not a string return control and 
+   * If split name is null or undefined or is not a string return control and
    * label exception and log the error.
    */
   if (isSplitNameUnexistence || !isString(splitName)) {

--- a/src/engine/index.js
+++ b/src/engine/index.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **/
 
-import get from 'lodash/get';
+import { get } from '../utils/lang';
 import parser from './parser';
 import keyParser from '../utils/key/parser';
 import keyLogError from '../utils/key/logError';

--- a/src/engine/matchers/cont_all.js
+++ b/src/engine/matchers/cont_all.js
@@ -16,15 +16,19 @@ limitations under the License.
 
 import logFactory from '../../utils/logger';
 const log = logFactory('splitio-engine:matcher');
-import intersection from 'lodash/intersection';
+import { findIndex } from '../../utils/lang';
 
 function containsAllMatcherContext(ruleAttr /*: array */) /*: Function */ {
   return function containsAllMatcher(runtimeAttr /*: array */) /*: boolean */ {
-    let containsAll = false;
+    let containsAll = true;
 
-    // If runtimeAttr has less elements than whitelist, there is now way that it contains all the whitelist elems.
-    if (runtimeAttr.length >= ruleAttr.length) {
-      containsAll = intersection(runtimeAttr, ruleAttr).length === ruleAttr.length;
+    if (runtimeAttr.length < ruleAttr.length) {
+      containsAll = false;
+    } else {
+      for (let i = 0; i < ruleAttr.length && containsAll; i++) {
+        if (findIndex(runtimeAttr, e => e === ruleAttr[i]) < 0)
+          containsAll = false;
+      }
     }
 
     log.debug(`[containsAllMatcher] ${runtimeAttr} contains all elements of ${ruleAttr}? ${containsAll}`);

--- a/src/engine/matchers/cont_any.js
+++ b/src/engine/matchers/cont_any.js
@@ -16,11 +16,15 @@ limitations under the License.
 
 import logFactory from '../../utils/logger';
 const log = logFactory('splitio-engine:matcher');
-import intersection from 'lodash/intersection';
+import { findIndex } from '../../utils/lang';
 
 function containsAnyMatcherContext(ruleAttr /*: array */) /*: Function */ {
   return function containsAnyMatcher(runtimeAttr /*: array */) /*: boolean */ {
-    const containsAny = intersection(runtimeAttr, ruleAttr).length > 0;
+    let containsAny = false;
+
+    for (let i = 0; i < ruleAttr.length && !containsAny; i++) {
+      if (findIndex(runtimeAttr, e => e === ruleAttr[i]) >= 0) containsAny = true;
+    }
 
     log.debug(`[containsAnyMatcher] ${runtimeAttr} contains at least an element of ${ruleAttr}? ${containsAny}`);
 

--- a/src/engine/matchers/cont_str.js
+++ b/src/engine/matchers/cont_str.js
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **/
 
+import { isString } from '../../utils/lang';
 import logFactory from '../../utils/logger';
 const log = logFactory('splitio-engine:matcher');
-import includes from 'lodash/includes';
 
 function containsStringMatcherContext(ruleAttr /*: array */) /*: Function */ {
   return function containsStringMatcher(runtimeAttr /*: string */) /*: boolean */ {
-    let contains = ruleAttr.some(e => includes(runtimeAttr, e));
+    let contains = ruleAttr.some(e => isString(runtimeAttr) && runtimeAttr.indexOf(e) > -1);
 
-    log.debug(`[containsStringMatcher] ${runtimeAttr} ends with ${ruleAttr}? ${contains}`);
+    log.debug(`[containsStringMatcher] ${runtimeAttr} contains ${ruleAttr}? ${contains}`);
 
     return contains;
   };

--- a/src/engine/matchers/eq_set.js
+++ b/src/engine/matchers/eq_set.js
@@ -16,12 +16,17 @@ limitations under the License.
 
 import logFactory from '../../utils/logger';
 const log = logFactory('splitio-engine:matcher');
-import difference from 'lodash/difference';
+import { findIndex } from '../../utils/lang';
 
 function equalToSetMatcherContext(ruleAttr /*: array */) /*: Function */ {
   return function equalToSetMatcher(runtimeAttr /*: array */) /*: boolean */ {
-    let isEqual = runtimeAttr.length === ruleAttr.length &&
-                  difference(ruleAttr, runtimeAttr).length === 0;
+    // Length being the same is the first condition.
+    let isEqual = runtimeAttr.length === ruleAttr.length;
+
+    for (let i = 0; i < runtimeAttr.length && isEqual; i++) {
+      // if length is the same we check that all elements are present in the other collection.
+      if (findIndex(ruleAttr, e => e === runtimeAttr[i]) < 0) isEqual = false;
+    }
 
     log.debug(`[equalToSetMatcher] is ${runtimeAttr} equal to set ${ruleAttr}? ${isEqual}`);
 

--- a/src/engine/matchers/ew.js
+++ b/src/engine/matchers/ew.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 import logFactory from '../../utils/logger';
 const log = logFactory('splitio-engine:matcher');
-import strEndsWith from 'lodash/endsWith';
+import { endsWith as strEndsWith } from '../../utils/lang';
 
 function endsWithMatcherContext(ruleAttr /*: array */) /*: Function */ {
   return function endsWithMatcher(runtimeAttr /*: string */) /*: boolean */ {

--- a/src/engine/matchers/part_of.js
+++ b/src/engine/matchers/part_of.js
@@ -15,13 +15,18 @@ limitations under the License.
 **/
 
 import logFactory from '../../utils/logger';
+import { findIndex } from '../../utils/lang';
 const log = logFactory('splitio-engine:matcher');
-import intersection from 'lodash/intersection';
 
 function partOfMatcherContext(ruleAttr /*: array */) /*: Function */ {
   return function partOfMatcher(runtimeAttr /*: array */) /*: boolean */ {
-    // If the intersection returns all of runtimeAttr elements, it is a part of ruleAttr
-    const isPartOf = intersection(runtimeAttr, ruleAttr).length === runtimeAttr.length;
+    // To be part of the length should be minor or equal.
+    let isPartOf = runtimeAttr.length <= ruleAttr.length;
+
+    for(let i = 0; i < runtimeAttr.length && isPartOf; i++) {
+      // If the length says is possible, we iterate until we prove otherwise or we check all elements.
+      if (findIndex(ruleAttr, e => e === runtimeAttr[i]) < 0) isPartOf = false;
+    }
 
     log.debug(`[partOfMatcher] ${runtimeAttr} is part of ${ruleAttr}? ${isPartOf}`);
 

--- a/src/engine/matchers/sw.js
+++ b/src/engine/matchers/sw.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 import logFactory from '../../utils/logger';
 const log = logFactory('splitio-engine:matcher');
-import startsWith from 'lodash/startsWith';
+import { startsWith } from '../../utils/lang';
 
 function startsWithMatcherContext(ruleAttr /*: array */) /*: Function */ {
   return function startsWithMatcher(runtimeAttr /*: string */) /*: boolean */ {

--- a/src/engine/transforms/matchers.js
+++ b/src/engine/transforms/matchers.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **/
 
-import findIndex from 'lodash/findIndex';
+import { findIndex } from '../../utils/lang';
 import {
   types as matcherTypes,
   mapper as matcherTypesMapper,

--- a/src/engine/treatments/index.js
+++ b/src/engine/treatments/index.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **/
 
-import findIndex from 'lodash/findIndex';
+import { findIndex } from '../../utils/lang';
 
 function Treatments(ranges, treatments) {
   if (!(this instanceof Treatments)) {

--- a/src/engine/value/sanitize.js
+++ b/src/engine/value/sanitize.js
@@ -16,10 +16,7 @@ limitations under the License.
 
 import logFactory from '../../utils/logger';
 const log = logFactory('splitio-engine:sanitize');
-import isObject from 'lodash/isObject';
-import uniq from 'lodash/uniq';
-import toString from 'lodash/toString';
-import toNumber from 'lodash/toNumber';
+import { isObject, uniq, toString, toNumber } from '../../utils/lang';
 import { zeroSinceHH, zeroSinceSS } from '../convertions';
 import {
   types as matcherTypes,

--- a/src/engine/value/sanitize.js
+++ b/src/engine/value/sanitize.js
@@ -16,7 +16,6 @@ limitations under the License.
 
 import logFactory from '../../utils/logger';
 const log = logFactory('splitio-engine:sanitize');
-import isArray from 'lodash/isArray';
 import isObject from 'lodash/isObject';
 import uniq from 'lodash/uniq';
 import toString from 'lodash/toString';
@@ -47,7 +46,7 @@ function sanitizeString(val) {
 }
 
 function sanitizeArray(val) {
-  const arr = isArray(val) ? uniq(val.map(e => e + '')) : [];
+  const arr = Array.isArray(val) ? uniq(val.map(e => e + '')) : [];
   return arr.length ? arr : undefined;
 }
 

--- a/src/listeners/__tests__/node.spec.js
+++ b/src/listeners/__tests__/node.spec.js
@@ -149,7 +149,7 @@ tape('Node JS / Signal Listener SIGTERM callback with async handler that throws 
       rej();
     }, 0);
   });
-  const clock = sinon.useFakeTimers()
+  const clock = sinon.useFakeTimers();
   const handlerMock = sinon.stub().returns(fakePromise);
 
   // Stub stop function since we don't want side effects on test.

--- a/src/manager/index.js
+++ b/src/manager/index.js
@@ -1,5 +1,5 @@
 import thenable from '../utils/promise/thenable';
-import find from 'lodash/find';
+import { find } from '../utils/lang';
 import validateManagerSplit from '../utils/manager/validate';
 
 const collectTreatments = (conditions) => {

--- a/src/producer/fetcher/SegmentChanges.js
+++ b/src/producer/fetcher/SegmentChanges.js
@@ -17,7 +17,7 @@ limitations under the License.
 import segmentChangesService from '../../services/segmentChanges';
 import segmentChangesRequest from '../../services/segmentChanges/get';
 import tracker from '../../utils/timeTracker';
-import startsWith from 'lodash/startsWith';
+import { startsWith } from '../../utils/lang';
 
 function greedyFetch(settings, lastSinceValue, segmentName, metricCollectors) {
   return tracker.start(tracker.TaskNames.SEGMENTS_FETCH, metricCollectors, segmentChangesService(segmentChangesRequest(settings, {

--- a/src/producer/updater/SegmentChanges.js
+++ b/src/producer/updater/SegmentChanges.js
@@ -17,7 +17,7 @@ limitations under the License.
 import logFactory from '../../utils/logger';
 const log = logFactory('splitio-producer:segment-changes');
 import segmentChangesFetcher from '../fetcher/SegmentChanges';
-import findIndex from 'lodash/findIndex';
+import { findIndex } from '../../utils/lang';
 
 const SegmentChangesUpdaterFactory = (context) => {
   const {

--- a/src/services/impressions/dto.js
+++ b/src/services/impressions/dto.js
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **/
-import groupBy from 'lodash/groupBy';
+import { groupBy } from '../../utils/lang';
 
 export function fromImpressionsCollector(collector, settings) {
   const sendLabels = settings.core.labelsEnabled;

--- a/src/services/metrics/dto.js
+++ b/src/services/metrics/dto.js
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **/
-import forOwn from 'lodash/forOwn';
+import { forOwn } from '../../utils/lang';
 
 export function fromLatenciesCollector(latenciesCollector) {
   const result = [];

--- a/src/services/request/index.js
+++ b/src/services/request/index.js
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **/
 import options from './options';
-import isEmpty from 'lodash/isEmpty';
 
 function RequestFactory(settings, relativeUrl, params) {
   const token = settings.core.authorizationKey;
@@ -28,8 +27,8 @@ function RequestFactory(settings, relativeUrl, params) {
   headers['Authorization'] = `Bearer ${token}`;
   headers['SplitSDKVersion'] = version;
 
-  if (!isEmpty(ip)) headers['SplitSDKMachineIP'] = ip;
-  if (!isEmpty(hostname)) headers['SplitSDKMachineName'] = hostname;
+  if (ip) headers['SplitSDKMachineIP'] = ip;
+  if (hostname) headers['SplitSDKMachineName'] = hostname;
 
   return {
     headers,

--- a/src/storage/Keys.js
+++ b/src/storage/Keys.js
@@ -1,4 +1,4 @@
-import startsWith from 'lodash/startsWith';
+import { startsWith } from '../utils/lang';
 
 const everythingAtTheEnd = /[^.]+$/;
 const everythingAfterCount = /count\.([^/]+)$/;

--- a/src/storage/KeysLocalStorage.js
+++ b/src/storage/KeysLocalStorage.js
@@ -1,4 +1,4 @@
-import startsWith from 'lodash/startsWith';
+import { startsWith } from '../utils/lang';
 import KeyBuilder from './Keys';
 import { matching } from '../utils/key/factory';
 

--- a/src/utils/__tests__/lang/index.spec.js
+++ b/src/utils/__tests__/lang/index.spec.js
@@ -328,6 +328,28 @@ tape('LANG UTILS / toString', function(assert) {
   assert.end();
 });
 
+tape('LANG UTILS / toNumber', function(assert) {
+  assert.equal(typeof toNumber(NaN), 'number', 'It should ALWAYS return a number.');
+  assert.equal(typeof toNumber(null), 'number', 'It should ALWAYS return a number.');
+  assert.equal(typeof toNumber(250), 'number', 'It should ALWAYS return a number.');
+  assert.equal(typeof toNumber('asdad'), 'number', 'It should ALWAYS return a number.');
+  assert.equal(typeof toNumber(/regex/), 'number', 'It should ALWAYS return a number.');
+
+  assert.ok(Number.isNaN(toNumber()), 'The returned number should be NaN for values that cannot be converted');
+  assert.ok(Number.isNaN(toNumber(/regex/)), 'The returned number should be NaN for values that cannot be converted');
+  assert.ok(Number.isNaN(toNumber({})), 'The returned number should be NaN for values that cannot be converted');
+  assert.ok(Number.isNaN(toNumber({})), 'The returned number should be NaN for values that cannot be converted');
+  assert.ok(Number.isNaN(toNumber('1.2.3')), 'The returned number should be NaN for values that cannot be converted');
+
+  assert.equal(toNumber('1.2124'), 1.2124, 'The returned number (if it can be converted) should be correct');
+  assert.equal(toNumber('238'), 238, 'The returned number (if it can be converted) should be correct');
+  assert.equal(toNumber(null), 0, 'The returned number (if it can be converted) should be correct');
+  assert.equal(toNumber(15), 15, 'The returned number (if it can be converted) should be correct');
+  assert.equal(toNumber(''), 0, 'The returned number (if it can be converted) should be correct');
+
+  assert.end();
+});
+
 tape('LANG UTILS / groupBy', function(assert) {
   let arr = [{
     team: 'SDK',

--- a/src/utils/__tests__/lang/index.spec.js
+++ b/src/utils/__tests__/lang/index.spec.js
@@ -1,9 +1,11 @@
 import tape from 'tape-catch';
+import sinon from 'sinon';
 import {
   startsWith,
   endsWith,
   get,
   findIndex,
+  find,
   merge,
   uniq,
   groupBy
@@ -87,6 +89,38 @@ tape('LANG UTILS / findIndex', function(assert) {
   assert.equal(findIndex(arr, e => e === 3), 2, 'It should return the index of the first element that causes iteratee to return truthy.');
 
   /* Not testing the params received by iteratee because we know that Array.prototype.findIndex works ok */
+
+  assert.end();
+});
+
+tape('LANG UTILS / find', function(assert) {
+  assert.equal(find(), undefined, 'We cant find the element if the collection is wrong type, so we return undefined.');
+  assert.equal(find(null, () => true), undefined, 'We cant find the element if the collection is wrong type, so we return undefined.');
+
+  assert.equal(find([], () => true), undefined, 'If the collection is empty there is no element to be found, so we return undefined.');
+  assert.equal(find({}, () => true), undefined, 'If the collection is empty there is no element to be found, so we return undefined.');
+
+  const spy = sinon.spy();
+  const obj = { myKey: 'myVal', myOtherKey: 'myOtherVal' };
+
+  find(obj, spy);
+  assert.ok(spy.calledTwice, 'The iteratee should be called as many times as elements we have on the collection.');
+  assert.ok(spy.firstCall.calledWithExactly('myVal', 'myKey', obj), 'When iterating on an object the iteratee should be called with (val, key, collection)');
+  assert.ok(spy.secondCall.calledWithExactly('myOtherVal', 'myOtherKey', obj), 'When iterating on an object the iteratee should be called with (val, key, collection)');
+
+  const arr = ['one', 'two'];
+  spy.resetHistory();
+
+  find(arr, spy);
+  assert.ok(spy.calledTwice, 'The iteratee should be called as many times as elements we have on the collection.');
+  assert.ok(spy.firstCall.calledWithExactly('one', 0, arr), 'When iterating on an array the iteratee should be called with (val, index, collection)');
+  assert.ok(spy.secondCall.calledWithExactly('two', 1, arr), 'When iterating on an array the iteratee should be called with (val, index, collection)');
+
+  assert.equal(find({
+    val1: '1',
+    val2: '2'
+  }, e => e === '2'), '2', 'If an element causes iteratee to return a truthy value, that value is returned.');
+  assert.equal(find(['uno', 'dos'], e => e === 'uno'), 'uno', 'If an element causes iteratee to return a truthy value, that value is returned.');
 
   assert.end();
 });

--- a/src/utils/__tests__/lang/index.spec.js
+++ b/src/utils/__tests__/lang/index.spec.js
@@ -11,6 +11,8 @@ import {
   uniqueId,
   merge,
   uniq,
+  toString,
+  toNumber,
   groupBy
 } from '../../lang';
 
@@ -304,6 +306,24 @@ tape('LANG UTILS / uniq', function(assert) {
   assert.deepEqual(uniq(['2', '2']), ['2'], 'uniq should remove all duplicate strings from array.');
   assert.deepEqual(uniq(['2', '3']), ['2', '3'], 'uniq should remove all duplicate strings from array.');
   assert.deepEqual(uniq(['3', '2', '3']), ['3', '2'], 'uniq should remove all duplicate strings from array.');
+
+  assert.end();
+});
+
+tape('LANG UTILS / toString', function(assert) {
+  assert.equal(typeof toString(), 'string', 'It should ALWAYS return a string.');
+  assert.equal(typeof toString(null), 'string', 'It should ALWAYS return a string.');
+  assert.equal(typeof toString(250), 'string', 'It should ALWAYS return a string.');
+  assert.equal(typeof toString('asdad'), 'string', 'It should ALWAYS return a string.');
+  assert.equal(typeof toString(/regex/), 'string', 'It should ALWAYS return a string.');
+
+  assert.equal(toString(), '', 'And the returned string should be correct');
+  assert.equal(toString('it is just me'), 'it is just me', 'And the returned string should be correct');
+  assert.equal(toString(5), '5', 'And the returned string should be correct');
+  assert.equal(toString(['str', /not_str/, 'secondStr']), 'str,,secondStr', 'And the returned string should be correct');
+  assert.equal(toString(0), '0', 'And the returned string should be correct');
+  assert.equal(toString(-0), '-0', 'And the returned string should be correct');
+  assert.equal(toString(-Infinity), '-Infinity', 'And the returned string should be correct');
 
   assert.end();
 });

--- a/src/utils/__tests__/lang/index.spec.js
+++ b/src/utils/__tests__/lang/index.spec.js
@@ -8,6 +8,7 @@ import {
   find,
   isString,
   isFinite,
+  uniqueId,
   merge,
   uniq,
   groupBy
@@ -156,6 +157,19 @@ tape('LANG UTILS / isFinite', function(assert) {
   assert.notOk(isFinite({}), 'Should return false for anything that is not a finite number.');
   assert.notOk(isFinite(/regex/), 'Should return false for anything that is not a finite number.');
   assert.notOk(isFinite('5'), 'Should return false for anything that is not a finite number.');
+
+  assert.end();
+});
+
+tape('LANG UTILS / uniqueId', function(assert) {
+  let currId = -100;
+  let prevId = -100;
+
+  for(let i = 0; i < 10; i++) {
+    currId = uniqueId();
+    assert.ok(prevId < currId, 'Each time we call the function, the new ID should be different (greater than) the previous one.');
+    prevId = currId;
+  }
 
   assert.end();
 });

--- a/src/utils/__tests__/lang/index.spec.js
+++ b/src/utils/__tests__/lang/index.spec.js
@@ -1,5 +1,5 @@
 import tape from 'tape-catch';
-import { merge, uniq } from '../../lang';
+import { merge, uniq, groupBy } from '../../lang';
 
 tape('LANG UTILS / merge', function(assert) {
   let obj1 = {};
@@ -131,6 +131,42 @@ tape('LANG UTILS / uniq', function(assert) {
   assert.deepEqual(uniq(['2', '2']), ['2'], 'uniq should remove all duplicate strings from array.');
   assert.deepEqual(uniq(['2', '3']), ['2', '3'], 'uniq should remove all duplicate strings from array.');
   assert.deepEqual(uniq(['3', '2', '3']), ['3', '2'], 'uniq should remove all duplicate strings from array.');
+
+  assert.end();
+});
+
+tape('LANG UTILS / groupBy', function(assert) {
+  let arr = [{
+    team: 'SDK',
+    name: 'Nico',
+    ex: 'glb'
+  }, {
+    team: 'SDK',
+    name: 'Martin'
+  }, {
+    team: 'QA',
+    name: 'Adrian',
+    ex: 'glb'
+  }];
+
+  assert.deepEqual(groupBy(arr, 'team'), {
+    SDK: [{ team: 'SDK', name: 'Nico', ex: 'glb' }, { team: 'SDK', name: 'Martin' }],
+    QA: [{ team: 'QA', name: 'Adrian', ex: 'glb' }]
+  }, 'Should group by the property specified respecting the order of appearance.');
+  assert.deepEqual(groupBy(arr, 'not_exist'), {}, 'If the property specified does not exist on the elements the map will be empty.');
+  assert.deepEqual(groupBy(arr, 'ex'), {
+    glb: [{ team: 'SDK', name: 'Nico', ex: 'glb' }, { team: 'QA', name: 'Adrian', ex: 'glb' }]
+  }, 'If the property specified does not exist on all the elements the ones without it will be skipped.');
+
+
+  assert.deepEqual(groupBy([], 'team'), {}, 'If the input is empty or wrong type, it will return an empty object.');
+  assert.deepEqual(groupBy(null, 'team'), {}, 'If the input is empty or wrong type, it will return an empty object.');
+  assert.deepEqual(groupBy(undefined, 'team'), {}, 'If the input is empty or wrong type, it will return an empty object.');
+  assert.deepEqual(groupBy(true, 'team'), {}, 'If the input is empty or wrong type, it will return an empty object.');
+  assert.deepEqual(groupBy('string', 'team'), {}, 'If the input is empty or wrong type, it will return an empty object.');
+  assert.deepEqual(groupBy({}, 'team'), {}, 'If the input is empty or wrong type, it will return an empty object.');
+  assert.deepEqual(groupBy({ something: 1 }, null), {}, 'If the input is empty or wrong type, it will return an empty object.');
+  assert.deepEqual(groupBy({ something: 1 }), {}, 'If the input is empty or wrong type, it will return an empty object.');
 
   assert.end();
 });

--- a/src/utils/__tests__/lang/index.spec.js
+++ b/src/utils/__tests__/lang/index.spec.js
@@ -6,6 +6,8 @@ import {
   get,
   findIndex,
   find,
+  isString,
+  isFinite,
   merge,
   uniq,
   groupBy
@@ -121,6 +123,39 @@ tape('LANG UTILS / find', function(assert) {
     val2: '2'
   }, e => e === '2'), '2', 'If an element causes iteratee to return a truthy value, that value is returned.');
   assert.equal(find(['uno', 'dos'], e => e === 'uno'), 'uno', 'If an element causes iteratee to return a truthy value, that value is returned.');
+
+  assert.end();
+});
+
+tape('LANG UTILS / isString', function(assert) {
+  assert.ok(isString(''), 'Should return true for strings.');
+  assert.ok(isString('asd'), 'Should return true for strings.');
+  assert.ok(isString(new String('asdf')), 'Should return true for strings.');
+
+  assert.notOk(isString(), 'Should return false for non-strings.');
+  assert.notOk(isString(null), 'Should return false for non-strings.');
+  assert.notOk(isString([]), 'Should return false for non-strings.');
+  assert.notOk(isString({}), 'Should return false for non-strings.');
+  assert.notOk(isString(/regex/), 'Should return false for non-strings.');
+
+  assert.end();
+});
+
+tape('LANG UTILS / isFinite', function(assert) {
+  assert.ok(isFinite(1), 'Should return true for finite numbers.');
+  assert.ok(isFinite(new Number(4)), 'Should return true for finite numbers.');
+
+  assert.notOk(isFinite(), 'Should return false for anything that is not a finite number.');
+  assert.notOk(isFinite(Infinity), 'Should return false for anything that is not a finite number.');
+  assert.notOk(isFinite(-Infinity), 'Should return false for anything that is not a finite number.');
+  assert.notOk(isFinite(NaN), 'Should return false for anything that is not a finite number.');
+  assert.notOk(isFinite(new Number(Infinity)), 'Should return false for anything that is not a finite number.');
+  assert.notOk(isFinite(new Number(NaN)), 'Should return false for anything that is not a finite number.');
+  assert.notOk(isFinite(null), 'Should return false for anything that is not a finite number.');
+  assert.notOk(isFinite([]), 'Should return false for anything that is not a finite number.');
+  assert.notOk(isFinite({}), 'Should return false for anything that is not a finite number.');
+  assert.notOk(isFinite(/regex/), 'Should return false for anything that is not a finite number.');
+  assert.notOk(isFinite('5'), 'Should return false for anything that is not a finite number.');
 
   assert.end();
 });

--- a/src/utils/__tests__/lang/index.spec.js
+++ b/src/utils/__tests__/lang/index.spec.js
@@ -1,0 +1,127 @@
+import tape from 'tape-catch';
+import { merge } from '../../lang';
+
+tape('LANG UTILS / merge', function(assert) {
+  let obj1 = {};
+  let res1 = merge(obj1, { something: 'else' });
+
+  assert.ok(res1 === obj1, 'It merges on the target, modifying that object and returning it too.');
+
+
+  assert.deepEqual(merge({ a: 'a', b: 'b' }, { c: 'c' }), { a: 'a', b: 'b', c: 'c' }, 'Should be able to merge simple objects, an unlimited amount of them.');
+  assert.deepEqual(merge({ a: 'a', b: 'b' }, { c: 'c' }, { d: 'd' }), { a: 'a', b: 'b', c: 'c', d: 'd' }, 'Should be able to merge simple objects, an unlimited amount of them.');
+  assert.deepEqual(merge({ a: 'a' }, { b: 'b'}, { c: 'c' }, { d: 'd' }), { a: 'a', b: 'b', c: 'c', d: 'd' }, 'Should be able to merge simple objects, an unlimited amount of them.');
+
+  obj1 = {
+    a: 'a',
+    abc: { b: 'b', c: 'c' },
+    arr: [1,2]
+  };
+  let obj2 = {
+    a: 'not a anymore',
+    d: 'd'
+  };
+
+  // Two objects with complex structures but not in common.
+  assert.deepEqual(merge(obj1, obj2), {
+    a: 'not a anymore',
+    abc: { b: 'b', c: 'c' },
+    d: 'd',
+    arr: [1,2]
+  }, 'Should be able to merge complex objects');
+
+  obj1 = {
+    a: 'a',
+    abc: { b: 'b', c: 'c' }
+  };
+
+  obj2 = {
+    a: 'not a anymore',
+    abc: { c: 'not c anymore', d: 'd' }
+  };
+
+  // Two objects with object property in common
+  assert.deepEqual(merge(obj1, obj2), {
+    a: 'not a anymore',
+    abc: { b: 'b', c: 'not c anymore', d: 'd' },
+  }, 'Should be able to merge complex objects');
+
+  obj2.abc.d = { ran: 'dom' };
+
+  // Two objects with object property in common and with objects in it.
+  assert.deepEqual(merge(obj1, obj2), {
+    a: 'not a anymore',
+    abc: { b: 'b', c: 'not c anymore', d: { ran: 'dom' }},
+  }, 'Should be able to merge complex objects');
+
+  obj1.abc = 'abc';
+
+  // Two objects with property in common, as object on source.
+  assert.deepEqual(merge(obj1, obj2), {
+    a: 'not a anymore',
+    abc: { c: 'not c anymore', d: { ran: 'dom' }}
+  }, 'Should be able to merge complex objects');
+
+  obj1.abc = { a: 'obja', b: 'objb' };
+  obj2.abc = 'str';
+
+  // Two objects with property in common, as object on target. Source should always take precedence.
+  assert.deepEqual(merge(obj1, obj2), {
+    a: 'not a anymore',
+    abc: 'str'
+  }, 'Should be able to merge complex objects');
+
+  obj1 = {
+    1: '1',
+    abc: { a: 'a', b: 'b' }
+  };
+  obj2 = {
+    2: '2',
+    abc: { a: 'a2', c: 'c' }
+  };
+  let obj3 = {
+    3: '3',
+    abc: { c: 'c3', d: { d: 'd' }},
+    33: {
+      3: 3
+    }
+  };
+
+  // Three complex objects.
+  assert.deepEqual(merge(obj1, obj2, obj3), {
+    1: '1', 2: '2', 3: '3', 33: { 3: 3 },
+    abc: { a: 'a2', b: 'b', c: 'c3', d: { d: 'd' }}
+  }, 'Should be able to merge complex objects, an unlimited amount of them.');
+
+  let obj4 = {
+    33: {
+      4: false
+    }
+  };
+  delete obj2.abc; // This removes the reference.
+  obj1.abc.a = 'a'; // Remember that it merges on the target.
+
+  // Four complex objects, not all of them have the object prop.
+  assert.deepEqual(merge(obj1, obj2, obj3, obj4), {
+    1: '1', 2: '2', 3: '3', 33: { 3: 3, 4: false },
+    abc: { a: 'a', b: 'b', c: 'c3', d: { d: 'd' }}
+  }, 'Should be able to merge complex objects, an unlimited amount of them.');
+  assert.deepEqual(obj1, {
+    1: '1', 2: '2', 3: '3', 33: { 3: 3, 4: false },
+    abc: { a: 'a', b: 'b', c: 'c3', d: { d: 'd' }}
+  }, 'Always modifying the target.');
+
+  obj2.abc = undefined; // We should avoid undefined values.
+
+  // Four complex objects, all of them have the object prop but one instead of object, undefined.
+  assert.deepEqual(merge(obj1, obj2, obj3, obj4), {
+    1: '1', 2: '2', 3: '3', 33: { 3: 3, 4: false },
+    abc: { a: 'a', b: 'b', c: 'c3', d: { d: 'd' }}
+  }, 'Should be able to merge complex objects, an unlimited amount of them and still filter undefined props.');
+
+  res1 = {};
+  assert.ok(merge(res1, obj1) === res1, 'Always returns the modified target.');
+  assert.deepEqual(res1, obj1, 'If target is an empty object, it will be a clone of the source on that one.');
+
+  assert.end();
+});

--- a/src/utils/__tests__/lang/index.spec.js
+++ b/src/utils/__tests__/lang/index.spec.js
@@ -3,6 +3,7 @@ import {
   startsWith,
   endsWith,
   get,
+  findIndex,
   merge,
   uniq,
   groupBy
@@ -38,9 +39,57 @@ tape('LANG UTILS / endsWith', function(assert) {
   assert.end();
 });
 
-// tape('LANG UTILS / get', function(assert) {
+tape('LANG UTILS / get', function(assert) {
+  const obj = {
+    simple: 'simple',
+    undef: undefined,
+    deepProp: {
+      sample: 'sample',
+      deeperProp: {
+        deeper: true
+      }
+    }
+  };
 
-// });
+  // negative
+  assert.equal(get(obj, 'not_exists', 'default'), 'default', 'If the property path does not match a property of the source, return the default value.');
+  assert.equal(get(obj, 'undef', 'default'), 'default', 'If the property is found but the value is undefined, return the default value.');
+  assert.equal(get(obj, 'undef.crap', 'default'), 'default', 'If the property path is incorrect and could cause an error, return the default value.');
+  assert.equal(get(obj, null, 'default'), 'default', 'If the property path is of wrong type, return the default value.');
+  assert.equal(get(obj, /regex/, 'default'), 'default', 'If the property path is of wrong type, return the default value.');
+  assert.equal(get(null, 'simple', 'default'), 'default', 'If the source is of wrong type, return the default value.');
+  assert.equal(get(/regex/, 'simple', 'default'), 'default', 'If the source is of wrong type, return the default value.');
+
+  // positive
+  assert.equal(get(obj, 'simple', 'default'), 'simple', 'If the property path (regardless of how "deep") matches a defined property of the object, returns that value instead of default.');
+  assert.equal(get(obj, 'deepProp.sample', 'default'), 'sample', 'If the property path (regardless of how "deep") matches a defined property of the object, returns that value instead of default.');
+  assert.equal(get(obj, 'deepProp.deeperProp.deeper', 'default'), true, 'If the property path (regardless of how "deep") matches a defined property of the object, returns that value instead of default.');
+  assert.deepEqual(get(obj, 'deepProp.deeperProp', 'default'), {
+    deeper: true
+  }, 'If the property path (regardless of how "deep") matches a defined property of the object, returns that value (regardless of the type) instead of default.');
+
+  assert.end();
+});
+
+tape('LANG UTILS / findIndex', function(assert) {
+  const arr = [1,2,3,4,3];
+
+  assert.equal(findIndex(), -1, 'If the parameters for findIndex are wrong it returns -1.');
+  assert.equal(findIndex(null, () => {}), -1, 'If the parameters for findIndex are wrong it returns -1.');
+  assert.equal(findIndex({}, () => {}), -1, 'If the parameters for findIndex are wrong it returns -1.');
+  assert.equal(findIndex({}, false), -1, 'If the parameters for findIndex are wrong it returns -1.');
+
+  assert.equal(findIndex(arr, () => false), -1, 'If no element causes iteratee to return truthy, it returns -1.');
+  assert.equal(findIndex(arr, e => e === 5), -1, 'If no element causes iteratee to return truthy, it returns -1.');
+
+  assert.equal(findIndex(arr, e => e === 1), 0, 'It should return the index of the first element that causes iteratee to return truthy.');
+  assert.equal(findIndex(arr, e => e === 2), 1, 'It should return the index of the first element that causes iteratee to return truthy.');
+  assert.equal(findIndex(arr, e => e === 3), 2, 'It should return the index of the first element that causes iteratee to return truthy.');
+
+  /* Not testing the params received by iteratee because we know that Array.prototype.findIndex works ok */
+
+  assert.end();
+});
 
 tape('LANG UTILS / merge', function(assert) {
   let obj1 = {};

--- a/src/utils/__tests__/lang/index.spec.js
+++ b/src/utils/__tests__/lang/index.spec.js
@@ -1,5 +1,46 @@
 import tape from 'tape-catch';
-import { merge, uniq, groupBy } from '../../lang';
+import {
+  startsWith,
+  endsWith,
+  get,
+  merge,
+  uniq,
+  groupBy
+} from '../../lang';
+
+tape('LANG UTILS / startsWith', function(assert) {
+  assert.ok(startsWith('myStr', 'myS'));
+  assert.ok(startsWith('this is something', 'this is'));
+
+  assert.notOk(startsWith('myStr', 'yS'));
+  assert.notOk(startsWith(' myStr', 'yS'));
+  assert.notOk(startsWith('myStr', ' yS'));
+  assert.notOk(startsWith('myStr', null));
+  assert.notOk(startsWith(false, null));
+  assert.notOk(startsWith());
+  assert.notOk(startsWith(null, 'ys'));
+
+  assert.end();
+});
+
+tape('LANG UTILS / endsWith', function(assert) {
+  assert.ok(endsWith('myStr', 'Str'));
+  assert.ok(endsWith('is a str', ' str'));
+
+  assert.notOk(endsWith('myStr', 'Sr'));
+  assert.notOk(endsWith('myStr ', 'tr'));
+  assert.notOk(endsWith('myStr', 'tr '));
+  assert.notOk(endsWith('myStr', null));
+  assert.notOk(endsWith(false, null));
+  assert.notOk(endsWith());
+  assert.notOk(endsWith(null, 'ys'));
+
+  assert.end();
+});
+
+// tape('LANG UTILS / get', function(assert) {
+
+// });
 
 tape('LANG UTILS / merge', function(assert) {
   let obj1 = {};

--- a/src/utils/__tests__/lang/index.spec.js
+++ b/src/utils/__tests__/lang/index.spec.js
@@ -1,5 +1,5 @@
 import tape from 'tape-catch';
-import { merge } from '../../lang';
+import { merge, uniq } from '../../lang';
 
 tape('LANG UTILS / merge', function(assert) {
   let obj1 = {};
@@ -122,6 +122,15 @@ tape('LANG UTILS / merge', function(assert) {
   res1 = {};
   assert.ok(merge(res1, obj1) === res1, 'Always returns the modified target.');
   assert.deepEqual(res1, obj1, 'If target is an empty object, it will be a clone of the source on that one.');
+
+  assert.end();
+});
+
+tape('LANG UTILS / uniq', function(assert) {
+  assert.deepEqual(uniq(['1', '2', '1', '3', '3', '4', '3']), ['1', '2', '3', '4'], 'uniq should remove all duplicate strings from array.');
+  assert.deepEqual(uniq(['2', '2']), ['2'], 'uniq should remove all duplicate strings from array.');
+  assert.deepEqual(uniq(['2', '3']), ['2', '3'], 'uniq should remove all duplicate strings from array.');
+  assert.deepEqual(uniq(['3', '2', '3']), ['3', '2'], 'uniq should remove all duplicate strings from array.');
 
   assert.end();
 });

--- a/src/utils/__tests__/lang/index.spec.js
+++ b/src/utils/__tests__/lang/index.spec.js
@@ -13,6 +13,7 @@ import {
   uniq,
   toString,
   toNumber,
+  forOwn,
   groupBy
 } from '../../lang';
 
@@ -346,6 +347,18 @@ tape('LANG UTILS / toNumber', function(assert) {
   assert.equal(toNumber(null), 0, 'The returned number (if it can be converted) should be correct');
   assert.equal(toNumber(15), 15, 'The returned number (if it can be converted) should be correct');
   assert.equal(toNumber(''), 0, 'The returned number (if it can be converted) should be correct');
+
+  assert.end();
+});
+
+tape('LANG UTILS / forOwn', function(assert) {
+  const spy = sinon.spy();
+  const obj = { myKey: 'myVal', myOtherKey: 'myOtherVal' };
+
+  forOwn(obj, spy);
+  assert.ok(spy.calledTwice, 'The iteratee should be called as many times as elements we have on the object.');
+  assert.ok(spy.firstCall.calledWithExactly('myVal', 'myKey', obj), 'When iterating on an object the iteratee should be called with (val, key, collection)');
+  assert.ok(spy.secondCall.calledWithExactly('myOtherVal', 'myOtherKey', obj), 'When iterating on an object the iteratee should be called with (val, key, collection)');
 
   assert.end();
 });

--- a/src/utils/__tests__/settings/index.spec.js
+++ b/src/utils/__tests__/settings/index.spec.js
@@ -52,7 +52,8 @@ tape('SETTINGS / key and traffic type should be overwritable', assert => {
     ...settings,
     core: {
       ...settings.core,
-      key: 'second_key'
+      key: 'second_key',
+      trafficType: undefined
     }
   }, settings2, 'Of course, the new instance should match with the origin settings on every property but the overriden key.');
 

--- a/src/utils/key/factory.js
+++ b/src/utils/key/factory.js
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **/
-import isObject from 'lodash/isObject';
+import { isObject } from '../lang';
 import sanatize from './sanatize';
 
 /**

--- a/src/utils/key/logError.js
+++ b/src/utils/key/logError.js
@@ -13,8 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **/
-import { isObject } from '../lang';
-import { isFinite } from '../lang';
+import { isObject, isFinite } from '../lang';
 import sanatize from './sanatize';
 import logFactory from '../logger';
 const log = logFactory('splitio-client');

--- a/src/utils/key/logError.js
+++ b/src/utils/key/logError.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **/
 import isObject from 'lodash/isObject';
-import isFinite from 'lodash/isFinite';
+import { isFinite } from '../lang';
 import sanatize from './sanatize';
 import logFactory from '../logger';
 const log = logFactory('splitio-client');

--- a/src/utils/key/logError.js
+++ b/src/utils/key/logError.js
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **/
-import isObject from 'lodash/isObject';
+import { isObject } from '../lang';
 import { isFinite } from '../lang';
 import sanatize from './sanatize';
 import logFactory from '../logger';

--- a/src/utils/key/parser.js
+++ b/src/utils/key/parser.js
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **/
-import isObject from 'lodash/isObject';
+import { isObject } from '../lang';
 import sanatize from './sanatize';
 
 /**
@@ -25,7 +25,7 @@ export default (key) => {
     // If we've received an object, we will sanatizes the value of each property
     const keyObject = {
       matchingKey: sanatize(key.matchingKey),
-      bucketingKey: sanatize(key.bucketingKey)      
+      bucketingKey: sanatize(key.bucketingKey)
     };
 
     // and if they've resulted on a invalid type of key we will return false
@@ -37,7 +37,7 @@ export default (key) => {
   }
 
   const sanatizedKey = sanatize(key);
-  
+
   // sanatize would return false if the key is invalid
   if (sanatizedKey !== false) {
     return {

--- a/src/utils/key/sanatize.js
+++ b/src/utils/key/sanatize.js
@@ -13,8 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **/
-import isString from 'lodash/isString';
-import isFinite from 'lodash/isFinite';
+import { isString } from '../../utils/lang';
+import { isFinite } from '../lang';
 import toString from 'lodash/toString';
 
 function sanatizeKey(key) {
@@ -23,6 +23,6 @@ function sanatizeKey(key) {
   }
 
   return false;
-} 
+}
 
 export default sanatizeKey;

--- a/src/utils/key/sanatize.js
+++ b/src/utils/key/sanatize.js
@@ -13,9 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **/
-import { isString } from '../../utils/lang';
-import { isFinite } from '../lang';
-import toString from 'lodash/toString';
+import { isFinite, toString, isString } from '../lang';
 
 function sanatizeKey(key) {
   if (isString(key) || isFinite(key)) {

--- a/src/utils/lang/index.js
+++ b/src/utils/lang/index.js
@@ -178,6 +178,9 @@ export function toNumber(val) {
   return +val;
 }
 
+/**
+ * Executes iteratee for given obj own props.
+ */
 export function forOwn(obj, iteratee) {
   const keys = Object.keys(obj);
 
@@ -186,6 +189,9 @@ export function forOwn(obj, iteratee) {
   return obj;
 }
 
+/**
+ * Parses an array into a map of different arrays, grouping by the specified prop value.
+ */
 export function groupBy(source, prop) {
   const map = {};
 

--- a/src/utils/lang/index.js
+++ b/src/utils/lang/index.js
@@ -30,16 +30,20 @@ export function get(obj, prop, val) {
     let partial = obj;
     pathPieces.forEach(pathPiece => partial = partial[pathPiece]);
 
-    res = partial;
+    if (typeof partial !== 'undefined') res = partial;
   } catch (e) {
     // noop
   }
   return res;
 }
 
-export function findIndex(target, iteratee) {
-  if (Array.isArray(target) && typeof iteratee === 'function') {
-    return target.findIndex(iteratee);
+/**
+ * Evaluates iteratee for each element of the source array. Returns the index of the first element
+ * for which iteratee returns truthy. If no element is found or there's an issue with the params it returns -1.
+ */
+export function findIndex(source, iteratee) {
+  if (Array.isArray(source) && typeof iteratee === 'function') {
+    return source.findIndex(iteratee);
   }
 
   return -1;

--- a/src/utils/lang/index.js
+++ b/src/utils/lang/index.js
@@ -164,7 +164,7 @@ export function toNumber(val) {
   if (typeof val === 'number') return val;
 
   if (isObject(val) && typeof val.valueOf === 'function') {
-    let valOf = val.valueOf();
+    const valOf = val.valueOf();
     val = isObject(valOf) ? valOf + '' : valOf;
   }
 

--- a/src/utils/lang/index.js
+++ b/src/utils/lang/index.js
@@ -96,6 +96,9 @@ export function isFinite(val) {
 
 let uniqueIdCounter = -1;
 
+/**
+ * Returns a number to be used as ID, which will be unique.
+ */
 export function uniqueId() {
   return uniqueIdCounter++;
 }

--- a/src/utils/lang/index.js
+++ b/src/utils/lang/index.js
@@ -138,3 +138,22 @@ export function forOwn(obj, iteratee) {
 
   return obj;
 }
+
+export function groupBy(source, prop) {
+  const map = {};
+
+  if (Array.isArray(source) && isString(prop)) {
+    for(let i = 0; i < source.length; i++) {
+      const key = source[i][prop];
+
+      // Skip the element if the key is not a string.
+      if (isString(key)) {
+        if (!map[key]) map[key] = [];
+
+        map[key].push(source[i]);
+      }
+    }
+  }
+
+  return map;
+}

--- a/src/utils/lang/index.js
+++ b/src/utils/lang/index.js
@@ -43,7 +43,7 @@ export function uniqueId() {
 }
 
 export function isObject(obj) {
-  return typeof obj === 'object' && obj.constructor === Object;
+  return obj && typeof obj === 'object' && obj.constructor === Object;
 }
 
 /**
@@ -71,4 +71,11 @@ export function merge(target, source, ...rest) {
   }
 
   return res;
+}
+
+export function uniq(arr) {
+  const seen = {};
+  return Array.filter(arr, function(item) {
+    return seen.hasOwnProperty(item) ? false : seen[item] = true;
+  });
 }

--- a/src/utils/lang/index.js
+++ b/src/utils/lang/index.js
@@ -77,12 +77,21 @@ export function find(source, iteratee) {
   return res;
 }
 
-export function isString(obj) {
-  return typeof obj === 'string' || obj instanceof String;
+/**
+ * Checks if a given value is a string.
+ */
+export function isString(val) {
+  return typeof val === 'string' || val instanceof String;
 }
 
+/**
+ * Checks if a given value is a finite number.
+ */
 export function isFinite(val) {
-  return typeof val == 'number' && Number.isFinite(val);
+  if (typeof val === 'number') return Number.isFinite(val);
+  if (val instanceof Number) return Number.isFinite(val.valueOf());
+
+  return false;
 }
 
 let uniqueIdCounter = -1;

--- a/src/utils/lang/index.js
+++ b/src/utils/lang/index.js
@@ -49,6 +49,12 @@ export function findIndex(source, iteratee) {
   return -1;
 }
 
+/**
+ * Loops through a source collection (an object or an array) running iteratee
+ * against each element. It returns the first element for which iteratee returned
+ * a truthy value and stops the loop.
+ * Iteratee receives three arguments (element, key/index, collection)
+ */
 export function find(source, iteratee) {
   let res;
 

--- a/src/utils/lang/index.js
+++ b/src/utils/lang/index.js
@@ -73,9 +73,21 @@ export function merge(target, source, ...rest) {
   return res;
 }
 
+/**
+ * Removes duplicate items on an array of strings.
+ */
 export function uniq(arr) {
   const seen = {};
   return Array.filter(arr, function(item) {
     return seen.hasOwnProperty(item) ? false : seen[item] = true;
   });
+}
+
+export function toString(val) {
+  if (val == null) return '';
+  if (typeof val === 'string') return val;
+  if (Array.isArray(val)) return val.map(val => isString(val) ? val : '') + '';
+
+  let result = val + '';
+  return (result === '0' && (1 / val) === Number.NEGATIVE_INFINITY) ? '-0' : result;
 }

--- a/src/utils/lang/index.js
+++ b/src/utils/lang/index.js
@@ -144,6 +144,9 @@ export function uniq(arr) {
   });
 }
 
+/**
+ * Transforms a value into it's string representation.
+ */
 export function toString(val) {
   if (val == null) return '';
   if (typeof val === 'string') return val;
@@ -153,6 +156,10 @@ export function toString(val) {
   return (result === '0' && (1 / val) === Number.NEGATIVE_INFINITY) ? '-0' : result;
 }
 
+/**
+ * Transforms a value into a number.
+ * Note: We're not expecting anything fancy here. If we are at some point, add more type checks.
+ */
 export function toNumber(val) {
   if (typeof val === 'number') return val;
 
@@ -164,6 +171,7 @@ export function toNumber(val) {
   if (typeof val !== 'string') {
     return val === 0 ? val : +val;
   }
+
   // Remove trailing whitespaces.
   val = val.replace(/^\s+|\s+$/g, '');
 

--- a/src/utils/lang/index.js
+++ b/src/utils/lang/index.js
@@ -91,3 +91,20 @@ export function toString(val) {
   let result = val + '';
   return (result === '0' && (1 / val) === Number.NEGATIVE_INFINITY) ? '-0' : result;
 }
+
+export function toNumber(val) {
+  if (typeof val === 'number') return val;
+
+  if (isObject(val) && typeof val.valueOf === 'function') {
+    let valOf = val.valueOf();
+    val = isObject(valOf) ? valOf + '' : valOf;
+  }
+
+  if (typeof val !== 'string') {
+    return val === 0 ? val : +val;
+  }
+  // Remove trailing whitespaces.
+  val = val.replace(/^\s+|\s+$/g, '');
+
+  return +val;
+}

--- a/src/utils/lang/index.js
+++ b/src/utils/lang/index.js
@@ -108,3 +108,11 @@ export function toNumber(val) {
 
   return +val;
 }
+
+export function forOwn(obj, iteratee) {
+  const keys = Object.keys(obj);
+
+  keys.forEach(key => iteratee(obj[key], key, obj));
+
+  return obj;
+}

--- a/src/utils/lang/index.js
+++ b/src/utils/lang/index.js
@@ -1,29 +1,46 @@
+/**
+ * Checks if the target string starts with the sub string.
+ */
 export function startsWith(target, sub) {
+  if (!(isString(target) && isString(sub))) {
+    return false;
+  }
   return target.slice(0, sub.length) === sub;
 }
 
+/**
+ * Checks if the target string ends with the sub string.
+ */
 export function endsWith(target, sub) {
+  if (!(isString(target) && isString(sub))) {
+    return false;
+  }
   return target.slice(target.length - sub.length) === sub;
 }
 
+/**
+ * Safely retrieve the specified prop from obj. If we can't retrieve
+ * that property value, we return the default value.
+ */
 export function get(obj, prop, val) {
   let res = val;
 
-  try {
+  try { // No risks nor lots of checks.
     const pathPieces = prop.split('.');
     let partial = obj;
     pathPieces.forEach(pathPiece => partial = partial[pathPiece]);
 
     res = partial;
   } catch (e) {
-    // noop;
+    // noop
   }
   return res;
 }
 
 export function findIndex(target, iteratee) {
-  if (Array.isArray(target) && typeof iteratee === 'function')
+  if (Array.isArray(target) && typeof iteratee === 'function') {
     return target.findIndex(iteratee);
+  }
 
   return -1;
 }

--- a/src/utils/lang/index.js
+++ b/src/utils/lang/index.js
@@ -28,6 +28,28 @@ export function findIndex(target, iteratee) {
   return -1;
 }
 
+export function find(source, iteratee) {
+  let res;
+
+  if (isObject(source)) {
+    const keys = Object.keys(source);
+    for (let i = 0; i < keys.length && !res; i++) {
+      const key = keys[i];
+      const iterateeResult = iteratee(source[key], key, source);
+
+      if (iterateeResult) res = source[key];
+    }
+  } else if (Array.isArray(source)) {
+    for (let i = 0; i < source.length && !res; i++) {
+      const iterateeResult = iteratee(source[i], i, source);
+
+      if (iterateeResult) res = source[i];
+    }
+  }
+
+  return res;
+}
+
 export function isString(obj) {
   return typeof obj === 'string' || obj instanceof String;
 }

--- a/src/utils/lang/index.js
+++ b/src/utils/lang/index.js
@@ -1,0 +1,74 @@
+export function startsWith(target, sub) {
+  return target.slice(0, sub.length) === sub;
+}
+
+export function endsWith(target, sub) {
+  return target.slice(target.length - sub.length) === sub;
+}
+
+export function get(obj, prop, val) {
+  let res = val;
+
+  try {
+    const pathPieces = prop.split('.');
+    let partial = obj;
+    pathPieces.forEach(pathPiece => partial = partial[pathPiece]);
+
+    res = partial;
+  } catch (e) {
+    // noop;
+  }
+  return res;
+}
+
+export function findIndex(target, iteratee) {
+  if (Array.isArray(target) && typeof iteratee === 'function')
+    return target.findIndex(iteratee);
+
+  return -1;
+}
+
+export function isString(obj) {
+  return typeof obj === 'string' || obj instanceof String;
+}
+
+export function isFinite(val) {
+  return typeof val == 'number' && Number.isFinite(val);
+}
+
+let uniqueIdCounter = -1;
+
+export function uniqueId() {
+  return uniqueIdCounter++;
+}
+
+export function isObject(obj) {
+  return typeof obj === 'object' && obj.constructor === Object;
+}
+
+/**
+ * There are some assumptions here. It's for internal use and we don't need verbose errors
+ * or to ensure the data types or whatever. Parameters should always be correct (at least have a target and a source, of type object).
+ */
+export function merge(target, source, ...rest) {
+  let res = target;
+
+  isObject(source) && Object.keys(source).forEach(key => {
+    let val = source[key];
+
+    if (isObject(val) && res[key] && isObject(res[key])) {
+      val = merge({}, res[key], val);
+    }
+
+    if (val !== undefined) {
+      res[key] = val;
+    }
+  });
+
+  if (rest && rest.length) {
+    const nextSource = rest.splice(0, 1)[0];
+    res = merge(res, nextSource, ...rest);
+  }
+
+  return res;
+}

--- a/src/utils/logger/index.js
+++ b/src/utils/logger/index.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { Logger, LogLevels, setLogLevel } from './LoggerFactory';
 import isLocalStorageAvailable from '../localstorage/isAvailable';
-import find from 'lodash/find';
+import { find } from '../lang';
 
 const isLogLevelString = str => !!find(LogLevels, lvl => str === lvl);
 

--- a/src/utils/manager/validate.js
+++ b/src/utils/manager/validate.js
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **/
-import isString from 'lodash/isString';
+import { isString } from '../../utils/lang';
 import logFactory from '../logger';
 const log = logFactory('splitio-client');
 

--- a/src/utils/settings/index.js
+++ b/src/utils/settings/index.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **/
 
-import merge from 'lodash/merge';
+import { merge } from '../lang';
 import language from './language';
 import { ip, hostname } from './runtime';
 import overridesPerPlatform from './defaults';

--- a/src/utils/settings/runtime/browser.js
+++ b/src/utils/settings/runtime/browser.js
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **/
 
-export const ip = {};
-export const hostname = {};
+export const ip = false;
+export const hostname = false;

--- a/src/utils/timeTracker/index.js
+++ b/src/utils/timeTracker/index.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **/
 
-import uniqueId from 'lodash/uniqueId';
+import { uniqueId } from '../lang';
 import { Logger } from '../logger/LoggerFactory';
 import timer from './timer';
 import thenable from '../promise/thenable';

--- a/src/utils/track/logError.js
+++ b/src/utils/track/logError.js
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **/
-import isString from 'lodash/isString';
+import { isString } from '../../utils/lang';
 import logFactory from '../logger';
 const log = logFactory('splitio-client');
 

--- a/src/utils/track/validate.js
+++ b/src/utils/track/validate.js
@@ -28,14 +28,12 @@ function validateTrackArguments(key, trafficTypeName, eventTypeId, value) {
     return false;
   }
 
-  if (trafficTypeName === null || trafficTypeName === undefined
-    || !isString(trafficTypeName)
-    || (isString(trafficTypeName) && !trafficTypeName.length)) {
+  if (!trafficTypeName || !isString(trafficTypeName)) {
     logError(trafficTypeName, 'traffic_type_name', false);
     return false;
   }
 
-  if (eventTypeId === null || eventTypeId === undefined || !isString(trafficTypeName)) {
+  if (eventTypeId === null || eventTypeId === undefined || !isString(eventTypeId)) {
     logError(eventTypeId, 'event_name');
     return false;
   }

--- a/src/utils/track/validate.js
+++ b/src/utils/track/validate.js
@@ -1,4 +1,4 @@
-import isString from 'lodash/isString';
+import { isString } from '../../utils/lang';
 /**
 Copyright 2016 Split Software
 
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **/
-import isFinite from 'lodash/isFinite';
+import { isFinite } from '../lang';
 import keyParser from '../key/parser';
 import keyLogError from '../key/logError';
 import logError from './logError';
@@ -28,15 +28,15 @@ function validateTrackArguments(key, trafficTypeName, eventTypeId, value) {
     return false;
   }
 
-  if (trafficTypeName === null || trafficTypeName === undefined 
-    || !isString(trafficTypeName) 
+  if (trafficTypeName === null || trafficTypeName === undefined
+    || !isString(trafficTypeName)
     || (isString(trafficTypeName) && !trafficTypeName.length)) {
     logError(trafficTypeName, 'traffic_type_name', false);
     return false;
   }
 
   if (eventTypeId === null || eventTypeId === undefined || !isString(trafficTypeName)) {
-    logError(eventTypeId, 'event_name');    
+    logError(eventTypeId, 'event_name');
     return false;
   }
 


### PR DESCRIPTION
Replaced lodash for ES6 methods and built in utilities.
Some code tweaks here and there.

Regarding minification, after tons of tests and asking devs (from Split and outside Split) for opinion, that should be handled by our customer. There's some documentation that can be written about it, which I still need to figure out the right place for it.

We will continue to iterate on this at future times. But we've already removed 200 raw kbs with it. After minification we're under ~80kb on a customer bundle, of course depending no their setup.
`cjs` build is a little bit heavier because it has some localized polyfills.

