### PR TITLE
[SDKS-263] Caching default client instance.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+## 10.4.1 (XXX X, 2018)
+
+* Bugfixing - Calling factory.client on the browser with the same key used on configuration created a new unnecessary instance.
+
 ## 10.4.0 (Oct 4, 2018)
 
 * Removed dependency for logging library.

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,3 +1,7 @@
+## 10.4.1 (XXX X, 2018)
+
+* Bugfixing - Calling factory.client on the browser with the same key used on configuration created a new unnecessary instance.
+
 ## 10.4.0 (Oct 4, 2018)
 
 * Removed dependency for logging library.

--- a/src/__tests__/browserSuites/shared-instantiation.spec.js
+++ b/src/__tests__/browserSuites/shared-instantiation.spec.js
@@ -19,6 +19,7 @@ export default function(startWithTT, mock, assert) {
   });
   let mainClient = factory.client();
   assert.equal(mainClient, factory.client(), 'If we call factory.client() (no params) more than once, it is just a get of the main client.');
+  assert.equal(mainClient, factory.client('facundo@split.io', startWithTT ? 'start_tt' : undefined), 'If we call factory.client() with params matching what was passed on the configuration, it is just a get of the main client still.');
 
   let nicolasClient = factory.client('nicolas@split.io', 'nico_tt');
   let marcioClient = factory.client('marcio@split.io');


### PR DESCRIPTION
[SDKS-263](https://splitio.atlassian.net/browse/SDKS-263)

On the browser, calling `factory.client()` with the same key and traffic type combination that was provided on the configuration was creating a new instance instead of retrieving the default one.