### PR TITLE
Implementation and E2E tests of BrowserListener with Beacon API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ deploy:
     acl: public_read
     cache_control: "max-age=31536000, public"
     on:
-      branch: beacon-api
+      branch: development
   - provider: s3
     access_key_id: ${AWS_ACCESS_KEY_ID_PROD}
     secret_access_key: ${AWS_SECRET_ACCESS_PROD}

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ deploy:
     acl: public_read
     cache_control: "max-age=31536000, public"
     on:
-      branch: development
+      branch: beacon-api
   - provider: s3
     access_key_id: ${AWS_ACCESS_KEY_ID_PROD}
     secret_access_key: ${AWS_SECRET_ACCESS_PROD}

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,4 @@
 10.9.0 (Oct XX, 2019)
- - Fetch multiple splits at once on getTreatments/getTreatmentsWithConfig.
  - Added listener for 'unload' DOM events to push remaining impressions and events when the browser page is closed or reloaded. 
  - Added setting core.IPAddressesEnabled to disable reporting IP Addresses and Machine name back to Split cloud.
  - Updated Redis storage to fetch multiple splits at once for getTreatments/getTreatmentsWithConfig.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,6 @@
 10.9.0 (Oct XX, 2019)
+ - Fetch multiple splits at once on getTreatments/getTreatmentsWithConfig.
+ - Added listener for 'unload' DOM events to push remaining impressions and events when the browser page is closed or reloaded. 
  - Added setting core.IPAddressesEnabled to disable reporting IP Addresses and Machine name back to Split cloud.
  - Updated Redis storage to fetch multiple splits at once for getTreatments/getTreatmentsWithConfig.
  - Updated most dependencies to their latest versions. Biggest change is babel (from 6 to 7), Webpack 3 to 4, Karma and ioredis.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.9.0-canary.14",
+  "version": "10.9.0-canary.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.9.0-canary.14",
+  "version": "10.9.0-canary.15",
   "description": "Split SDK",
   "files": [
     "README.md",

--- a/src/__tests__/browser.spec.js
+++ b/src/__tests__/browser.spec.js
@@ -12,6 +12,7 @@ import {
 import sharedInstantiationSuite from './browserSuites/shared-instantiation.spec';
 import managerSuite from './browserSuites/manager.spec';
 import ignoreIpAddressesSettingSuite from './browserSuites/ignore-ip-addresses-setting.spec';
+import useBeaconApiSuite from './browserSuites/use-beacon-api.spec';
 
 import { __getAxiosInstance } from '../services/transport';
 import SettingsFactory from '../utils/settings';
@@ -109,6 +110,8 @@ tape('## E2E CI Tests ##', function(assert) {
   assert.test('E2E / Readiness', readinessSuite.bind(null, mock));
   /* Validate headers for ip and hostname are not sended with requests (ignore setting IPAddressesEnabled) */
   assert.test('E2E / Ignore setting IPAddressesEnabled', ignoreIpAddressesSettingSuite.bind(null, mock));
+  /* Check that impressions and events are sended to backend via Beacon API or XHR when page unload is triggered. */
+  assert.test('E2E / Use Beacon API (or XHR if not available) to send remaining impressions and events when browser page is unload', useBeaconApiSuite.bind(null, mock));
 
   //If we change the mocks, we need to clear localstorage. Cleaning up after testing ensures "fresh data".
   localStorage.clear();

--- a/src/__tests__/browserSuites/use-beacon-api.spec.js
+++ b/src/__tests__/browserSuites/use-beacon-api.spec.js
@@ -1,0 +1,129 @@
+import sinon from 'sinon';
+import { SplitFactory } from '../../';
+import SettingsFactory from '../../utils/settings';
+import splitChangesMock1 from '../mocks/splitchanges.since.-1.json';
+import mySegmentsFacundo from '../mocks/mysegments.facundo@split.io.json';
+
+const config = {
+  core: {
+    authorizationKey: '...',
+    key: 'facundo@split.io'
+  },
+  urls: {
+    sdk: 'https://sdk.baseurl',
+    events: 'https://sdk.baseurl'
+  }
+};
+
+const settings = SettingsFactory(config);
+
+// util method to trigger 'unload' event
+function triggerUnloadEvent() {
+  const event = document.createEvent('HTMLEvents');
+  event.initEvent('unload', true, true);
+  event.eventName = 'unload';
+  window.dispatchEvent(event);
+}
+
+const assertImpressionSent = (assert, impression) => {
+  assert.equal(impression.testName, 'hierarchical_splits_test', 'Present impression should have the correct split name.');
+  assert.equal(impression.keyImpressions[0].keyName, 'facundo@split.io', 'Present impression should have the correct key.');
+  assert.equal(impression.keyImpressions[0].label, 'expected label', 'Present impression should have the correct label.');
+  assert.equal(impression.keyImpressions[0].treatment, 'on', 'Present impression should have the correct treatment.');
+};
+
+const assertEventSent = (assert, event) => {
+  assert.equal(event.key, 'facundo@split.io', 'Key should match received value.');
+  assert.equal(event.eventTypeId, 'someEvent', 'EventTypeId should match received value.');
+  assert.equal(event.trafficTypeName, 'sometraffictype', 'TrafficTypeName should match the binded value.');
+};
+
+const assertCallsToBeaconAPI = (assert, sendBeaconSpy) => {
+  const impressionsCallArgs = sendBeaconSpy.firstCall.args;
+  assert.equal(impressionsCallArgs[0], settings.url('/testImpressions/beacon'), 'assert correct url');
+  let parsedPayload = JSON.parse(impressionsCallArgs[1]);
+  assert.equal(parsedPayload.token, '...', 'assert correct payload token');
+  assert.equal(parsedPayload.sdk, settings.version, 'assert correct sdk version');
+  assertImpressionSent(assert, parsedPayload.entries[0]);
+
+  const eventsCallArgs = sendBeaconSpy.secondCall.args;
+  assert.equal(eventsCallArgs[0], settings.url('/events/beacon'), 'assert correct url');
+  parsedPayload = JSON.parse(eventsCallArgs[1]);
+  assert.equal(parsedPayload.token, '...', 'assert correct payload token');
+  assert.equal(parsedPayload.sdk, settings.version, 'assert correct sdk version');
+  assertEventSent(assert, parsedPayload.entries[0]);
+};
+
+// This E2E test checks that impressions and events are sent to backend via Beacon API when page unload is triggered.
+function beaconApiTest(mock, assert) {
+
+  // Mocking this specific route to make sure we only get the items we want to test from the handlers.
+  mock.onGet(settings.url('/splitChanges?since=-1')).reply(200, splitChangesMock1);
+  mock.onGet(settings.url('/mySegments/facundo@split.io')).reply(200, mySegmentsFacundo);
+
+  // Spy calls to Beacon API
+  const sendBeaconSpy = sinon.spy(window.navigator,'sendBeacon');
+
+  // Init and run Split client
+  const splitio = SplitFactory(config);
+  const client = splitio.client();
+  client.on(client.Event.SDK_READY, () => {
+    client.getTreatment('hierarchical_splits_test');
+    client.track('sometraffictype', 'someEvent', 10);
+
+    // trigger unload event inmmediatly, before scheduled push of events and impressions
+    triggerUnloadEvent();
+
+    // queue the assertion of the Beacon requests, destruction of client and execution of the second E2E test named assertFallbacl
+    setTimeout(() => {
+      
+      assertCallsToBeaconAPI(assert, sendBeaconSpy);
+      client.destroy().then(()=>{
+        fallbackTest(mock,assert);
+      });
+    }, 0);
+  });
+}
+
+// This E2E test checks that impressions and events are sent to backend via Axios when page unload is triggered and Beacon API is not available.
+function fallbackTest(mock, assert) {
+
+  // destroy reference to Beacon API
+  window.navigator.sendBeacon = null;
+
+  const splitio = SplitFactory(config);
+  const client = splitio.client();
+
+  // synchronize client destruction when both endpoints ('/testImpressions/bulk' and '/events/bulk') are called
+  const finish = (function*() {
+    yield;
+    client.destroy().then(function(){
+      assert.end();
+    });
+  })();
+  
+  // Mock endpoints used by Axios
+  mock.onPost(settings.url('/testImpressions/bulk')).replyOnce(req => {
+    const resp = JSON.parse(req.data);
+    assert.ok(req, 'Fallback to /testImpressions/bulk');
+    assertImpressionSent(assert,resp[0]);
+    finish.next();
+    return [200];
+  });
+  mock.onPost(settings.url('/events/bulk')).replyOnce(req => {
+    const resp = JSON.parse(req.data);
+    assert.ok(req, 'Fallback to /events/bulk');
+    assertEventSent(assert,resp[0]);
+    finish.next();
+    return [200];
+  });
+
+  client.on(client.Event.SDK_READY, () => {
+    client.getTreatment('hierarchical_splits_test');
+    client.track('sometraffictype', 'someEvent', 10);
+    // trigger unload event inmmediatly, before scheduled push of events and impressions
+    triggerUnloadEvent();
+  });
+}
+
+export default beaconApiTest;

--- a/src/__tests__/browserSuites/use-beacon-api.spec.js
+++ b/src/__tests__/browserSuites/use-beacon-api.spec.js
@@ -39,6 +39,7 @@ const assertEventSent = (assert, event) => {
 };
 
 const assertCallsToBeaconAPI = (assert, sendBeaconSpy) => {
+  // The first call is for flushing impressions
   const impressionsCallArgs = sendBeaconSpy.firstCall.args;
   assert.equal(impressionsCallArgs[0], settings.url('/testImpressions/beacon'), 'assert correct url');
   let parsedPayload = JSON.parse(impressionsCallArgs[1]);
@@ -46,6 +47,7 @@ const assertCallsToBeaconAPI = (assert, sendBeaconSpy) => {
   assert.equal(parsedPayload.sdk, settings.version, 'assert correct sdk version');
   assertImpressionSent(assert, parsedPayload.entries[0]);
 
+  // The second call is for flushing events
   const eventsCallArgs = sendBeaconSpy.secondCall.args;
   assert.equal(eventsCallArgs[0], settings.url('/events/beacon'), 'assert correct url');
   parsedPayload = JSON.parse(eventsCallArgs[1]);

--- a/src/listeners/__tests__/browser.spec.js
+++ b/src/listeners/__tests__/browser.spec.js
@@ -1,0 +1,46 @@
+import tape from 'tape-catch';
+import sinon from 'sinon';
+import Context from '../../utils/context';
+import StorageFactory from '../../storage';
+import SettingsFactory from '../../utils/settings';
+import BrowserSignalListener from '../browser';
+
+const UNLOAD_DOM_EVENT = 'unload';
+
+const windowAddEventListenerSpy = sinon.spy();
+const windowRemoveEventListenerSpy = sinon.spy();
+
+sinon.stub(window, 'addEventListener').callsFake(windowAddEventListenerSpy);
+sinon.stub(window, 'removeEventListener').callsFake(windowRemoveEventListenerSpy);
+
+const createFakeContext = function() {
+  const config = {};
+  const context = new Context();
+
+  const settings = SettingsFactory(config);
+  context.put(context.constants.SETTINGS, settings);
+
+  const storage = StorageFactory(context);
+  context.put(context.constants.STORAGE, storage);
+  return context;
+};
+
+tape('Browser JS / Browser listener class constructor, start and stop methods', function (assert) {
+  const listener = new BrowserSignalListener(createFakeContext());
+
+  listener.start();
+
+  // Assigned right function to right signal.
+  assert.ok(windowAddEventListenerSpy.calledOnce);
+  assert.ok(windowAddEventListenerSpy.calledOnceWithExactly(UNLOAD_DOM_EVENT, listener.flushData));
+
+  // pre-check and call stop
+  assert.ok(windowRemoveEventListenerSpy.notCalled);
+  listener.stop();
+
+  // removed correct listener from correct signal on stop.
+  assert.ok(windowRemoveEventListenerSpy.calledOnce);
+  assert.ok(windowRemoveEventListenerSpy.calledOnceWithExactly(UNLOAD_DOM_EVENT, listener.flushData));
+
+  assert.end();
+});

--- a/src/listeners/__tests__/browser.spec.js
+++ b/src/listeners/__tests__/browser.spec.js
@@ -1,32 +1,99 @@
 import tape from 'tape-catch';
 import sinon from 'sinon';
-import Context from '../../utils/context';
-import StorageFactory from '../../storage';
-import SettingsFactory from '../../utils/settings';
 import BrowserSignalListener from '../browser';
 
 const UNLOAD_DOM_EVENT = 'unload';
 
-const windowAddEventListenerSpy = sinon.spy();
-const windowRemoveEventListenerSpy = sinon.spy();
+const windowAddEventListenerSpy = sinon.spy(window, 'addEventListener');
+const windowRemoveEventListenerSpy = sinon.spy(window, 'removeEventListener');
+const sendBeaconSpy = sinon.spy(window.navigator, 'sendBeacon');
 
-sinon.stub(window, 'addEventListener').callsFake(windowAddEventListenerSpy);
-sinon.stub(window, 'removeEventListener').callsFake(windowRemoveEventListenerSpy);
+/* Mocks start */
+const generateContextMocks = () => {
+  // We are only mocking the pieces we care about
+  const fakeImpression = {
+    feature: 'splitName',
+    keyName: 'facundo@split.io',
+    treatment: 'off',
+    time: Date.now(),
+    bucketingKey: null,
+    label: null,
+    changeNumber: null
+  };
+  const fakeEvent = {
+    eventTypeId: 'someEvent',
+    trafficTypeName: 'sometraffictype',
+    value: null,
+    timestamp: null,
+    key: 'facundo@split.io',
+    properties: null
+  };
+  const fakeSettings = {
+    url: sinon.stub(),
+    core: {
+      labelsEnabled: true
+    }
+  };
+  const fakeStorage = {
+    impressions: {
+      isEmpty: sinon.stub(),
+      clear: sinon.stub(),
+      queue: [fakeImpression],
+      state() {
+        return this.queue;
+      }
+    },
+    events: {
+      isEmpty: sinon.stub(),
+      clear: sinon.stub(),
+      queue: [fakeEvent],
+      toJSON() {
+        return this.queue;
+      }
+    }
+  };
 
-const createFakeContext = function() {
-  const config = {};
-  const context = new Context();
-
-  const settings = SettingsFactory(config);
-  context.put(context.constants.SETTINGS, settings);
-
-  const storage = StorageFactory(context);
-  context.put(context.constants.STORAGE, storage);
-  return context;
+  return {
+    fakeSettings, fakeStorage
+  };
 };
 
+class ContextMock {
+  constructor(fakeStorage, fakeSettings) {
+    this.constants = {
+      STORAGE: 'storage',
+      SETTINGS: 'settings'
+    };
+
+    this.fakeStorage = fakeStorage;
+    this.fakeSettings = fakeSettings;
+  }
+
+  get(target) {
+    switch (target) {
+      case 'storage':
+        return this.fakeStorage;
+      case 'settings':
+        return this.fakeSettings;
+      default:
+        break;
+    }
+  }
+}
+/* Mocks end */
+
+function triggerUnloadEvent() {
+  const event = document.createEvent('HTMLEvents');
+  event.initEvent('unload', true, true);
+  event.eventName = 'unload';
+  window.dispatchEvent(event);
+}
+
 tape('Browser JS / Browser listener class constructor, start and stop methods', function (assert) {
-  const listener = new BrowserSignalListener(createFakeContext());
+  const { fakeStorage, fakeSettings } = generateContextMocks();
+  const contextMock = new ContextMock(fakeStorage, fakeSettings);
+
+  const listener = new BrowserSignalListener(contextMock);
 
   listener.start();
 
@@ -34,13 +101,21 @@ tape('Browser JS / Browser listener class constructor, start and stop methods', 
   assert.ok(windowAddEventListenerSpy.calledOnce);
   assert.ok(windowAddEventListenerSpy.calledOnceWithExactly(UNLOAD_DOM_EVENT, listener.flushData));
 
-  // pre-check and call stop
-  assert.ok(windowRemoveEventListenerSpy.notCalled);
-  listener.stop();
+  triggerUnloadEvent();
 
-  // removed correct listener from correct signal on stop.
-  assert.ok(windowRemoveEventListenerSpy.calledOnce);
-  assert.ok(windowRemoveEventListenerSpy.calledOnceWithExactly(UNLOAD_DOM_EVENT, listener.flushData));
+  setTimeout(() => {
+    // Unload event was triggered. Thus sendBeacon method should have been called twice.
+    assert.equal(sendBeaconSpy.callCount, 2);
 
-  assert.end();
+    // pre-check and call stop
+    assert.ok(windowRemoveEventListenerSpy.notCalled);
+    listener.stop();
+
+    // removed correct listener from correct signal on stop.
+    assert.ok(windowRemoveEventListenerSpy.calledOnce);
+    assert.ok(windowRemoveEventListenerSpy.calledOnceWithExactly(UNLOAD_DOM_EVENT, listener.flushData));
+  
+    assert.end();
+  }, 0);
+
 });

--- a/src/listeners/browser.js
+++ b/src/listeners/browser.js
@@ -3,7 +3,6 @@ import eventsService from '../services/events';
 import impressionsBulkRequest from '../services/impressions/bulk';
 import impressionsService from '../services/impressions';
 import { fromImpressionsCollector } from '../services/impressions/dto';
-import { STORAGE, SETTINGS } from '../utils/context/constants';
 import logFactory from '../utils/logger';
 
 const log = logFactory('splitio-client:cleanup');
@@ -16,10 +15,10 @@ const UNLOAD_DOM_EVENT = 'unload';
  *
  */
 export default class BrowserSignalListener {
-  
+
   constructor(context) {
-    this.storage = context.get(STORAGE);
-    this.settings = context.get(SETTINGS);
+    this.storage = context.get(context.constants.STORAGE);
+    this.settings = context.get(context.constants.SETTINGS);
     this.flushData = this.flushData.bind(this);
   }
 
@@ -27,7 +26,7 @@ export default class BrowserSignalListener {
    * start method. 
    * Called when SplitFactory is initialized. 
    * We add a handler on unload events. The handler flushes remaining impressions and events to the backend.
-   */ 
+   */
   start() {
     log.debug('Registering flush handler when unload page event is triggered.');
     if (window && window.addEventListener) {
@@ -45,7 +44,7 @@ export default class BrowserSignalListener {
     log.debug('Deregistering flush handler when unload page event is triggered.');
     if (window && window.removeEventListener) {
       window.removeEventListener(UNLOAD_DOM_EVENT, this.flushData);
-    } 
+    }
   }
 
   /**
@@ -85,9 +84,9 @@ export default class BrowserSignalListener {
   }
 
   /**
-   * _sendBeacon method. 
+   * _sendBeacon method.
    * Util method that check if beacon API is available, build the payload and send it.
-   */ 
+   */
   _sendBeacon(url, data) {
     if (navigator && navigator.sendBeacon) {
       const payload = JSON.stringify({

--- a/src/listeners/browser.js
+++ b/src/listeners/browser.js
@@ -1,16 +1,87 @@
+import eventsBulkRequest from '../services/events/bulk';
+import eventsService from '../services/events';
+import impressionsBulkRequest from '../services/impressions/bulk';
+import impressionsService from '../services/impressions';
+import { fromImpressionsCollector } from '../services/impressions/dto';
+import { STORAGE, SETTINGS } from '../utils/context/constants';
+import logFactory from '../utils/logger';
+const log = logFactory('splitio-client:cleanup');
+
 /**
- * Not implemented yet.
+ * We'll listen for 'unload' event over the window object, since it's the standard way to listen page reload and close.
+ *
  */
 export default class BrowserSignalListener {
-  constructor() {
-    // noop
+  constructor(context) {
+    this.storage = context.get(STORAGE);
+    this.settings = context.get(SETTINGS);
+    this._flushEventsAndImpressions = this._flushEventsAndImpressions.bind(this);
+    // this._sendBeacon = this._sendBeacon.bind(this); // not need of binding _sendBeacon
   }
 
+  /**
+   * start method. 
+   * Called when SplitFactory is initialized. 
+   * We add a handler on unload events. The handler flushes remaining impressions and events to the backend.
+   */ 
   start() {
-    // noop
+    log.debug('Registering flush handler when unload page event is triggered.');
+    if (window && window.addEventListener) {
+      window.addEventListener('unload', this._flushEventsAndImpressions);
+    }  
   }
 
+
+  /**
+   * stop method. 
+   * Called when client is destroyed. 
+   * We need to remove the handler for unload events, since it can break if called when Split context was destroyed.
+   */ 
   stop() {
-    // noop
+    log.debug('Deregistering flush handler when unload page event is triggered.');
+    if (window && window.addEventListener) {
+      window.removeEventListener('unload', this._flushEventsAndImpressions);
+    } 
+  }
+
+  /**
+   * _flushEventsAndImpressions method. 
+   * Called when unload event is triggered. It flushed remaining impressions and events to the backend, 
+   * using beacon API if possible, or falling back to XHR.
+   */ 
+  _flushEventsAndImpressions() {
+    // if there are impressions in storage, send them to backend
+    if (!this.storage.impressions.isEmpty()) {
+      const url = this.settings.url('/testImpressions/beacon');
+      const impressions = fromImpressionsCollector(this.storage.impressions, this.settings);
+      if (!this._sendBeacon(url, impressions))
+        impressionsService(impressionsBulkRequest(this.settings, { data: JSON.stringify(impressions) }));
+      this.storage.impressions.clear();
+    }
+    
+    // if there are events in storage, send them to backend
+    if (!this.storage.events.isEmpty()) {
+      const url = this.settings.url('/events/beacon');
+      const events = this.storage.events.toJSON();
+      if (!this._sendBeacon(url, events))
+        eventsService(eventsBulkRequest(this.settings, { data: JSON.stringify(events) }));
+      this.storage.events.clear();
+    }
+  }
+
+  /**
+   * _sendBeacon method. 
+   * Util method that check if beacon API is available, build the payload and send it.
+   */ 
+  _sendBeacon(url, data) {
+    if (navigator && navigator.sendBeacon) {
+      const payload = JSON.stringify({
+        entries: data,
+        token: this.settings.core.authorizationKey,
+        sdk: this.settings.version
+      });
+      return navigator.sendBeacon(url, payload);
+    }
+    return false;
   }
 }

--- a/src/listeners/browser.js
+++ b/src/listeners/browser.js
@@ -28,8 +28,8 @@ export default class BrowserSignalListener {
    * We add a handler on unload events. The handler flushes remaining impressions and events to the backend.
    */
   start() {
-    log.debug('Registering flush handler when unload page event is triggered.');
     if (window && window.addEventListener) {
+      log.debug('Registering flush handler when unload page event is triggered.');
       window.addEventListener(UNLOAD_DOM_EVENT, this.flushData);
     }  
   }
@@ -41,8 +41,8 @@ export default class BrowserSignalListener {
    * We need to remove the handler for unload events, since it can break if called when Split context was destroyed.
    */ 
   stop() {
-    log.debug('Deregistering flush handler when unload page event is triggered.');
     if (window && window.removeEventListener) {
+      log.debug('Deregistering flush handler when unload page event is triggered.');
       window.removeEventListener(UNLOAD_DOM_EVENT, this.flushData);
     }
   }


### PR DESCRIPTION
# JS SDK

## What did you accomplish?
BrowserListener registers a handler for 'unload' DOM events, in order to flush remaining impressions and events when a page is closed or reload, using Beacon API if available or falling back to Axios (XHR).

## How do we test the changes introduced in this PR?
Three E2E tests were added:
1- Check that sendBeacon is not called when no events are impressions are in cache
2- Check that payloads of beacon requests are well formed
2- Check that HTTP requests are sent using Axios when Beacon API is not available, and also check if their payloads are well formed.

## Extra Notes
Manual testing (opening and closing an HTML page in a browser to trigger an 'unload' event) works well with the new beacon API feature.
Fallback to Axios works well on IE10 