### PR TITLE
return expire result to avoid unhandled promise rejection race condition

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+10.9.2 (Nov 19, 2019)
+ - Bugfixing - When using Redis, return expire result to avoid race condition with redis disconnection due to a client destroy.
+
 10.9.1 (Nov 7, 2019)
  - Bugfixing - Avoid certain keys (containing one of three keywords) on the browser to generate a request to the wrong endpoint.
  - Added SonarQube integration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.9.1",
+  "version": "10.9.2-canary.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.9.1",
+  "version": "10.9.2-canary.0",
   "description": "Split SDK",
   "files": [
     "README.md",

--- a/src/storage/ImpressionsCache/InRedis.js
+++ b/src/storage/ImpressionsCache/InRedis.js
@@ -28,7 +28,7 @@ class ImpressionsCacheInRedis {
     ).then(queuedCount => {
       // If this is the creation of the key on Redis, set the expiration for it in 1hr.
       if (queuedCount === 1) {
-        this.redis.expire(this.keys.buildImpressionsKey(), 3600);
+        return this.redis.expire(this.keys.buildImpressionsKey(), 3600);
       }
     });
   }

--- a/src/storage/ImpressionsCache/InRedis.js
+++ b/src/storage/ImpressionsCache/InRedis.js
@@ -27,7 +27,7 @@ class ImpressionsCacheInRedis {
       this.toJSON(impressions)
     ).then(queuedCount => {
       // If this is the creation of the key on Redis, set the expiration for it in 1hr.
-      if (queuedCount === 1) {
+      if (queuedCount === impressions.length) {
         return this.redis.expire(this.keys.buildImpressionsKey(), 3600);
       }
     });

--- a/src/storage/__tests__/ImpressionsCache/InRedis/node.spec.js
+++ b/src/storage/__tests__/ImpressionsCache/InRedis/node.spec.js
@@ -10,22 +10,23 @@ You may obtain a copy of the License at
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
+See the License for the spe cific language governing permissions and
 limitations under the License.
 **/
-import Redis from 'ioredis';
+import Redis from '../../../RedisAdapter';
 import tape from 'tape-catch';
+import sinon from 'sinon';
 import KeyBuilder from '../../../Keys';
 import ImpressionsCacheInRedis from '../../../ImpressionsCache/InRedis';
 import SettingsFactory from '../../../../utils/settings';
-const settings = SettingsFactory({
-  storage: {
-    type: 'REDIS',
-    prefix: 'ut_impr_cache'
-  }
-});
 
 tape('IMPRESSIONS CACHE IN REDIS / should incrementally store values', async function(assert) {
+  const settings = SettingsFactory({
+    storage: {
+      type: 'REDIS',
+      prefix: 'ut_impr_cache'
+    }
+  });
   const impressionsKey = 'ut_impr_cache.SPLITIO.impressions';
   const testMeta = { thisIsTheMeta: true };
   const connection = new Redis(settings.storage.options);
@@ -78,6 +79,55 @@ tape('IMPRESSIONS CACHE IN REDIS / should incrementally store values', async fun
     i: { k: o3.keyName, f: o3.feature, t: o3.treatment, c: o3.changeNumber, m: o3.time }
   }));
 
-  connection.quit();
+  await connection.del(impressionsKey);
+  await connection.quit();
   assert.end();
+});
+
+tape('IMPRESSIONS CACHE IN REDIS / should not resolve track before calling expire', async function(assert) {
+  const impressionsKey = 'ut_impr_cache_2.SPLITIO.impressions';
+  const settings = SettingsFactory({
+    storage: {
+      type: 'REDIS',
+      prefix: 'ut_impr_cache_2'
+    }
+  });
+  const testMeta = { thisIsTheMeta: true };
+  const redis = new Redis(settings.storage.options);
+  const keys = new KeyBuilder(settings);
+  const c = new ImpressionsCacheInRedis(keys, redis, testMeta);
+
+  const i1 = { feature: 'test4', keyName: 'nicolas@split.io', treatment: 'off', time: Date.now(), changeNumber: 1 };
+  const i2 = { feature: 'test5', keyName: 'matias@split.io', treatment: 'on', time: Date.now(), changeNumber: 2 };
+  
+  const spy1 = sinon.spy(redis, 'rpush');
+  const spy2 = sinon.spy(redis, 'expire');
+  
+  // Crap so we can reproduce the latency as we would have on a remote server.
+  const originalExpire = redis.expire;
+  redis.expire = function patchedForTestRedisExpire() {
+    return new Promise((res, rej) => {
+      setTimeout(() => {
+        originalExpire.apply(redis, arguments).then(res).catch(rej);
+      }, 150); // 150ms of delay on the expire
+    });
+  };
+
+  // cleanup prior to test.
+  await redis.del(impressionsKey);
+  
+  c.track([i1, i2]).then(() => {
+    redis.quit(); // Try to disconnect right away.
+    console.log('####### CALLBACK');
+    assert.ok(spy1.called, 'Redis rpush was called once before executing external callback.');
+    // Following assertion fails if the expire takes place after disconnected and throws unhandledPromiseRejection
+    assert.ok(spy2.called, 'Redis expire was called once before executing external callback.');
+  }).catch(e => {
+    assert.fail(`An error was generated from the redis expire tests: ${e}`);
+  }).then(async () => {
+    // Finally clean up and wrap up.
+    spy1.restore();
+    spy2.restore();
+    assert.end();
+  });
 });

--- a/src/storage/__tests__/ImpressionsCache/InRedis/node.spec.js
+++ b/src/storage/__tests__/ImpressionsCache/InRedis/node.spec.js
@@ -10,7 +10,7 @@ You may obtain a copy of the License at
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the spe cific language governing permissions and
+See the License for the specific language governing permissions and
 limitations under the License.
 **/
 import Redis from '../../../RedisAdapter';
@@ -118,7 +118,6 @@ tape('IMPRESSIONS CACHE IN REDIS / should not resolve track before calling expir
   
   c.track([i1, i2]).then(() => {
     redis.quit(); // Try to disconnect right away.
-    console.log('####### CALLBACK');
     assert.ok(spy1.called, 'Redis rpush was called once before executing external callback.');
     // Following assertion fails if the expire takes place after disconnected and throws unhandledPromiseRejection
     assert.ok(spy2.called, 'Redis expire was called once before executing external callback.');


### PR DESCRIPTION
# JS SDK

## What did you accomplish? fix a bug where unhandled rejection blows up because redis is no longer connected

## How do we test the changes introduced in this PR? run the sample lambda code that anthony sent over the support channel with this installed

## Extra Notes 