### PR TITLE
[HOLD] [Bugfixing] Multiple NodeJS instances of the factory increase the timeout schedules exponentially

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,8 +1,9 @@
-## 10.4.1 (XXX X, 2018)
+## 10.4.1 (XXX XX, 2018)
 
 * Added custom impression listener feature.
 * Added Redis support for track events.
 * Bugfixing - Calling factory.client on the browser with the same key used on configuration created a new unnecessary instance.
+* Bugfixing - Fixing multiple instances of the client without specific scheduler configurations cause overflow on timeout values.
 
 ## 10.4.0 (Oct 4, 2018)
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,4 @@
-## 10.4.1 (XXX X, 2018)
+## 10.4.1 (XXX XX, 2018)
 
 * Added custom impression listener feature, so customers can receive all the impressions data on a callback to handle as they place.
   Completely optional, the only requirement is that the element being set as impression listener should have a method called `logImpression`
@@ -6,6 +6,8 @@
 * Added Redis support for track events. Now if you're running the `split-synchronizer` and the Node SDK on `consumer mode`, your track events
   will go to Redis and be sent to Split by the synchronizer.
 * Bugfixing - Calling factory.client on the browser with the same key used on configuration created a new unnecessary instance.
+* Bugfixing - Fixing multiple instances of the client without specific scheduler configurations cause overflow on timeout values,
+  there was an issue with an internal object merge function that was keeping a reference instead of a clone for internal object properties.
 
 ## 10.4.0 (Oct 4, 2018)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.4.1-canary.1",
+  "version": "10.4.1-canary.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.4.1-canary.1",
+  "version": "10.4.1-canary.2",
   "description": "Split SDK",
   "files": [
     "README.md",

--- a/src/__tests__/nodeSuites/events.spec.js
+++ b/src/__tests__/nodeSuites/events.spec.js
@@ -24,7 +24,7 @@ const baseSettings = {
   }
 };
 
-export function withoutBindingTT(mock, assert) {
+export default function trackAssertions(mock, assert) {
   const splitio = SplitFactory(baseSettings);
   const client = splitio.client();
 

--- a/src/utils/__tests__/lang/index.spec.js
+++ b/src/utils/__tests__/lang/index.spec.js
@@ -300,6 +300,28 @@ tape('LANG UTILS / merge', function(assert) {
   assert.ok(merge(res1, obj1) === res1, 'Always returns the modified target.');
   assert.deepEqual(res1, obj1, 'If target is an empty object, it will be a clone of the source on that one.');
 
+  const one = {};
+  const two = {
+    prop: 'val'
+  };
+  const three = {
+    otherProp: 'val',
+    objProp: { innerProp: true, innerObj: { deeperProp: 'test' }}
+  };
+  const four = {
+    prop: 'val4'
+  };
+
+  const returnedObj = merge(one, two, three, four);
+
+  assert.equal(one, returnedObj, 'The target object should be modified.');
+  assert.deepEqual(two, { prop: 'val' }, 'But no other objects sents as source should be modified.');
+  assert.deepEqual(three, { otherProp: 'val', objProp: { innerProp: true, innerObj: { deeperProp: 'test' }}}, 'But no other objects sents as source should be modified.');
+  assert.deepEqual(four, { prop: 'val4' }, 'But no other objects sents as source should be modified.');
+
+  assert.notEqual(returnedObj.objProp, three.objProp, 'Object properties should be clones of the value we had on source, not a reference.');
+  assert.notEqual(returnedObj.objProp.innerObj, three.objProp.innerObj, 'Object properties should be clones of the value we had on source, not a reference.');
+
   assert.end();
 });
 

--- a/src/utils/lang/index.js
+++ b/src/utils/lang/index.js
@@ -121,13 +121,15 @@ export function merge(target, source, ...rest) {
   isObject(source) && Object.keys(source).forEach(key => {
     let val = source[key];
 
-    if (isObject(val) && res[key] && isObject(res[key])) {
-      val = merge({}, res[key], val);
+    if (isObject(val)) {
+      if (res[key] && isObject(res[key])) { // If both are objects, merge into a new one.
+        val = merge({}, res[key], val);
+      } else { // else make a copy.
+        val = merge({}, val);
+      }
     }
-
-    if (val !== undefined) {
-      res[key] = val;
-    }
+    // We skip undefined values.
+    if (val !== undefined) res[key] = val;
   });
 
   if (rest && rest.length) {


### PR DESCRIPTION
There was an issue with an internal object merge function that was keeping a reference instead of a clone for internal object properties.

- [x] Added unit test.
- [x] Running on TApps.