### PR TITLE
[DO NOT MERGE] Spike Adding Cloudflare Workers Support

### DIFF
--- a/src/client/inputValidation.js
+++ b/src/client/inputValidation.js
@@ -12,7 +12,7 @@ import {
   validateIfReady
 } from '../utils/inputValidation';
 import { startsWith } from '../utils/lang';
-import { STORAGE_REDIS, CONTROL, CONTROL_WITH_CONFIG } from '../utils/constants';
+import { STORAGE_REDIS, CONTROL, CONTROL_WITH_CONFIG, STORAGE_CLOUDFLARE_KV } from '../utils/constants';
 
 /**
  * We will validate the input before actually executing the client methods. We should "guard" the client here,
@@ -20,7 +20,7 @@ import { STORAGE_REDIS, CONTROL, CONTROL_WITH_CONFIG } from '../utils/constants'
  */
 function ClientInputValidationLayer(context, isKeyBinded, isTTBinded) {
   const settings = context.get(context.constants.SETTINGS);
-  const isStorageSync = settings.storage.type !== STORAGE_REDIS;
+  const isStorageSync = settings.storage.type !== STORAGE_REDIS && settings.storage.type !== STORAGE_CLOUDFLARE_KV;
   // instantiate the client
   const client = ClientFactory(context);
   // Keep a reference to the original methods

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -1,4 +1,4 @@
 {
   "main": "./node.js",
-  "browser": "./browser.js"
+  "browser": "./node.js"
 }

--- a/src/listeners/package.json
+++ b/src/listeners/package.json
@@ -1,4 +1,4 @@
 {
   "main": "./node.js",
-  "browser": "./browser.js"
+  "browser": "./node.js"
 }

--- a/src/producer/offline/package.json
+++ b/src/producer/offline/package.json
@@ -1,4 +1,4 @@
 {
   "main": "./node.js",
-  "browser": "./browser.js"
+  "browser": "./node.js"
 }

--- a/src/producer/package.json
+++ b/src/producer/package.json
@@ -1,4 +1,4 @@
 {
   "main": "./node.js",
-  "browser": "./browser/Full.js"
+  "browser": "./node.js"
 }

--- a/src/services/request/options/package.json
+++ b/src/services/request/options/package.json
@@ -1,4 +1,4 @@
 {
   "main": "node.js",
-  "browser": "browser.js"
+  "browser": "node.js"
 }

--- a/src/services/transport/index.js
+++ b/src/services/transport/index.js
@@ -1,13 +1,37 @@
-import axios from 'axios';
+// import axios from 'axios';
 import { SplitNetworkError } from '../../utils/lang/Errors';
 import logFactory from '../../utils/logger';
 const log = logFactory('splitio-services:service');
 
-const _axiosInstance = axios.create();
+// const _axiosInstance = axios.create();
 
 export default function Fetcher(request) {
-  return _axiosInstance.request(request)
+  let result;
+  // TODO: This will log credentials, we should strip out Authorization header
+  log['debug'](`Fetcher making request: ${JSON.stringify(request)}`)
+  // TODO: This is a pretty lazy map from an axio request to fetch API
+  // we should do this properly and actually test it.
+  return fetch(request.url, request)
+    .then(res => {
+      log['debug'](`Got response: ${JSON.stringify(res)}`)
+      result = res
+      return res.json()
+    })
+    .then(json => {
+      log['debug'](`Got response body: ${JSON.stringify(json)}`);
+      return {
+        status: result.status,
+        statusText: result.statusText,
+        data: json,
+        headers: result.headers,
+        // TODO: Do we need these keys in the response? Axios would have provided them
+        // config
+        // request
+      }
+    })
     .catch(error => {
+      // TODO: When using the fetch API, an error will only be thrown if there are network
+      // problems, we should move this 400x error handling up into the response handler
       const resp = error.response;
       const url = error.config ? error.config.url : 'unknown';
       let msg = '';

--- a/src/storage/ImpressionsCache/InCloudflareKV.js
+++ b/src/storage/ImpressionsCache/InCloudflareKV.js
@@ -1,0 +1,62 @@
+/**
+Copyright 2016 Split Software
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+**/
+
+import logFactory from '../../utils/logger';
+const log = logFactory('splitio-storage:cloudflarekv:impressions');
+
+const ONE_HOUR = 60 * 60
+
+class ImpressionsCacheInCloudflareKV {
+  // TODO: Pass in the key builder
+  constructor(binding, keys) {
+    this._client = binding;
+    this._keys = keys;
+  }
+
+  /**
+   * Store objects in sequential order
+   * @param impressions {Array<{
+   *  feature: string,
+   *  keyName: string
+   *  treatment: string
+   *  time: string // eg. "1582819171342"
+   *  label: string
+   *  changeNumber: number
+   * }>} an array of impressions to track
+   */
+  async track(impressions) {
+    log['debug'](`track(${JSON.stringify(impressions)})`)
+    // TODO: Run in parallel
+    for (var i = 0; i < impressions.length; i++) {
+      const impression = impressions[i];
+      const key = this._keys.buildImpressionsKey(impression);
+      // Give the producer 1 hour to pick this up and push to Split.io
+      await this._client.put(key, JSON.stringify(impression), { expirationTtl: ONE_HOUR })
+    }
+    return true
+  }
+
+  /**
+   * We are returning true because...
+   * Not really sure why but the Redis implementation says to do so.
+   * TODO: Lets try to understand what's going on here better.
+   */
+  isEmpty() {
+    return true;
+  }
+}
+
+export default ImpressionsCacheInCloudflareKV;

--- a/src/storage/KeysCloudflareKV.js
+++ b/src/storage/KeysCloudflareKV.js
@@ -1,0 +1,28 @@
+import KeyBuilder from './Keys';
+
+class KeyBuilderForCloudflareKV extends KeyBuilder {
+  buildImpressionsKey(impression) {
+    const suffix = getRandomString(10)
+    return `${this.settings.storage.prefix}.impressions.${impression.time}.${suffix}`;
+  }
+
+  searchPatternForSplitKeys() {
+    return `${this.settings.storage.prefix}.split.`;
+  }
+}
+
+/**
+ * Generate a random string of the given length
+ * Reference: https://medium.com/@dazcyril/generating-cryptographic-random-state-in-javascript-in-the-browser-c538b3daae50
+ * @param {number} length The length of the random string to generate
+ * @return {string} The random string
+ */
+function getRandomString(length) {
+  const validChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let array = new Uint8Array(length);
+  crypto.getRandomValues(array);
+  array = array.map(x => validChars.charCodeAt(x % validChars.length));
+  return String.fromCharCode.apply(null, array);
+}
+
+export default KeyBuilderForCloudflareKV;

--- a/src/storage/SegmentCache/InCloudflareKV/index.js
+++ b/src/storage/SegmentCache/InCloudflareKV/index.js
@@ -1,0 +1,57 @@
+import logFactory from '../../../utils/logger';
+const log = logFactory('splitio-storage:cloudflarekv:segments');
+
+class SegmentCacheInCloudflareKV {
+
+  constructor(binding) {
+    log['debug'](`new SegmentCacheInCloudflareKV(${binding})`)
+    this._client = binding;
+  }
+
+  async addToSegment(segmentName, segmentKeys) {
+    log['debug'](`addToSegment(${segmentName}, ${JSON.stringify(segmentKeys)})`)
+    return true
+  }
+
+  async removeFromSegment(segmentName, segmentKeys) {
+    log['debug'](`removeFromSegment(${segmentName}, ${JSON.stringify(segmentKeys)})`)
+    return true
+  }
+
+  async isInSegment(segmentName, key) {
+    log['debug'](`isInSegment(${segmentName}, ${key})`)
+    return false
+  }
+
+  async setChangeNumber(segmentName, changeNumber) {
+    log['debug'](`setChangeNumber(${segmentName}, ${changeNumber})`)
+    return true
+  }
+
+  async getChangeNumber(segmentName) {
+    log['debug'](`getChangeNumber(${segmentName})`)
+    return -1;
+  }
+
+  async registerSegment(segment) {
+    log['debug'](`registerSegment(${segment})`)
+    return this.registerSegments(segment);
+  }
+
+  async registerSegments(segments) {
+    log['debug'](`registerSegments(${JSON.stringify(segments)})`)
+    return true;
+  }
+
+  async getRegisteredSegments() {
+    log['debug'](`getRegisteredSegments()`)
+    return [] /* TODO: WTF is the shape of this object? */
+  }
+
+  async flush() {
+    log['debug'](`flush()`)
+    return true
+  }
+}
+
+export default SegmentCacheInCloudflareKV;

--- a/src/storage/SegmentCache/InMemory/package.json
+++ b/src/storage/SegmentCache/InMemory/package.json
@@ -1,4 +1,4 @@
 {
   "main": "./node.js",
-  "browser": "./browser.js"
+  "browser": "./node.js"
 }

--- a/src/storage/SplitCache/InCloudflareKV.js
+++ b/src/storage/SplitCache/InCloudflareKV.js
@@ -1,0 +1,163 @@
+import { isFinite } from '../../utils/lang';
+import usesSegments from '../../utils/splits/usesSegments';
+import logFactory from '../../utils/logger';
+const log = logFactory('splitio-storage:cloudflarekv');
+
+// TODO: This is essentially just a copy of in memory
+// we need to modify this to read / write to Cloudflare KV
+class SplitCacheInCloudflareKV {
+
+  constructor(binding) {
+    log['debug'](`Constructing SplitCacheInCloudflareKV with binding: ${JSON.stringify(binding)}`)
+    // The KV binding that will be used to talk to CloudFlare KV
+    this._client = binding;
+    this.flush();
+  }
+
+  async addSplit(splitName, split) {
+    log['debug'](`addSplit(${splitName}, ${split})`);
+    const splitFromMemory = await this.getSplit(splitName);
+    if (splitFromMemory) { // We had this Split already
+      const previousSplit = JSON.parse(splitFromMemory);
+
+      if (previousSplit.trafficTypeName) {
+        const previousTtName = previousSplit.trafficTypeName;
+        this.ttCache[previousTtName]--;
+        if (!this.ttCache[previousTtName]) delete this.ttCache[previousTtName];
+      }
+
+      if (usesSegments(previousSplit.conditions)) { // Substract from segments count for the previous version of this Split.
+        this.splitsWithSegmentsCount--;
+      }
+    }
+
+    const parsedSplit = JSON.parse(split);
+
+    if (parsedSplit) {
+      // Store the Split.
+      this.splitCache.set(splitName, split);
+      // Update TT cache
+      const ttName = parsedSplit.trafficTypeName;
+      if (ttName) { // safeguard
+        if (!this.ttCache[ttName]) this.ttCache[ttName] = 0;
+        this.ttCache[ttName]++;
+      }
+
+      // Add to segments count for the new version of the Split
+      if (usesSegments(parsedSplit.conditions)) this.splitsWithSegmentsCount++;
+
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  async addSplits(entries) {
+    log['debug'](`addSplits(${entries})`);
+    let results = [];
+
+    for (const [key, value] of entries) {
+      results.push(this.addSplit(key, value));
+    }
+
+    return results;
+  }
+
+  async removeSplit(splitName) {
+    log['debug'](`removeSplit(${splitName})`);
+    const split = await this.getSplit(splitName);
+    if (split) {
+      // Delete the Split
+      this.splitCache.delete(splitName);
+
+      const parsedSplit = JSON.parse(split);
+      const ttName = parsedSplit.trafficTypeName;
+
+      if (ttName) { // safeguard
+        this.ttCache[ttName]--; // Update tt cache
+        if (!this.ttCache[ttName]) delete this.ttCache[ttName];
+      }
+
+      // Update the segments count.
+      if (usesSegments(parsedSplit.conditions)) this.splitsWithSegmentsCount--;
+
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  async removeSplits(splitNames) {
+    log['debug'](`removeSplits(${splitNames})`);
+    splitNames.forEach(n => this.removeSplit(n));
+
+    return splitNames.length;
+  }
+
+  async getSplit(splitName) {
+    log['debug'](`getSplit(${splitName})`);
+    return this.splitCache.get(splitName);
+  }
+
+  async setChangeNumber(changeNumber) {
+    log['debug'](`setChangeNumber(${changeNumber})`);
+    this.changeNumber = changeNumber;
+
+    return true;
+  }
+
+  async getChangeNumber() {
+    log['debug'](`getChangeNumber()`);
+    return this.changeNumber;
+  }
+
+  async getAll() {
+    log['debug'](`getAll()`);
+    return [...this.splitCache.values()];
+  }
+
+  async getKeys() {
+    log['debug'](`getKeys()`);
+    return [...this.splitCache.keys()];
+  }
+
+  async trafficTypeExists(trafficType) {
+    log['debug'](`trafficTypeExists(${trafficType})`);
+    return isFinite(this.ttCache[trafficType]) && this.ttCache[trafficType] > 0;
+  }
+
+  async usesSegments() {
+    log['debug'](`usesSegments()`);
+    return this.getChangeNumber() === -1 || this.splitsWithSegmentsCount > 0;
+  }
+
+  async flush() {
+    log['debug'](`flush()`);
+    this.splitCache = new Map;
+    this.ttCache = {};
+    this.changeNumber = -1;
+    this.splitsWithSegmentsCount = 0;
+  }
+
+  /**
+   * Fetches multiple splits definitions.
+   */
+  async fetchMany(splitNames) {
+    log['debug'](`fetchMany(${splitNames})`);
+    const splits = new Map();
+    splitNames.forEach(splitName => {
+      splits.set(splitName, this.splitCache.get(splitName) || null);
+    });
+    return splits;
+  }
+
+  /**
+   * Check if the splits information is already stored in cache. In memory there is no cache to check.
+   */
+  async checkCache() {
+    log['debug'](`checkCache()`);
+    return false;
+  }
+}
+
+export default SplitCacheInCloudflareKV;

--- a/src/storage/browser.js
+++ b/src/storage/browser.js
@@ -3,12 +3,15 @@ import SplitCacheInLocalStorage from './SplitCache/InLocalStorage';
 import SplitCacheInCloudflareKV from './SplitCache/InCloudflareKV';
 import SegmentCacheInMemory from './SegmentCache/InMemory';
 import SegmentCacheInLocalStorage from './SegmentCache/InLocalStorage';
+import SegmentCacheInCloudflareKV from './SegmentCache/InCloudflareKV';
 import ImpressionsCacheInMemory from './ImpressionsCache/InMemory';
+import ImpressionsCacheInCloudflareKV from './ImpressionsCache/InCloudflareKV';
 import LatencyCacheInMemory from './LatencyCache/InMemory';
 import CountCacheInMemory from './CountCache/InMemory';
 import EventsCacheInMemory from './EventsCache/InMemory';
 import KeyBuilder from './Keys';
 import KeyBuilderLocalStorage from './KeysLocalStorage';
+import KeyBuilderForCloudflareKV from './KeysCloudflareKV';
 import { STORAGE_MEMORY, STORAGE_LOCALSTORAGE, STORAGE_CLOUDFLARE_KV } from '../utils/constants';
 
 const BrowserStorageFactory = context => {
@@ -18,13 +21,13 @@ const BrowserStorageFactory = context => {
   console.log('Selected storage type', storage.type)
   switch (storage.type) {
     case STORAGE_CLOUDFLARE_KV: {
-      const keys = new KeyBuilder(settings);
-
+      const keys = new KeyBuilderForCloudflareKV(settings);
       return {
-        splits: new SplitCacheInCloudflareKV(storage.options.binding),
+        // TODO: Pass keys to all of these storage adapters
+        splits: new SplitCacheInCloudflareKV(storage.options.binding, keys),
+        segments: new SegmentCacheInCloudflareKV(storage.options.binding),
+        impressions: new ImpressionsCacheInCloudflareKV(storage.options.binding, keys),
         // TODO: Replace these in memory implementations with a KV implementation
-        segments: new SegmentCacheInMemory(keys),
-        impressions: new ImpressionsCacheInMemory,
         metrics: new LatencyCacheInMemory,
         count: new CountCacheInMemory,
         events: new EventsCacheInMemory(context),

--- a/src/utils/constants/index.js
+++ b/src/utils/constants/index.js
@@ -7,6 +7,7 @@ export const CONSUMER_MODE = 'consumer';
 export const STORAGE_MEMORY = 'MEMORY';
 export const STORAGE_REDIS = 'REDIS';
 export const STORAGE_LOCALSTORAGE = 'LOCALSTORAGE';
+export const STORAGE_CLOUDFLARE_KV = 'CLOUDFLARE_KV';
 // Special treatments
 export const CONTROL = 'control';
 export const CONTROL_WITH_CONFIG = {

--- a/src/utils/settings/defaults/package.json
+++ b/src/utils/settings/defaults/package.json
@@ -1,4 +1,4 @@
 {
   "main": "./node.js",
-  "browser": "./browser.js"
+  "browser": "./node.js"
 }

--- a/src/utils/settings/language/package.json
+++ b/src/utils/settings/language/package.json
@@ -1,4 +1,4 @@
 {
   "main": "./node.js",
-  "browser": "./browser.js"
+  "browser": "./node.js"
 }

--- a/src/utils/settings/runtime/package.json
+++ b/src/utils/settings/runtime/package.json
@@ -1,4 +1,4 @@
 {
   "main": "./node.js",
-  "browser": "./browser.js"
+  "browser": "./node.js"
 }

--- a/src/utils/settings/storage/browser.js
+++ b/src/utils/settings/storage/browser.js
@@ -20,7 +20,8 @@ import isLocalStorageAvailable from '../../../utils/localstorage/isAvailable';
 import {
   LOCALHOST_MODE,
   STORAGE_MEMORY,
-  STORAGE_LOCALSTORAGE
+  STORAGE_LOCALSTORAGE,
+  STORAGE_CLOUDFLARE_KV
 } from '../../../utils/constants';
 
 const ParseStorageSettings = settings => {
@@ -46,8 +47,8 @@ const ParseStorageSettings = settings => {
 
   // If an invalid storage type is provided OR we want to use LOCALSTORAGE and
   // it's not available, fallback into MEMORY
-  if (type !== STORAGE_MEMORY && type !== STORAGE_LOCALSTORAGE ||
-      type === STORAGE_LOCALSTORAGE && !isLocalStorageAvailable()) {
+  if (type !== STORAGE_MEMORY && type !== STORAGE_LOCALSTORAGE && type !== STORAGE_CLOUDFLARE_KV ||
+    type === STORAGE_LOCALSTORAGE && !isLocalStorageAvailable()) {
     type = STORAGE_MEMORY;
     log.warn('Invalid or unavailable storage. Fallbacking into MEMORY storage');
   }


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

In an ideal world, we would like to run Split in [consumer mode](https://help.split.io/hc/en-us/articles/360020564931-Node-js-SDK#consumer-mode) on [Cloudflare Workers](https://developers.cloudflare.com/workers/). This is a dirty spike to understand what changes would be required.

## How do we test the changes introduced in this PR?

Don't! This is throwaway code.

## Extra Notes

The difficulty of running Split on a CloudFlare worker is born out of the fact that CloudFlare workers take what is traditionally a client side API (service workers) and run this server side. The SDK bakes in the assumption that if you are in a non-node environment, then you are client side which is not true for our use case.

* [This commit](https://github.com/splitio/javascript-client/commit/690ea721893b4ce203aa2bdf852f7f88d5871495) gets the Split SDK running on a CloudFlare worker in "browser" mode - we replace [axios](https://github.com/axios/axios) to remove the dependency on `XMLHTTPRequest` (CloudFlare workers use the fetch API).
* [This commit](https://github.com/splitio/javascript-client/commit/ba81eeeed6967305627b9d79df2312001431c6b0) messes with a bunch of `package.json` files to force webpack to compile the Node.js SDK for the browser. This allows us to instantiate a client without being forced to provide a "key" on start-up.
* The rest of this MR is then spent experimenting with which storage methods we need to implement to run the CloudFlare Worker in "consumer" mode, pointing at [Workers KV](https://developers.cloudflare.com/workers/reference/storage/).