### PR TITLE
Fix #314, Support @types/node@12.11.5

### DIFF
--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -277,9 +277,9 @@ interface INodeBasicSettings extends ISharedSettings {
 /**
  * Common API for entities that expose status handlers.
  * @interface IStatusInterface
- * @extends NodeJS.Events
+ * @extends NodeJS.EventEmitter
  */
-interface IStatusInterface extends NodeJS.Events {
+interface IStatusInterface extends NodeJS.EventEmitter {
   /**
    * Constant object containing the SDK events for you to use.
    * @property {EventConsts} Event


### PR DESCRIPTION
Fix error message `Property 'on' does not exist on type 'IClient'.`

The latest node typings doesnt have NodeJS.Events anymore, it is now NodeJS.EventEmitter