### PR TITLE
Setting IPAddressesEnabled to disable sending IP and machine name to BE. 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+10.9.0 (Oct XX, 2019)
+ - Added setting core.IPAddressesEnabled to disable reporting IP Addresses and Machine name back to Split cloud.
+
 10.8.4 (Sep 24, 2019)
  - Added module "events" as optional dependency.
  - Removed dependency on "util" module.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.8.4",
+  "version": "10.9.0-cannary.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.8.4",
+  "version": "10.9.0-cannary.0",
   "description": "Split SDK",
   "files": [
     "README.md",

--- a/src/__tests__/browser.spec.js
+++ b/src/__tests__/browser.spec.js
@@ -11,6 +11,7 @@ import {
 } from './browserSuites/events.spec';
 import sharedInstantiationSuite from './browserSuites/shared-instantiation.spec';
 import managerSuite from './browserSuites/manager.spec';
+import ignoreIpAddressesSettingSuite from './browserSuites/ignore-ip-addresses-setting.spec';
 
 import { __getAxiosInstance } from '../services/transport';
 import SettingsFactory from '../utils/settings';
@@ -106,6 +107,8 @@ tape('## E2E CI Tests ##', function(assert) {
   assert.test('E2E / Manager API', managerSuite.bind(null, settings, mock));
   /* Validate readiness */
   assert.test('E2E / Readiness', readinessSuite.bind(null, mock));
+  /* Validate headers for ip and hostname are not sended with requests (ignore setting IPAddressesEnabled) */
+  assert.test('E2E / Ignore setting IPAddressesEnabled', ignoreIpAddressesSettingSuite.bind(null, mock));
 
   //If we change the mocks, we need to clear localstorage. Cleaning up after testing ensures "fresh data".
   localStorage.clear();

--- a/src/__tests__/browserSuites/ignore-ip-addresses-setting.spec.js
+++ b/src/__tests__/browserSuites/ignore-ip-addresses-setting.spec.js
@@ -17,6 +17,7 @@ const scheduler = {
 const configWithIPAddressesDisabled = {
   core: {
     authorizationKey: '<fake-token>',
+    key: 'nicolas@split.io',
     IPAddressesEnabled: false
   },
   urls: {
@@ -30,6 +31,7 @@ const configWithIPAddressesDisabled = {
 const configWithIPAddressesEnabled = {
   core: {
     authorizationKey: '<fake-token>',
+    key: 'nicolas@split.io',
     IPAddressesEnabled: true
   },
   urls: {
@@ -42,7 +44,8 @@ const configWithIPAddressesEnabled = {
 // Config with default IPAddressesEnabled (true)
 const configWithIPAddressesDefault = {
   core: {
-    authorizationKey: '<fake-token>'
+    authorizationKey: '<fake-token>',
+    key: 'nicolas@split.io'
   },
   urls: {
     sdk: 'https://sdk.split-ipdefault.io/api',
@@ -106,10 +109,6 @@ export default function(mock, assert) {
       finish.next();
     })();
 
-    // Mock GET endpoints to run client normally
-    mock.onGet(settings.url('/splitChanges?since=-1')).reply(200, splitChangesMock);
-    mock.onGet(new RegExp(`${settings.url('/segmentChanges/')}.*`)).reply(200, {since:10, till:10, name: 'segmentName', added: [], removed: []});
-    
     // Mock and assert POST endpoints
     postEndpoints.forEach( postEndpoint => {
       mock.onPost(settings.url(postEndpoint)).replyOnce(req => {
@@ -120,9 +119,9 @@ export default function(mock, assert) {
     });
     
     // Run normal client flow 
-    client.on(client.Event.SDK_READY, () => {
-      client.getTreatment('nicolas@split.io', 'hierarchical_splits_test');
-      client.track('nicolas@split.io', 'sometraffictype', 'someEvent', 10);
+    client.ready().then(() => {
+      client.getTreatment('hierarchical_splits_test');
+      client.track('sometraffictype', 'someEvent', 10);
     });
   }
 

--- a/src/__tests__/browserSuites/ignore-ip-addresses-setting.spec.js
+++ b/src/__tests__/browserSuites/ignore-ip-addresses-setting.spec.js
@@ -1,6 +1,5 @@
 import { SplitFactory } from '../..';
 import SettingsFactory from '../../utils/settings';
-import splitChangesMock from '../mocks/splitchanges.since.-1.json';
 
 // Header keys and expected values. Expected values are obtained with the runtime function evaluated with IPAddressesEnabled in true.
 const HEADER_SPLITSDKMACHINEIP = 'SplitSDKMachineIP';

--- a/src/__tests__/node.spec.js
+++ b/src/__tests__/node.spec.js
@@ -9,6 +9,7 @@ import metricsSuite from './nodeSuites/metrics.spec';
 import impressionsListenerSuite from './nodeSuites/impressions-listener.spec';
 import expectedTreatmentsSuite from './nodeSuites/expected-treatments.spec';
 import managerSuite from './nodeSuites/manager.spec';
+import ipAddressesSetting from './nodeSuites/ip-addresses-setting.spec';
 
 import { __getAxiosInstance } from '../services/transport';
 
@@ -67,6 +68,9 @@ tape('## Node JS - E2E CI Tests ##', async function (assert) {
 
   /* Manager basic tests */
   assert.test('E2E / Manager basics', managerSuite.bind(null, settings, mock));
+
+  /* Check IP address and Machine name headers when IP address setting is enabled and disabled */
+  assert.test('E2E / IP Addresses Setting', ipAddressesSetting.bind(null, mock));
 
   assert.end();
 });

--- a/src/__tests__/nodeSuites/ip-addresses-setting.spec.js
+++ b/src/__tests__/nodeSuites/ip-addresses-setting.spec.js
@@ -1,11 +1,13 @@
 import { SplitFactory } from '../../';
 import SettingsFactory from '../../utils/settings';
 import runtime from '../../utils/settings/runtime';
+import splitChangesMock1 from '../mocks/splitchanges.since.-1.json';
 
 // Header keys and expected values. Expected values are obtained with the runtime function evaluated with IPAddressesEnabled in true.
 const HEADER_SPLITSDKMACHINEIP = 'SplitSDKMachineIP';
 const HEADER_SPLITSDKMACHINENAME = 'SplitSDKMachineName';
-const { ip: HEADER_SPLITSDKMACHINEIP_VALUE, hostname: HEADER_SPLITSDKMACHINENAME_VALUE} = runtime(true);
+const { ip: HEADER_SPLITSDKMACHINEIP_VALUE, hostname: HEADER_SPLITSDKMACHINENAME_VALUE } = runtime(true);
+const NA = 'NA';
 
 // Refresh rates are set to 1 second to finish the test quickly. Otherwise, it would finish in 1 minute (60 seconds is the default value)
 const scheduler = {
@@ -52,54 +54,91 @@ const configWithIPAddressesDefault = {
   scheduler
 };
 
+const configSamples = [
+  configWithIPAddressesDisabled,
+  configWithIPAddressesEnabled,
+  configWithIPAddressesDefault
+];
+
+const postEndpoints = [
+  '/events/bulk',
+  '/testImpressions/bulk',
+  '/metrics/times',
+  '/metrics/counters'
+];
+
 export default function ipAddressesSettingAssertions(mock, assert) {
 
+  // Generator to synchronize the call of assert.end() when all Splitio configurations are run.
   const finish = (function*() {
-    const clients = [];
-    let count = 1;
-    do{
-      const currentYield = yield;
-      if(currentYield) {
-        clients.push(currentYield);
-        count--;
-      }else
-        count++;
-    }while(count);
-    clients.forEach(client => client.destroy());
+    const CONFIG_SAMPLES_COUNT = configSamples.length;
+    for (let i = 0; i < CONFIG_SAMPLES_COUNT-1; i++) {
+      yield;
+    }
     assert.end();
   })();
 
-  function assertHeaders(IPAddressesEnabled, req){
-    assert.equal(HEADER_SPLITSDKMACHINEIP in req.headers, IPAddressesEnabled, `Request must include ${HEADER_SPLITSDKMACHINEIP} header if IPAddressesEnabled is true.`);
-    assert.equal(HEADER_SPLITSDKMACHINENAME in req.headers, IPAddressesEnabled, `Request must include ${HEADER_SPLITSDKMACHINENAME} header if IPAddressesEnabled is true.`);
-    if(IPAddressesEnabled){
-      assert.equal(req.headers[HEADER_SPLITSDKMACHINEIP], HEADER_SPLITSDKMACHINEIP_VALUE, `${HEADER_SPLITSDKMACHINEIP} header must be equal to the machine ip.`);
-      assert.equal(req.headers[HEADER_SPLITSDKMACHINENAME], HEADER_SPLITSDKMACHINENAME_VALUE, `${HEADER_SPLITSDKMACHINENAME} header must be equal to the machine name.`);
+  // Assert properties in impressions
+  function assertImpression(IPAddressesEnabled, impression) {
+    assert.equal(impression.ip, IPAddressesEnabled ? HEADER_SPLITSDKMACHINEIP_VALUE : NA, `If IPAddressesEnabled, "ip" property in impressions must be equal to the machine ip, or "${NA}" otherwise.`);
+    assert.equal(impression.hostname, IPAddressesEnabled ? HEADER_SPLITSDKMACHINENAME_VALUE : NA, `If IPAddressesEnabled, "hostname" property in impressions must be equal to the machine hostname, or "${NA}" otherwise.`);
+  }
+
+  // Assert request headers
+  function assertHeaders(IPAddressesEnabled, req) {
+    assert.equal(HEADER_SPLITSDKMACHINEIP in req.headers, IPAddressesEnabled, `Request must ${IPAddressesEnabled ? '' : 'NOT '} include ${HEADER_SPLITSDKMACHINEIP} header if IPAddressesEnabled is ${IPAddressesEnabled}.`);
+    assert.equal(HEADER_SPLITSDKMACHINENAME in req.headers, IPAddressesEnabled, `Request must ${IPAddressesEnabled ? '' : 'NOT '} include ${HEADER_SPLITSDKMACHINENAME} header if IPAddressesEnabled is ${IPAddressesEnabled}.`);
+    if (IPAddressesEnabled) {
+      assert.equal(req.headers[HEADER_SPLITSDKMACHINEIP], HEADER_SPLITSDKMACHINEIP_VALUE, `If present, ${HEADER_SPLITSDKMACHINEIP} header must be equal to the machine ip.`);
+      assert.equal(req.headers[HEADER_SPLITSDKMACHINENAME], HEADER_SPLITSDKMACHINENAME_VALUE, `If present, ${HEADER_SPLITSDKMACHINENAME} header must be equal to the machine name.`);
     }
   }
 
-  function mockAndAssertIPAddressesEnabled(config, endpointToMock, clientAction){
-    finish.next();
+  function mockAndAssertIPAddressesEnabled(config) {
 
+    config.impressionListener = {
+      logImpression: function(impression) {
+        assertImpression( config.core.IPAddressesEnabled === undefined ? true : config.core.IPAddressesEnabled , impression );
+      }
+    };
     const splitio = SplitFactory(config);
     const client = splitio.client();
     const settings = SettingsFactory(config);
-  
-    mock.onPost(settings.url(endpointToMock)).replyOnce(req => {
-      assertHeaders(settings.core.IPAddressesEnabled, req);
-      finish.next(client);
-      return [200];
+
+    // Generator to synchronize the destruction of the client when all the post endpoints where called once.
+    const finishConfig = (function*() {
+      const POST_ENDPOINTS_TO_TEST = postEndpoints.length;
+      for (let i = 0; i < POST_ENDPOINTS_TO_TEST-1; i++) {
+        yield;
+      }
+      client.destroy();
+      finish.next();
+    })();
+
+    // Mock GET endpoints to run client normally
+    mock.onGet(settings.url('/splitChanges?since=-1')).reply(200, splitChangesMock1);
+    mock.onGet(new RegExp(`${settings.url('/segmentChanges/')}.*`)).reply(200, {since:10, till:10, name: 'segmentName', added: [], removed: []});
+    
+    // Mock and assert POST endpoints
+    postEndpoints.forEach( postEndpoint => {
+      mock.onPost(settings.url(postEndpoint)).replyOnce(req => {
+        assertHeaders(settings.core.IPAddressesEnabled, req);
+        finishConfig.next();
+        return [200];
+      });
     });
-  
-    clientAction(client);
+    
+    // Run normal client flow 
+    client.on(client.Event.SDK_READY, () => {
+      client.getTreatment('nicolas@split.io', 'hierarchical_splits_test');
+      client.track('nicolas@split.io', 'sometraffictype', 'someEvent', 10);
+    });
+    
   }
 
-  const endpointToMock = '/events/bulk';
-  const clientAction = client => client.track('nicolas@split.io', 'sometraffictype', 'someEvent', 10);
-
-  mockAndAssertIPAddressesEnabled(configWithIPAddressesEnabled, endpointToMock, clientAction);
-  mockAndAssertIPAddressesEnabled(configWithIPAddressesDisabled, endpointToMock, clientAction);
-  mockAndAssertIPAddressesEnabled(configWithIPAddressesDefault, endpointToMock, clientAction);
+  configSamples.forEach( 
+    configSample => mockAndAssertIPAddressesEnabled(configSample)
+  );
 
 }
   

--- a/src/__tests__/nodeSuites/ip-addresses-setting.spec.js
+++ b/src/__tests__/nodeSuites/ip-addresses-setting.spec.js
@@ -1,0 +1,95 @@
+import { SplitFactory } from '../../';
+import SettingsFactory from '../../utils/settings';
+
+// Header constants
+const HEADER_SPLITSDKMACHINEIP = 'SplitSDKMachineIP';
+const HEADER_SPLITSDKMACHINENAME = 'SplitSDKMachineName';
+
+// Refresh rates are set to 1 second to finish the test quickly. Otherwise, it would finish in 1 minute (60 seconds is the default value)
+const scheduler = {
+  metricsRefreshRate: 1,
+  impressionsRefreshRate: 1,
+  eventsPushRate: 1
+};
+
+// Config with IPAddressesEnabled set to false
+const configWithIPAddressesDisabled = {
+  core: {
+    authorizationKey: '<fake-token>',
+    IPAddressesEnabled: false
+  },
+  urls: {
+    sdk: 'https://sdk.split-ipdisabled.io/api',
+    events: 'https://events.split-ipdisabled.io/api'
+  },
+  scheduler
+};
+
+// Config with IPAddressesEnabled set to true
+const configWithIPAddressesEnabled = {
+  core: {
+    authorizationKey: '<fake-token>',
+    IPAddressesEnabled: true
+  },
+  urls: {
+    sdk: 'https://sdk.split-ipenabled.io/api',
+    events: 'https://events.split-ipenabled.io/api'
+  },
+  scheduler
+};
+
+// Config with default IPAddressesEnabled (true)
+const configWithIPAddressesDefault = {
+  core: {
+    authorizationKey: '<fake-token>'
+  },
+  urls: {
+    sdk: 'https://sdk.split-ipdefault.io/api',
+    events: 'https://events.split-ipdefault.io/api'
+  },
+  scheduler
+};
+
+export default function ipAddressesSettingAssertions(mock, assert) {
+
+  let splitioEnabled = SplitFactory(configWithIPAddressesEnabled);
+  let clientEnabled = splitioEnabled.client();
+  const settingsEnabled = SettingsFactory(configWithIPAddressesEnabled);
+
+  mock.onPost(settingsEnabled.url('/events/bulk')).replyOnce(req => {
+    assert.equal(HEADER_SPLITSDKMACHINEIP in req.headers, true, `Request must include ${HEADER_SPLITSDKMACHINEIP} header.`);
+    assert.equal(HEADER_SPLITSDKMACHINENAME in req.headers, true, `Request must include ${HEADER_SPLITSDKMACHINENAME} header.`);
+    clientEnabled.destroy();
+    return [200];
+  });
+
+  clientEnabled.track('nicolas@split.io', 'sometraffictype', 'someEvent', 10);
+
+  let splitioDisabled = SplitFactory(configWithIPAddressesDisabled);
+  let clientDisabled = splitioDisabled.client();
+  const settingsDisabled = SettingsFactory(configWithIPAddressesDisabled);
+
+  mock.onPost(settingsDisabled.url('/events/bulk')).replyOnce(req => {
+    assert.equal(HEADER_SPLITSDKMACHINEIP in req.headers, false, `Request must not include ${HEADER_SPLITSDKMACHINEIP} header.`);
+    assert.equal(HEADER_SPLITSDKMACHINENAME in req.headers, false, `Request must not include ${HEADER_SPLITSDKMACHINENAME} header.`);
+    clientDisabled.destroy();
+    return [200];
+  });
+
+  clientDisabled.track('nicolas@split.io', 'sometraffictype', 'someEvent', 10);
+
+  let splitioDefault = SplitFactory(configWithIPAddressesDefault);
+  let clientDefault = splitioDefault.client();
+  const settingsDefault = SettingsFactory(configWithIPAddressesDefault);
+
+  mock.onPost(settingsDefault.url('/events/bulk')).replyOnce(req => {
+    assert.equal(HEADER_SPLITSDKMACHINEIP in req.headers, true, `Request must include ${HEADER_SPLITSDKMACHINEIP} header.`);
+    assert.equal(HEADER_SPLITSDKMACHINENAME in req.headers, true, `Request must include ${HEADER_SPLITSDKMACHINENAME} header.`);
+    clientDefault.destroy();
+    assert.end();
+    return [200];
+  });
+
+  clientDefault.track('nicolas@split.io', 'sometraffictype', 'someEvent', 10);
+}
+  

--- a/src/__tests__/nodeSuites/ip-addresses-setting.spec.js
+++ b/src/__tests__/nodeSuites/ip-addresses-setting.spec.js
@@ -1,9 +1,11 @@
 import { SplitFactory } from '../../';
 import SettingsFactory from '../../utils/settings';
+import runtime from '../../utils/settings/runtime';
 
-// Header constants
+// Header keys and expected values. Expected values are obtained with the runtime function evaluated with IPAddressesEnabled in true.
 const HEADER_SPLITSDKMACHINEIP = 'SplitSDKMachineIP';
 const HEADER_SPLITSDKMACHINENAME = 'SplitSDKMachineName';
+const { ip: HEADER_SPLITSDKMACHINEIP_VALUE, hostname: HEADER_SPLITSDKMACHINENAME_VALUE} = runtime(true);
 
 // Refresh rates are set to 1 second to finish the test quickly. Otherwise, it would finish in 1 minute (60 seconds is the default value)
 const scheduler = {
@@ -52,44 +54,52 @@ const configWithIPAddressesDefault = {
 
 export default function ipAddressesSettingAssertions(mock, assert) {
 
-  let splitioEnabled = SplitFactory(configWithIPAddressesEnabled);
-  let clientEnabled = splitioEnabled.client();
-  const settingsEnabled = SettingsFactory(configWithIPAddressesEnabled);
-
-  mock.onPost(settingsEnabled.url('/events/bulk')).replyOnce(req => {
-    assert.equal(HEADER_SPLITSDKMACHINEIP in req.headers, true, `Request must include ${HEADER_SPLITSDKMACHINEIP} header.`);
-    assert.equal(HEADER_SPLITSDKMACHINENAME in req.headers, true, `Request must include ${HEADER_SPLITSDKMACHINENAME} header.`);
-    clientEnabled.destroy();
-    return [200];
-  });
-
-  clientEnabled.track('nicolas@split.io', 'sometraffictype', 'someEvent', 10);
-
-  let splitioDisabled = SplitFactory(configWithIPAddressesDisabled);
-  let clientDisabled = splitioDisabled.client();
-  const settingsDisabled = SettingsFactory(configWithIPAddressesDisabled);
-
-  mock.onPost(settingsDisabled.url('/events/bulk')).replyOnce(req => {
-    assert.equal(HEADER_SPLITSDKMACHINEIP in req.headers, false, `Request must not include ${HEADER_SPLITSDKMACHINEIP} header.`);
-    assert.equal(HEADER_SPLITSDKMACHINENAME in req.headers, false, `Request must not include ${HEADER_SPLITSDKMACHINENAME} header.`);
-    clientDisabled.destroy();
-    return [200];
-  });
-
-  clientDisabled.track('nicolas@split.io', 'sometraffictype', 'someEvent', 10);
-
-  let splitioDefault = SplitFactory(configWithIPAddressesDefault);
-  let clientDefault = splitioDefault.client();
-  const settingsDefault = SettingsFactory(configWithIPAddressesDefault);
-
-  mock.onPost(settingsDefault.url('/events/bulk')).replyOnce(req => {
-    assert.equal(HEADER_SPLITSDKMACHINEIP in req.headers, true, `Request must include ${HEADER_SPLITSDKMACHINEIP} header.`);
-    assert.equal(HEADER_SPLITSDKMACHINENAME in req.headers, true, `Request must include ${HEADER_SPLITSDKMACHINENAME} header.`);
-    clientDefault.destroy();
+  const finish = (function*() {
+    const clients = [];
+    let count = 1;
+    do{
+      const currentYield = yield;
+      if(currentYield) {
+        clients.push(currentYield);
+        count--;
+      }else
+        count++;
+    }while(count);
+    clients.forEach(client => client.destroy());
     assert.end();
-    return [200];
-  });
+  })();
 
-  clientDefault.track('nicolas@split.io', 'sometraffictype', 'someEvent', 10);
+  function assertHeaders(IPAddressesEnabled, req){
+    assert.equal(HEADER_SPLITSDKMACHINEIP in req.headers, IPAddressesEnabled, `Request must include ${HEADER_SPLITSDKMACHINEIP} header if IPAddressesEnabled is true.`);
+    assert.equal(HEADER_SPLITSDKMACHINENAME in req.headers, IPAddressesEnabled, `Request must include ${HEADER_SPLITSDKMACHINENAME} header if IPAddressesEnabled is true.`);
+    if(IPAddressesEnabled){
+      assert.equal(req.headers[HEADER_SPLITSDKMACHINEIP], HEADER_SPLITSDKMACHINEIP_VALUE, `${HEADER_SPLITSDKMACHINEIP} header must be equal to the machine ip.`);
+      assert.equal(req.headers[HEADER_SPLITSDKMACHINENAME], HEADER_SPLITSDKMACHINENAME_VALUE, `${HEADER_SPLITSDKMACHINENAME} header must be equal to the machine name.`);
+    }
+  }
+
+  function mockAndAssertIPAddressesEnabled(config, endpointToMock, clientAction){
+    finish.next();
+
+    const splitio = SplitFactory(config);
+    const client = splitio.client();
+    const settings = SettingsFactory(config);
+  
+    mock.onPost(settings.url(endpointToMock)).replyOnce(req => {
+      assertHeaders(settings.core.IPAddressesEnabled, req);
+      finish.next(client);
+      return [200];
+    });
+  
+    clientAction(client);
+  }
+
+  const endpointToMock = '/events/bulk';
+  const clientAction = client => client.track('nicolas@split.io', 'sometraffictype', 'someEvent', 10);
+
+  mockAndAssertIPAddressesEnabled(configWithIPAddressesEnabled, endpointToMock, clientAction);
+  mockAndAssertIPAddressesEnabled(configWithIPAddressesDisabled, endpointToMock, clientAction);
+  mockAndAssertIPAddressesEnabled(configWithIPAddressesDefault, endpointToMock, clientAction);
+
 }
   

--- a/src/__tests__/node_redis.spec.js
+++ b/src/__tests__/node_redis.spec.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-console */
 
+import osFunction from 'os';
+import ipFunction from 'ip';
 import tape from 'tape';
 import sinon from 'sinon';
 import RedisServer from 'redis-server';
@@ -9,9 +11,9 @@ import { SplitFactory } from '../';
 import { merge } from '../utils/lang';
 import KeyBuilder from '../storage/Keys';
 import SettingsFactory from '../utils/settings';
-import runtime from '../utils/settings/runtime';
 
-const { ip, hostname } = runtime(true);
+const IP_VALUE = ipFunction.address();
+const HOSTNAME_VALUE = osFunction.hostname();
 const NA = 'NA';
 
 const redisPort = '6385';
@@ -239,15 +241,15 @@ tape('NodeJS Redis', function (t) {
           let redisImpressions = await connection.lrange(eventKey, 0, -1);
           assert.equal(redisImpressions.length, 1, 'After getting a treatment, we should have one impression on Redis.');
           const parsedImpression = JSON.parse(redisImpressions[0]);
-          assert.equal(parsedImpression.m.i, setting.core.IPAddressesEnabled? ip : NA, `If IPAddressesEnabled is true, the property .m.i of the impression object must be equal to the machine ip, or "${NA}" otherwise.`);
-          assert.equal(parsedImpression.m.n, setting.core.IPAddressesEnabled? hostname : NA, `If IPAddressesEnabled is true, the property .m.n of the impression object must be equal to the machine hostname, or "${NA}" otherwise.`);
+          assert.equal(parsedImpression.m.i, setting.core.IPAddressesEnabled? IP_VALUE : NA, `If IPAddressesEnabled is true, the property .m.i of the impression object must be equal to the machine ip, or "${NA}" otherwise.`);
+          assert.equal(parsedImpression.m.n, setting.core.IPAddressesEnabled? HOSTNAME_VALUE : NA, `If IPAddressesEnabled is true, the property .m.n of the impression object must be equal to the machine hostname, or "${NA}" otherwise.`);
 
           // Assert if the event object was stored properly
           let redisEvents = await connection.lrange(eventKey, 0, -1);
           assert.equal(redisEvents.length, 1, 'After tracking an event, we should have one event on Redis.');
           const parsedEvent = JSON.parse(redisEvents[0]);
-          assert.equal(parsedEvent.m.i, setting.core.IPAddressesEnabled? ip : NA, `If IPAddressesEnabled is true, the property .m.i of the event object must be equal to the machine ip, or "${NA}" otherwise.`);
-          assert.equal(parsedEvent.m.n, setting.core.IPAddressesEnabled? hostname : NA, `If IPAddressesEnabled is true, the property .m.n of the event object must be equal to the machine hostname, or "${NA}" otherwise.`);
+          assert.equal(parsedEvent.m.i, setting.core.IPAddressesEnabled? IP_VALUE : NA, `If IPAddressesEnabled is true, the property .m.i of the event object must be equal to the machine ip, or "${NA}" otherwise.`);
+          assert.equal(parsedEvent.m.n, setting.core.IPAddressesEnabled? HOSTNAME_VALUE : NA, `If IPAddressesEnabled is true, the property .m.n of the event object must be equal to the machine hostname, or "${NA}" otherwise.`);
 
           // Deallocate Split and Redis clients
           await client.destroy();

--- a/src/__tests__/node_redis.spec.js
+++ b/src/__tests__/node_redis.spec.js
@@ -3,8 +3,16 @@
 import tape from 'tape';
 import sinon from 'sinon';
 import RedisServer from 'redis-server';
+import RedisClient from 'ioredis';
 import { exec } from 'child_process';
 import { SplitFactory } from '../';
+import { merge } from '../utils/lang';
+import KeyBuilder from '../storage/Keys';
+import SettingsFactory from '../utils/settings';
+import runtime from '../utils/settings/runtime';
+
+const { ip, hostname } = runtime(true);
+const NA = 'NA';
 
 const redisPort = '6385';
 
@@ -193,6 +201,61 @@ tape('NodeJS Redis', function (t) {
           // close server connection and wrap up.
           server.close().then(assert.end);
         }, 2000);
+      });
+  });
+
+  t.test('Check IP and Hostname in Redis', assert => {
+    initializeRedisServer()
+      .then(async (server) => {
+        
+        const configs = [
+          config,
+          merge({ }, config, { core: { IPAddressesEnabled: true } }),
+          merge({ }, config, { core: { IPAddressesEnabled: false } })
+        ];
+
+        for (let config of configs) {
+
+          // Redis client and keys required to check Redis store.
+          const setting = SettingsFactory(config);  
+          const connection = new RedisClient(setting.storage.options.url);
+          const keys = new KeyBuilder(setting);
+          const eventKey = keys.buildEventsKey();
+          const impressionsKey = keys.buildImpressionsKey();
+
+          // Clean up list of events and impressions.
+          connection.del(eventKey);
+          connection.del(impressionsKey);
+
+          // Init Split client for current config
+          const sdk = SplitFactory(config);
+          const client = sdk.client();
+
+          // Perform client actions to store a single event and impression objects into Redis
+          await client.getTreatment('UT_Segment_member', 'UT_IN_SEGMENT');
+          await client.track('nicolas@split.io', 'user', 'test.redis.event', 18);
+
+          // Assert if the impression object was stored properly
+          let redisImpressions = await connection.lrange(eventKey, 0, -1);
+          assert.equal(redisImpressions.length, 1, 'After getting a treatment, we should have one impression on Redis.');
+          const parsedImpression = JSON.parse(redisImpressions[0]);
+          assert.equal(parsedImpression.m.i, setting.core.IPAddressesEnabled? ip : NA, `If IPAddressesEnabled is true, the property .m.i of the impression object must be equal to the machine ip, or "${NA}" otherwise.`);
+          assert.equal(parsedImpression.m.n, setting.core.IPAddressesEnabled? hostname : NA, `If IPAddressesEnabled is true, the property .m.n of the impression object must be equal to the machine hostname, or "${NA}" otherwise.`);
+
+          // Assert if the event object was stored properly
+          let redisEvents = await connection.lrange(eventKey, 0, -1);
+          assert.equal(redisEvents.length, 1, 'After tracking an event, we should have one event on Redis.');
+          const parsedEvent = JSON.parse(redisEvents[0]);
+          assert.equal(parsedEvent.m.i, setting.core.IPAddressesEnabled? ip : NA, `If IPAddressesEnabled is true, the property .m.i of the event object must be equal to the machine ip, or "${NA}" otherwise.`);
+          assert.equal(parsedEvent.m.n, setting.core.IPAddressesEnabled? hostname : NA, `If IPAddressesEnabled is true, the property .m.n of the event object must be equal to the machine hostname, or "${NA}" otherwise.`);
+
+          // Deallocate Split and Redis clients
+          await client.destroy();
+          await connection.quit();
+        }
+
+        // close server connection
+        server.close().then(assert.end);
       });
   });
 });

--- a/src/services/request/index.js
+++ b/src/services/request/index.js
@@ -27,8 +27,11 @@ function RequestFactory(settings, relativeUrl, params) {
   headers['Authorization'] = `Bearer ${token}`;
   headers['SplitSDKVersion'] = version;
 
-  if (ip) headers['SplitSDKMachineIP'] = ip;
-  if (hostname) headers['SplitSDKMachineName'] = hostname;
+  // IP and MachineName headers are sent only if the setting IPAddressesEnabled is true, even if the values are 'unknown'.  
+  if(settings.core.IPAddressesEnabled){
+    headers['SplitSDKMachineIP'] = ip;
+    headers['SplitSDKMachineName'] = hostname;
+  }
 
   return {
     headers,

--- a/src/services/request/index.js
+++ b/src/services/request/index.js
@@ -28,7 +28,7 @@ function RequestFactory(settings, relativeUrl, params) {
   headers['SplitSDKVersion'] = version;
 
   // IP and MachineName headers are sent only if the setting IPAddressesEnabled is true, even if the values are 'unknown'.  
-  if(settings.core.IPAddressesEnabled){
+  if (settings.core.IPAddressesEnabled) {
     headers['SplitSDKMachineIP'] = ip;
     headers['SplitSDKMachineName'] = hostname;
   }

--- a/src/services/request/index.js
+++ b/src/services/request/index.js
@@ -27,11 +27,8 @@ function RequestFactory(settings, relativeUrl, params) {
   headers['Authorization'] = `Bearer ${token}`;
   headers['SplitSDKVersion'] = version;
 
-  // IP and MachineName headers are sent only if the setting IPAddressesEnabled is true, even if the values are 'unknown'.  
-  if (settings.core.IPAddressesEnabled) {
-    headers['SplitSDKMachineIP'] = ip;
-    headers['SplitSDKMachineName'] = hostname;
-  }
+  if (ip) headers['SplitSDKMachineIP'] = ip;
+  if (hostname) headers['SplitSDKMachineName'] = hostname;
 
   return {
     headers,

--- a/src/utils/__tests__/settings/node.spec.js
+++ b/src/utils/__tests__/settings/node.spec.js
@@ -15,8 +15,10 @@ limitations under the License.
 **/
 import tape from 'tape-catch';
 import SettingsFactory from '../../settings';
+import { NA } from '../../constants';
+import runtime from '../../settings/runtime';
 
-tape('SETTINGS / Redis options hould be properly parsed', assert => {
+tape('SETTINGS / Redis options should be properly parsed', assert => {
   const settingsWithUrl = SettingsFactory({
     core: {
       authorizationKey: 'dummy token'
@@ -56,6 +58,32 @@ tape('SETTINGS / Redis options hould be properly parsed', assert => {
   assert.deepEqual(settingsWithoutUrl.storage, {
     type: 'REDIS', prefix: 'test_prefix.SPLITIO', options: { host: 'host', port: 'port', pass: 'pass', db: 'db', connectionTimeout: 33, operationTimeout: 44 }
   }, 'Redis storage settings and options should be passed correctly, url settings takes precedence when we are pointing to Redis.');
+
+  assert.end();
+});
+
+tape('SETTINGS / IPAddressesEnabled should be overwritable and true by default', assert => {
+  const settingsWithIPAddressDisabled = SettingsFactory({
+    core: {
+      authorizationKey: 'dummy token',
+      IPAddressesEnabled: false
+    }
+  });
+  const settingsWithIPAddressEnabled = SettingsFactory({
+    core: {
+      authorizationKey: 'dummy token'
+    }
+  });
+
+  assert.equal(settingsWithIPAddressDisabled.core.IPAddressesEnabled, false, 'When creating a setting instance, it will have the provided value for IPAddressesEnabled');
+  assert.equal(settingsWithIPAddressEnabled.core.IPAddressesEnabled, true, 'and if no IPAddressesEnabled was provided, it will be true.');
+
+  assert.deepEqual({
+    ip: NA,
+    hostname: NA
+  }, settingsWithIPAddressDisabled.runtime, 'When IP address is disabled, the runtime setting properties (ip and hostname) will have a default value of "NA".');
+
+  assert.deepEqual(runtime(), settingsWithIPAddressDisabled.runtime, 'When IP address is enabled, the runtime setting will have the current ip and hostname values.');
 
   assert.end();
 });

--- a/src/utils/__tests__/settings/node.spec.js
+++ b/src/utils/__tests__/settings/node.spec.js
@@ -14,9 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **/
 import tape from 'tape-catch';
+import osFunction from 'os';
+import ipFunction from 'ip';
 import SettingsFactory from '../../settings';
 import { NA } from '../../constants';
-import runtime from '../../settings/runtime';
+import { CONSUMER_MODE } from '../../../../lib/utils/constants';
+
+const IP_VALUE = ipFunction.address();
+const HOSTNAME_VALUE = osFunction.hostname();
 
 tape('SETTINGS / Redis options should be properly parsed', assert => {
   const settingsWithUrl = SettingsFactory({
@@ -74,16 +79,28 @@ tape('SETTINGS / IPAddressesEnabled should be overwritable and true by default',
       authorizationKey: 'dummy token'
     }
   });
+  const settingsWithIPAddressDisabledAndConsumerMode = SettingsFactory({
+    core: {
+      authorizationKey: 'dummy token',
+      IPAddressesEnabled: false
+    },
+    mode: CONSUMER_MODE
+  });
+  const settingsWithIPAddressEnabledAndConsumerMode = SettingsFactory({
+    core: {
+      authorizationKey: 'dummy token'
+    },
+    mode: CONSUMER_MODE
+  });  
 
   assert.equal(settingsWithIPAddressDisabled.core.IPAddressesEnabled, false, 'When creating a setting instance, it will have the provided value for IPAddressesEnabled');
   assert.equal(settingsWithIPAddressEnabled.core.IPAddressesEnabled, true, 'and if no IPAddressesEnabled was provided, it will be true.');
 
-  assert.deepEqual({
-    ip: NA,
-    hostname: NA
-  }, settingsWithIPAddressDisabled.runtime, 'When IP address is disabled, the runtime setting properties (ip and hostname) will have a default value of "NA".');
+  assert.deepEqual({ ip: false, hostname: false }, settingsWithIPAddressDisabled.runtime, 'When IP address is disabled in standalone mode, the runtime setting properties (ip and hostname) have to be false, to avoid be added as request headers.');
+  assert.deepEqual({ ip: NA, hostname: NA }, settingsWithIPAddressDisabledAndConsumerMode.runtime, 'When IP address is disabled in consumer mode, the runtime setting properties (ip and hostname) will have a value of "NA".');
 
-  assert.deepEqual(runtime(), settingsWithIPAddressDisabled.runtime, 'When IP address is enabled, the runtime setting will have the current ip and hostname values.');
+  assert.deepEqual({ ip: IP_VALUE, hostname: HOSTNAME_VALUE }, settingsWithIPAddressEnabled.runtime, 'When IP address is enabled, the runtime setting will have the current ip and hostname values.');
+  assert.deepEqual({ ip: IP_VALUE, hostname: HOSTNAME_VALUE }, settingsWithIPAddressEnabledAndConsumerMode.runtime, 'When IP address is enabled, the runtime setting will have the current ip and hostname values.');
 
   assert.end();
 });

--- a/src/utils/constants/index.js
+++ b/src/utils/constants/index.js
@@ -13,3 +13,6 @@ export const CONTROL_WITH_CONFIG = {
   treatment: CONTROL,
   config: null
 };
+// Constants for unknown and not-applicable values
+export const UNKNOWN = 'unknown';
+export const NA = 'NA';

--- a/src/utils/settings/defaults/node.js
+++ b/src/utils/settings/defaults/node.js
@@ -1,6 +1,6 @@
 export default {
   core: {
-    // Toggle sendind (true) or not sending (false) IP and Host Name with impressions and events.
+    // Default is true.
     IPAddressesEnabled: true
   },
   startup: {

--- a/src/utils/settings/defaults/node.js
+++ b/src/utils/settings/defaults/node.js
@@ -1,4 +1,8 @@
 export default {
+  core: {
+    // Toggle sendind (true) or not sending (false) IP and Host Name with impressions and events.
+    IPAddressesEnabled: true
+  },
   startup: {
     // Stress the request time used while starting up the SDK.
     requestTimeoutBeforeReady: 15,

--- a/src/utils/settings/index.js
+++ b/src/utils/settings/index.js
@@ -123,7 +123,7 @@ function defaults(custom) {
   setupLogger(withDefaults.debug);
 
   // Current ip/hostname information
-  withDefaults.runtime = runtime(withDefaults.core.IPAddressesEnabled);
+  withDefaults.runtime = runtime(withDefaults);
 
   return withDefaults;
 }

--- a/src/utils/settings/index.js
+++ b/src/utils/settings/index.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { merge } from '../lang';
 import language from './language';
-import { ip, hostname } from './runtime';
+import getIpAndHostName from './runtime';
 import overridesPerPlatform from './defaults';
 import storage from './storage';
 import mode from './mode';
@@ -120,6 +120,9 @@ function defaults(custom) {
 
   setupLogger(withDefaults.debug);
 
+  // Current ip/hostname information
+  withDefaults.runtime = getIpAndHostName(withDefaults.core.IPAddressesEnabled);
+
   return withDefaults;
 }
 
@@ -154,12 +157,6 @@ const proto = {
         }
       }
     );
-  },
-
-  // Current ip/hostname information (if available)
-  runtime: {
-    ip,
-    hostname
   }
 };
 

--- a/src/utils/settings/index.js
+++ b/src/utils/settings/index.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { merge } from '../lang';
 import language from './language';
-import getIpAndHostName from './runtime';
+import runtime from './runtime';
 import overridesPerPlatform from './defaults';
 import storage from './storage';
 import mode from './mode';
@@ -38,7 +38,9 @@ const base = {
     // traffic type for the given key (only used on browser version)
     trafficType: undefined,
     // toggle impressions tracking of labels
-    labelsEnabled: true
+    labelsEnabled: true,
+    // toggle sendind (true) or not sending (false) IP and Host Name with impressions, events, and telemetries requests (only used on nodejs version)
+    IPAddressesEnabled: undefined
   },
 
   scheduler: {
@@ -121,7 +123,7 @@ function defaults(custom) {
   setupLogger(withDefaults.debug);
 
   // Current ip/hostname information
-  withDefaults.runtime = getIpAndHostName(withDefaults.core.IPAddressesEnabled);
+  withDefaults.runtime = runtime(withDefaults.core.IPAddressesEnabled);
 
   return withDefaults;
 }

--- a/src/utils/settings/index.js
+++ b/src/utils/settings/index.js
@@ -21,7 +21,7 @@ import overridesPerPlatform from './defaults';
 import storage from './storage';
 import mode from './mode';
 import { API } from '../../utils/logger';
-import { STANDALONE_MODE, STORAGE_MEMORY } from '../../utils/constants';
+import { STANDALONE_MODE, STORAGE_MEMORY, CONSUMER_MODE } from '../../utils/constants';
 import { version } from '../../../package.json';
 
 const eventsEndpointMatcher = /\/(testImpressions|metrics|events)/;
@@ -123,7 +123,7 @@ function defaults(custom) {
   setupLogger(withDefaults.debug);
 
   // Current ip/hostname information
-  withDefaults.runtime = runtime(withDefaults);
+  withDefaults.runtime = runtime(withDefaults.core.IPAddressesEnabled,withDefaults.mode === CONSUMER_MODE);
 
   return withDefaults;
 }

--- a/src/utils/settings/runtime/browser.js
+++ b/src/utils/settings/runtime/browser.js
@@ -14,5 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **/
 
-export const ip = false;
-export const hostname = false;
+export default function() {
+  return {
+    ip: false,
+    hostname: false
+  };
+}

--- a/src/utils/settings/runtime/node.js
+++ b/src/utils/settings/runtime/node.js
@@ -17,23 +17,18 @@ limitations under the License.
 import osFunction from 'os';
 import ipFunction from 'ip';
 
-import { UNKNOWN, NA, CONSUMER_MODE } from '../../constants';
+import { UNKNOWN, NA } from '../../constants';
 
-export default function(settings) {
-  if (settings.core.IPAddressesEnabled) {
-    let ip = ipFunction.address();
-    let hostname = osFunction.hostname();
-    // IPAddressesEnabled && CONSUMER_MODE: return valid ip or 'unknown'
-    if (settings.mode === CONSUMER_MODE) {
-      return { ip: ip || UNKNOWN, hostname: hostname || UNKNOWN };
-    }
-    // IPAddressesEnabled && !CONSUMER_MODE: return valid ip or undefined (falsy)
-    return { ip, hostname };
+export default function(isIPAddressesEnabled, isConsumerMode) {
+  // If the values are not available, default to false (for standalone) or "unknown" (for consumer mode, to be used on Redis keys)
+  let ip = ipFunction.address() || (isConsumerMode ? UNKNOWN : false);
+  let hostname = osFunction.hostname() || (isConsumerMode ? UNKNOWN : false);
+  
+  if (!isIPAddressesEnabled) { // If IPAddresses setting is not enabled, set as false (for standalone) or "NA" (for consumer mode, to  be used on Redis keys)
+    ip = hostname = isConsumerMode ? NA : false;
   }
-  // !IPAddressesEnabled && CONSUMER_MODE: return 'NA'
-  if (settings.mode === CONSUMER_MODE) {
-    return { ip: NA, hostname: NA };
-  }
-  // !IPAddressesEnabled && !CONSUMER_MODE: return false
-  return { ip: false, hostname: false };
+  
+  return {
+    ip, hostname
+  };
 }

--- a/src/utils/settings/runtime/node.js
+++ b/src/utils/settings/runtime/node.js
@@ -20,7 +20,7 @@ import ipFunction from 'ip';
 import { UNKNOWN, NA } from '../../constants';
 
 export default function(IPAddressesEnabled) {
-  if(IPAddressesEnabled) {
+  if (IPAddressesEnabled) {
     return {
       ip: ipFunction.address() || UNKNOWN,
       hostname: osFunction.hostname() || UNKNOWN

--- a/src/utils/settings/runtime/node.js
+++ b/src/utils/settings/runtime/node.js
@@ -17,17 +17,23 @@ limitations under the License.
 import osFunction from 'os';
 import ipFunction from 'ip';
 
-import { UNKNOWN, NA } from '../../constants';
+import { UNKNOWN, NA, CONSUMER_MODE } from '../../constants';
 
-export default function(IPAddressesEnabled) {
-  if (IPAddressesEnabled) {
-    return {
-      ip: ipFunction.address() || UNKNOWN,
-      hostname: osFunction.hostname() || UNKNOWN
-    };
+export default function(settings) {
+  if (settings.core.IPAddressesEnabled) {
+    let ip = ipFunction.address();
+    let hostname = osFunction.hostname();
+    // IPAddressesEnabled && CONSUMER_MODE: return valid ip or 'unknown'
+    if (settings.mode === CONSUMER_MODE) {
+      return { ip: ip || UNKNOWN, hostname: hostname || UNKNOWN };
+    }
+    // IPAddressesEnabled && !CONSUMER_MODE: return valid ip or undefined (falsy)
+    return { ip, hostname };
   }
-  return {
-    ip: NA,
-    hostname: NA
-  };
+  // !IPAddressesEnabled && CONSUMER_MODE: return 'NA'
+  if (settings.mode === CONSUMER_MODE) {
+    return { ip: NA, hostname: NA };
+  }
+  // !IPAddressesEnabled && !CONSUMER_MODE: return false
+  return { ip: false, hostname: false };
 }

--- a/src/utils/settings/runtime/node.js
+++ b/src/utils/settings/runtime/node.js
@@ -17,5 +17,17 @@ limitations under the License.
 import osFunction from 'os';
 import ipFunction from 'ip';
 
-export const ip = ipFunction.address();
-export const hostname = osFunction.hostname();
+import { UNKNOWN, NA } from '../../constants';
+
+export default function(IPAddressesEnabled) {
+  if(IPAddressesEnabled) {
+    return {
+      ip: ipFunction.address() || UNKNOWN,
+      hostname: osFunction.hostname() || UNKNOWN
+    };
+  }
+  return {
+    ip: NA,
+    hostname: NA
+  };
+}

--- a/ts-tests/index.ts
+++ b/ts-tests/index.ts
@@ -166,6 +166,7 @@ AsyncSDK = SplitFactory(asyncSettings);
 const instantiatedSettingsCore: {
   authorizationKey: string,
   key: SplitIO.SplitKey,
+  trafficType: string,
   labelsEnabled: boolean
 } = SDK.settings.core;
 const instantiatedSettingsMode: ('standalone' | 'consumer') = SDK.settings.mode;
@@ -413,7 +414,8 @@ fullBrowserSettings.storage.type = 'MEMORY';
 let fullNodeSettings: SplitIO.INodeSettings = {
   core: {
     authorizationKey: 'asd',
-    labelsEnabled: false
+    labelsEnabled: false,
+    IPAddressesEnabled: false
   },
   scheduler: {
     featuresRefreshRate: 1,
@@ -444,7 +446,8 @@ fullNodeSettings.mode = 'consumer';
 let fullAsyncSettings: SplitIO.INodeAsyncSettings = {
   core: {
     authorizationKey: 'asd',
-    labelsEnabled: false
+    labelsEnabled: false,
+    IPAddressesEnabled: false
   },
   scheduler: {
     featuresRefreshRate: 1,

--- a/ts-tests/index.ts
+++ b/ts-tests/index.ts
@@ -167,7 +167,8 @@ const instantiatedSettingsCore: {
   authorizationKey: string,
   key: SplitIO.SplitKey,
   trafficType: string,
-  labelsEnabled: boolean
+  labelsEnabled: boolean,
+  IPAddressesEnabled: boolean
 } = SDK.settings.core;
 const instantiatedSettingsMode: ('standalone' | 'consumer') = SDK.settings.mode;
 const instantiatedSettingsScheduler: {[key: string]: number} = SDK.settings.scheduler;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,19 +10,19 @@ declare module JsSdk {
   /**
    * Split.io sdk factory function.
    * The settings parameter should be an object that complies with the SplitIO.INodeAsyncSettings.
-   * For more information read the corresponding article: @see {@link http://docs.split.io/docs/nodejs-sdk-overview#section-advanced-configuration-of-the-sdk}
+   * For more information read the corresponding article: @see {@link https://help.split.io/hc/en-us/articles/360020564931-Node-js-SDK#configuration}
    */
   export function SplitFactory(settings: SplitIO.INodeAsyncSettings): SplitIO.IAsyncSDK;
   /**
    * Split.io sdk factory function.
    * The settings parameter should be an object that complies with the SplitIO.INodeSettings.
-   * For more information read the corresponding article: @see {@link http://docs.split.io/docs/nodejs-sdk-overview#section-advanced-configuration-of-the-sdk}
+   * For more information read the corresponding article: @see {@link https://help.split.io/hc/en-us/articles/360020564931-Node-js-SDK#configuration}
    */
   export function SplitFactory(settings: SplitIO.INodeSettings): SplitIO.ISDK;
   /**
    * Split.io sdk factory function.
    * The settings parameter should be an object that complies with the SplitIO.IBrowserSettings.
-   * For more information read the corresponding article: @see {@link http://docs.split.io/docs/javascript-sdk-overview#section-advanced-configuration-of-the-sdk}
+   * For more information read the corresponding article: @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#configuration}
    */
   export function SplitFactory(settings: SplitIO.IBrowserSettings): SplitIO.ISDK;
 }

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -38,7 +38,8 @@ interface ISettings {
     authorizationKey: string,
     key: SplitIO.SplitKey,
     trafficType: string,
-    labelsEnabled: boolean
+    labelsEnabled: boolean,
+    IPAddressesEnabled: boolean
   },
   readonly mode: SDKMode,
   readonly scheduler: {

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -208,7 +208,7 @@ interface INodeBasicSettings extends ISharedSettings {
     eventsQueueSize?: number,
     /**
      * For mocking/testing only. The SDK will refresh the features mocked data when mode is set to "localhost" by defining the key.
-     * For more information @see {@link http://docs.split.io/docs/nodejs-sdk-overview#section-running-the-sdk-in-off-the-grid-mode}
+     * For more information @see {@link https://help.split.io/hc/en-us/articles/360020564931-Node-js-SDK#localhost-mode}
      * @property {number} offlineRefreshRate
      * @default 15
      */
@@ -220,7 +220,7 @@ interface INodeBasicSettings extends ISharedSettings {
    */
   core: {
     /**
-     * Your API key. More information: @see {@link http://docs.split.io/docs/understanding-api-keys}
+     * Your API key. More information: @see {@link https://help.split.io/hc/en-us/articles/360019916211-API-keys}
      * @property {string} authorizationKey
      */
     authorizationKey: string,
@@ -268,7 +268,7 @@ interface INodeBasicSettings extends ISharedSettings {
   mode?: SDKMode,
   /**
    * Mocked features file path. For testing purposses only. For using this you should specify "localhost" as authorizationKey on core settings.
-   * @see {@link http://docs.split.io/docs/nodejs-sdk-overview#section-running-the-sdk-in-off-the-grid-mode}
+   * @see {@link https://help.split.io/hc/en-us/articles/360020564931-Node-js-SDK#localhost-mode}
    * @property {MockedFeaturesFilePath} features
    * @default $HOME/.split
    */
@@ -520,7 +520,7 @@ declare namespace SplitIO {
    * Synchronous storage valid types for NodeJS.
    * @typedef {string} NodeSyncStorage
    */
-  type NodeSyncStorage = 'MEMORY' | 'LOCALSTORAGE';
+  type NodeSyncStorage = 'MEMORY';
   /**
    * Asynchronous storages valid types for NodeJS.
    * @typedef {string} NodeAsyncStorage
@@ -535,7 +535,7 @@ declare namespace SplitIO {
    * Impression listener interface. This is the interface that needs to be implemented
    * by the element you provide to the SDK as impression listener.
    * @interface IImpressionListener
-   * @see {@link https://docs.split.io/docs/nodejs-sdk-overview#section-listener}
+   * @see {@link https://help.split.io/hc/en-us/articles/360020564931-Node-js-SDK#listener}
    */
   interface IImpressionListener {
     logImpression(data: SplitIO.ImpressionData): void
@@ -544,7 +544,7 @@ declare namespace SplitIO {
    * Settings interface for SDK instances created on the browser
    * @interface IBrowserSettings
    * @extends ISharedSettings
-   * @see {@link http://docs.split.io/docs/javascript-sdk-overview#section-advanced-configuration-of-the-sdk}
+   * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#configuration}
    */
   interface IBrowserSettings extends ISharedSettings {
     /**
@@ -623,7 +623,7 @@ declare namespace SplitIO {
       eventsQueueSize?: number,
       /**
        * For mocking/testing only. The SDK will refresh the features mocked data when mode is set to "localhost" by defining the key.
-       * For more information @see {@link http://docs.split.io/docs/nodejs-sdk-overview#section-running-the-sdk-in-off-the-grid-mode}
+       * For more information @see {@link https://help.split.io/hc/en-us/articles/360020564931-Node-js-SDK#localhost-mode}
        * @property {number} offlineRefreshRate
        * @default 15
        */
@@ -635,17 +635,17 @@ declare namespace SplitIO {
      */
     core: {
       /**
-       * Your API key. More information: @see {@link http://docs.split.io/docs/understanding-api-keys}
+       * Your API key. More information: @see {@link https://help.split.io/hc/en-us/articles/360019916211-API-keys}
        * @property {string} authorizationKey
        */
       authorizationKey: string,
       /**
-       * Customer identifier. Whatever this means to you. @see {@link http://docs.split.io/docs/selecting-the-traffic-type}
+       * Customer identifier. Whatever this means to you. @see {@link https://help.split.io/hc/en-us/articles/360019916311-Traffic-type}
        * @property {SplitKey} key
        */
       key: SplitKey,
       /**
-       * Traffic type associated with the customer identifier. @see {@link http://docs.split.io/docs/selecting-the-traffic-type}
+       * Traffic type associated with the customer identifier. @see {@link https://help.split.io/hc/en-us/articles/360019916311-Traffic-type}
        * If no provided as a setting it will be required on the client.track() calls.
        * @property {string} trafficType
        */
@@ -659,7 +659,7 @@ declare namespace SplitIO {
     },
     /**
      * Mocked features map. For testing purposses only. For using this you should specify "localhost" as authorizationKey on core settings.
-     * @see {@link http://docs.split.io/docs/javascript-sdk-overview#section-running-the-sdk-in-off-the-grid-mode}
+     * @see {@link https://help.split.io/hc/en-us/articles/360020564931-Node-js-SDK#localhost-mode}
      */
     features?: MockedFeaturesMap,
     /**
@@ -686,7 +686,7 @@ declare namespace SplitIO {
    * If your storage is asynchronous (Redis for example) use SplitIO.INodeAsyncSettings instead.
    * @interface INodeSettings
    * @extends INodeBasicSettings
-   * @see {@link http://docs.split.io/docs/nodejs-sdk-overview#section-advanced-configuration-of-the-sdk}
+   * @see {@link https://help.split.io/hc/en-us/articles/360020564931-Node-js-SDK#configuration}
    */
   interface INodeSettings extends INodeBasicSettings {
     /**
@@ -713,7 +713,7 @@ declare namespace SplitIO {
    * If your storage is synchronous (by defaut we use memory, which is sync) use SplitIO.INodeSyncSettings instead.
    * @interface INodeAsyncSettings
    * @extends INodeBasicSettings
-   * @see {@link http://docs.split.io/docs/nodejs-sdk-overview#section-advanced-configuration-of-the-sdk}
+   * @see {@link https://help.split.io/hc/en-us/articles/360020564931-Node-js-SDK#configuration}
    */
   interface INodeAsyncSettings extends INodeBasicSettings {
     storage: {

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -229,6 +229,12 @@ interface INodeBasicSettings extends ISharedSettings {
      * @default true
      */
     labelsEnabled?: boolean
+    /**
+     * Disable machine IP and Name from being sent to Split backend.
+     * @property {boolean} IPAddressesEnabled
+     * @default true
+     */
+    IPAddressesEnabled?: boolean
   },
   /**
    * Defines which kind of storage we should instanciate.


### PR DESCRIPTION
- Setting IPAddressesEnabled only for Nodejs. True by default.
- Setting value used as condition for sending headers 'SplitSDKMachineIP' with IP address, and 'SplitSDKMachineName' with machine name.