### PR TITLE
Filter Split-to-GA hits from being re-tracked by GA-to-Split integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ deploy:
     acl: public_read
     cache_control: "max-age=31536000, public"
     on:
-      branch: development
+      branch: split_to_ga_to_split
   - provider: s3
     access_key_id: ${AWS_ACCESS_KEY_ID_PROD}
     secret_access_key: ${AWS_SECRET_ACCESS_PROD}

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ deploy:
     acl: public_read
     cache_control: "max-age=31536000, public"
     on:
-      branch: split_to_ga_to_split
+      branch: development
   - provider: s3
     access_key_id: ${AWS_ACCESS_KEY_ID_PROD}
     secret_access_key: ${AWS_SECRET_ACCESS_PROD}

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ script:
   - npm run test-browser-offline
   - npm run test-browser-destroy
   - npm run test-browser-errors
-  - npm run test-browser-gaintegration
   - 'npm run test-node -- --no-progress'
   - 'npm run test-node-e2e -- --no-progress'
   - 'npm run test-node-redis -- --no-progress'
@@ -49,7 +48,7 @@ deploy:
     acl: public_read
     cache_control: "max-age=31536000, public"
     on:
-      branch: ga_to_split
+      branch: development
   - provider: s3
     access_key_id: ${AWS_ACCESS_KEY_ID_PROD}
     secret_access_key: ${AWS_SECRET_ACCESS_PROD}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.11.0-canary.0",
+  "version": "10.11.0-canary.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/__tests__/gaIntegration/both-integrations.spec.js
+++ b/src/__tests__/gaIntegration/both-integrations.spec.js
@@ -24,11 +24,6 @@ const config = {
 };
 const settings = SettingsFactory(config);
 
-function filterSplitToGaHits(model) {
-  const eventCategory = model.get('eventCategory');
-  return !eventCategory || !eventCategory.startsWith('split-');
-}
-
 export default function (mock, assert) {
 
   let client;
@@ -108,7 +103,7 @@ export default function (mock, assert) {
 
     gaSpy();
 
-    window.ga('require', 'splitTracker', { filter: filterSplitToGaHits });
+    window.ga('require', 'splitTracker');
     customHits.forEach(hit => {
       setTimeout(() => {
         window.ga('send', hit);

--- a/src/__tests__/gaIntegration/both-integrations.spec.js
+++ b/src/__tests__/gaIntegration/both-integrations.spec.js
@@ -1,6 +1,7 @@
 import { SplitFactory } from '../..';
 import SettingsFactory from '../../utils/settings';
 import { gaSpy, gaTag } from './gaTestUtils';
+import includes from 'lodash/includes';
 
 function countImpressions(parsedImpressionsBulkPayload) {
   return parsedImpressionsBulkPayload
@@ -30,8 +31,6 @@ export default function (mock, assert) {
 
   // test default behavior of both integrations
   assert.test(t => {
-
-    // const hits = [];
     const customHits = [{ hitType: 'pageview' }, { hitType: 'event' }];
 
     const splitTrackParams = [['some_event'], ['other_event'], ['another_event']];
@@ -41,11 +40,12 @@ export default function (mock, assert) {
     const finish = (function* () {
       yield;
       const totalHits = customHits.length + splitTrackParams.length + splitGetTreatmentParams.length;
+
       t.equal(window.gaSpy.getHits().length, totalHits, 'Total hits');
       setTimeout(() => {
         client.destroy();
         t.end();
-      });
+      }, 0);
     })();
 
     mock.onPost(settings.url('/testImpressions/bulk')).replyOnce(req => {
@@ -70,19 +70,18 @@ export default function (mock, assert) {
     });
 
     mock.onPost(settings.url('/events/bulk')).replyOnce(req => {
-
       window.ga(() => {
         setTimeout(() => {
           try {
             const sentEvents = JSON.parse(req.data);
-            const sentEventsFromSplitToGa = sentEvents.filter(event =>
-              event.properties && event.properties.eventCategory &&
-              (event.properties.eventCategory === 'split-event' || event.properties.eventCategory === 'split-impression'));
+            const sentEventsFromSplitToGa = sentEvents.filter(event => {
+              return event.properties && event.properties.eventCategory && includes(event.properties.eventCategory, 'split');
+            });
 
             t.equal(sentEvents.length, splitTrackParams.length + customHits.length, 'Number of sent events is equal to custom events plus hits tracked as events');
             t.equal(sentEventsFromSplitToGa.length, 0, 'GA hits comming from Split-to-GA integration must not be tracked again as Split events');
 
-            const sentHitsNoSplitData = window.gaSpy.getHits().filter(hit => !hit.eventCategory || (hit.eventCategory !== 'split-event' && hit.eventCategory !== 'split-impression'));
+            const sentHitsNoSplitData = window.gaSpy.getHits().filter(hit => !hit.eventCategory || !includes(hit.eventCategory, 'split'));
             const sentHitsSplitEvents = window.gaSpy.getHits().filter(hit => hit.eventCategory === 'split-event');
 
             t.equal(sentHitsNoSplitData.length, customHits.length, 'Number of custom hits');
@@ -105,38 +104,31 @@ export default function (mock, assert) {
 
     window.ga('require', 'splitTracker');
     customHits.forEach(hit => {
-      setTimeout(() => {
-        window.ga('send', hit);
-      });
+      window.ga('send', hit);
     });
 
     const factory = SplitFactory({
       ...config,
       startup: {
-        eventsFirstPushWindow: -1,
+        eventsFirstPushWindow: 0,
       },
       scheduler: {
         impressionsRefreshRate: 1,
         // @TODO eventsPushRate is too high, but using eventsQueueSize don't let us assert `filterSplitToGaHits`
-        eventsPushRate: 15,
-        // we use eventsQueueSize instead of eventsPushRate to minimize the time for sending events
+        eventsPushRate: 10,
         // eventsQueueSize: splitTrackParams.length + customHits.length,
       },
     });
     client = factory.client();
+
     client.ready().then(() => {
       splitTrackParams.forEach(trackParams => {
-        setTimeout(() => {
-          client.track(trackParams[0]);
-        });
+        client.track.apply(client, trackParams);
       });
       splitGetTreatmentParams.forEach(getTreatmentParams => {
-        setTimeout(() => {
-          client.getTreatment(...getTreatmentParams);
-        });
+        client.getTreatment.apply(client, getTreatmentParams);
       });
     });
-
   });
 
 }

--- a/src/__tests__/gaIntegration/both-integrations.spec.js
+++ b/src/__tests__/gaIntegration/both-integrations.spec.js
@@ -1,0 +1,147 @@
+import { SplitFactory } from '../..';
+import SettingsFactory from '../../utils/settings';
+import { gaSpy, gaTag } from './gaTestUtils';
+
+function countImpressions(parsedImpressionsBulkPayload) {
+  return parsedImpressionsBulkPayload
+    .reduce((accumulator, currentValue) => { return accumulator + currentValue.keyImpressions.length; }, 0);
+}
+
+const config = {
+  core: {
+    key: 'facundo@split.io',
+    trafficType: 'user',
+  },
+  integrations: [{
+    type: 'GA_TO_SPLIT',
+  }, {
+    type: 'SPLIT_TO_GA',
+  }],
+  urls: {
+    sdk: 'https://sdk.both-integrations.io/api',
+    events: 'https://events.both-integrations.io/api'
+  },
+};
+const settings = SettingsFactory(config);
+
+function filterSplitToGaHits(model) {
+  const eventCategory = model.get('eventCategory');
+  return !eventCategory || !eventCategory.startsWith('split-');
+}
+
+export default function (mock, assert) {
+
+  let client;
+
+  // test default behavior of both integrations
+  assert.test(t => {
+
+    // const hits = [];
+    const customHits = [{ hitType: 'pageview' }, { hitType: 'event' }];
+
+    const splitTrackParams = [['some_event'], ['other_event'], ['another_event']];
+    const splitGetTreatmentParams = [['hierarchical_splits_test']];
+
+    // Generator to synchronize the call of t.end() when both impressions and events endpoints were invoked.
+    const finish = (function* () {
+      yield;
+      const totalHits = customHits.length + splitTrackParams.length + splitGetTreatmentParams.length;
+      t.equal(window.gaSpy.getHits().length, totalHits, 'Total hits');
+      setTimeout(() => {
+        client.destroy();
+        t.end();
+      });
+    })();
+
+    mock.onPost(settings.url('/testImpressions/bulk')).replyOnce(req => {
+      // we can assert payload and ga hits, once ga is ready and after `SplitToGa.queue`, that is timeout wrapped, make to the queue stack.
+      window.ga(() => {
+        setTimeout(() => {
+          try {
+            const resp = JSON.parse(req.data);
+            const numberOfSentImpressions = countImpressions(resp);
+            const sentImpressionHits = window.gaSpy.getHits().filter(hit => hit.eventCategory === 'split-impression');
+
+            t.equal(numberOfSentImpressions, splitGetTreatmentParams.length, 'Number of impressions');
+            t.equal(sentImpressionHits.length, splitGetTreatmentParams.length, `Number of sent impression hits must be equal to the number of impressions (${splitGetTreatmentParams.length})`);
+
+            finish.next();
+          } catch (err) {
+            console.error(err);
+          }
+        });
+      });
+      return [200];
+    });
+
+    mock.onPost(settings.url('/events/bulk')).replyOnce(req => {
+
+      window.ga(() => {
+        setTimeout(() => {
+          try {
+            const sentEvents = JSON.parse(req.data);
+            const sentEventsFromSplitToGa = sentEvents.filter(event =>
+              event.properties && event.properties.eventCategory &&
+              (event.properties.eventCategory === 'split-event' || event.properties.eventCategory === 'split-impression'));
+
+            t.equal(sentEvents.length, splitTrackParams.length + customHits.length, 'Number of sent events is equal to custom events plus hits tracked as events');
+            t.equal(sentEventsFromSplitToGa.length, 0, 'GA hits comming from Split-to-GA integration must not be tracked again as Split events');
+
+            const sentHitsNoSplitData = window.gaSpy.getHits().filter(hit => !hit.eventCategory || (hit.eventCategory !== 'split-event' && hit.eventCategory !== 'split-impression'));
+            const sentHitsSplitEvents = window.gaSpy.getHits().filter(hit => hit.eventCategory === 'split-event');
+
+            t.equal(sentHitsNoSplitData.length, customHits.length, 'Number of custom hits');
+            t.equal(sentHitsSplitEvents.length, splitTrackParams.length, 'Number of Split event hits');
+            finish.next();
+          } catch (err) {
+            console.error(err);
+          }
+        });
+      });
+      return [200];
+    });
+
+    gaTag();
+
+    // siteSpeedSampleRate set to 0 to never send a site speed timing hit
+    window.ga('create', 'UA-00000000-1', 'auto', { siteSpeedSampleRate: 0 });
+
+    gaSpy();
+
+    window.ga('require', 'splitTracker', { filter: filterSplitToGaHits });
+    customHits.forEach(hit => {
+      setTimeout(() => {
+        window.ga('send', hit);
+      });
+    });
+
+    const factory = SplitFactory({
+      ...config,
+      startup: {
+        eventsFirstPushWindow: -1,
+      },
+      scheduler: {
+        impressionsRefreshRate: 1,
+        // @TODO eventsPushRate is too high, but using eventsQueueSize don't let us assert `filterSplitToGaHits`
+        eventsPushRate: 15,
+        // we use eventsQueueSize instead of eventsPushRate to minimize the time for sending events
+        // eventsQueueSize: splitTrackParams.length + customHits.length,
+      },
+    });
+    client = factory.client();
+    client.ready().then(() => {
+      splitTrackParams.forEach(trackParams => {
+        setTimeout(() => {
+          client.track(trackParams[0]);
+        });
+      });
+      splitGetTreatmentParams.forEach(getTreatmentParams => {
+        setTimeout(() => {
+          client.getTreatment(...getTreatmentParams);
+        });
+      });
+    });
+
+  });
+
+}

--- a/src/__tests__/gaIntegration/browser.spec.js
+++ b/src/__tests__/gaIntegration/browser.spec.js
@@ -2,6 +2,7 @@ import tape from 'tape-catch';
 import MockAdapter from 'axios-mock-adapter';
 import gaToSplitSuite from './ga-to-split.spec';
 import splitToGaSuite from './split-to-ga.spec';
+import bothIntegrationsSuite from './both-integrations.spec';
 
 import { __getAxiosInstance } from '../../services/transport';
 import SettingsFactory from '../../utils/settings';
@@ -26,6 +27,7 @@ tape('## E2E CI Tests ##', function(assert) {
   /* Validate GA integration */
   assert.test('E2E / GA-to-Split', gaToSplitSuite.bind(null, mock));
   assert.test('E2E / Split-to-GA', splitToGaSuite.bind(null, mock));
+  assert.test('E2E / Both GA integrations', bothIntegrationsSuite.bind(null, mock));
 
   assert.end();
 });

--- a/src/integrations/ga/GaToSplit.js
+++ b/src/integrations/ga/GaToSplit.js
@@ -217,8 +217,8 @@ function GaToSplit(sdkOptions, storage, coreSettings) {
       tracker.set('sendHitTask', function (model) {
         originalSendHitTask(model);
 
-        // filter
-        if (opts.filter && !opts.filter(model))
+        // filter hit if it comes from Split-to-GA integration or if it is rejected by custom filter
+        if (model.get('splitHit') || (opts.filter && !opts.filter(model)))
           return;
 
         // map hit into an EventData instance

--- a/src/integrations/ga/SplitToGa.js
+++ b/src/integrations/ga/SplitToGa.js
@@ -75,7 +75,8 @@ class SplitToGa {
   }
 
   queue(data) {
-
+    // access ga command queue via `getGa` method, accounting for the possibility that
+    // the global `ga` reference was not yet mutated by analytics.js.
     const ga = SplitToGa.getGa();
     if (ga) {
 

--- a/src/integrations/ga/SplitToGa.js
+++ b/src/integrations/ga/SplitToGa.js
@@ -15,7 +15,6 @@ class SplitToGa {
           eventAction: 'Evaluate ' + payload.impression.feature,
           eventLabel: 'Treatment: ' + payload.impression.treatment + '. Targeting rule: ' + payload.impression.label + '.',
           nonInteraction: true,
-          splitHit: true,
         };
       case SPLIT_EVENT:
         return {
@@ -24,7 +23,6 @@ class SplitToGa {
           eventAction: payload.eventTypeId,
           eventValue: payload.value,
           nonInteraction: true,
-          splitHit: true,
         };
     }
     return null;
@@ -103,8 +101,9 @@ class SplitToGa {
       // send the hit
       this.trackerNames.forEach(trackerName => {
         const sendCommand = trackerName ? `${trackerName}.send` : 'send';
-        // access ga command queue via `getGa` method, accounting for the possibility that
-        // the global `ga` reference was not yet mutated by analytics.js.
+        // mark the hit as a Split one to avoid the loop.
+        fieldsObject.splitHit = true;
+        // Send to GA using our reference to the GA object.
         ga(sendCommand, fieldsObject);
       });
     }

--- a/src/integrations/ga/SplitToGa.js
+++ b/src/integrations/ga/SplitToGa.js
@@ -13,8 +13,9 @@ class SplitToGa {
           hitType: 'event',
           eventCategory: 'split-impression',
           eventAction: 'Evaluate ' + payload.impression.feature,
-          eventLabel: 'Treatment ' + payload.impression.treatment + ' Label ' + payload.impression.label,
+          eventLabel: 'Treatment: ' + payload.impression.treatment + '. Targeting rule: ' + payload.impression.label + '.',
           nonInteraction: true,
+          splitHit: true,
         };
       case SPLIT_EVENT:
         return {
@@ -23,6 +24,7 @@ class SplitToGa {
           eventAction: payload.eventTypeId,
           eventValue: payload.value,
           nonInteraction: true,
+          splitHit: true,
         };
     }
     return null;

--- a/src/integrations/ga/__tests__/SplitToGa.spec.js
+++ b/src/integrations/ga/__tests__/SplitToGa.spec.js
@@ -21,8 +21,7 @@ const fakeImpressionFieldsObject = {
   eventCategory: 'split-impression',
   eventAction: 'Evaluate ' + fakeImpressionPayload.impression.feature,
   eventLabel: 'Treatment: ' + fakeImpressionPayload.impression.treatment + '. Targeting rule: ' + fakeImpressionPayload.impression.label + '.',
-  nonInteraction: true,
-  splitHit: true,
+  nonInteraction: true
 };
 
 const fakeEventPayload = {
@@ -38,8 +37,7 @@ const fakeEventFieldsObject = {
   eventCategory: 'split-event',
   eventAction: fakeEventPayload.eventTypeId,
   eventValue: fakeEventPayload.value,
-  nonInteraction: true,
-  splitHit: true,
+  nonInteraction: true
 };
 
 tape('SplitToGa', t => {

--- a/src/integrations/ga/__tests__/SplitToGa.spec.js
+++ b/src/integrations/ga/__tests__/SplitToGa.spec.js
@@ -20,8 +20,9 @@ const fakeImpressionFieldsObject = {
   hitType: 'event',
   eventCategory: 'split-impression',
   eventAction: 'Evaluate ' + fakeImpressionPayload.impression.feature,
-  eventLabel: 'Treatment ' + fakeImpressionPayload.impression.treatment + ' Label ' + fakeImpressionPayload.impression.label,
+  eventLabel: 'Treatment: ' + fakeImpressionPayload.impression.treatment + '. Targeting rule: ' + fakeImpressionPayload.impression.label + '.',
   nonInteraction: true,
+  splitHit: true,
 };
 
 const fakeEventPayload = {
@@ -38,6 +39,7 @@ const fakeEventFieldsObject = {
   eventAction: fakeEventPayload.eventTypeId,
   eventValue: fakeEventPayload.value,
   nonInteraction: true,
+  splitHit: true,
 };
 
 tape('SplitToGa', t => {

--- a/src/integrations/ga/__tests__/SplitToGa.spec.js
+++ b/src/integrations/ga/__tests__/SplitToGa.spec.js
@@ -16,7 +16,11 @@ const fakeImpressionPayload = {
   hostname: 'hostname',
   sdkLanguageVersion: 'version',
 };
-const fakeImpressionFieldsObject = {
+const fakeImpression = {
+  type: SPLIT_IMPRESSION,
+  payload: fakeImpressionPayload,
+};
+const defaultImpressionFieldsObject = {
   hitType: 'event',
   eventCategory: 'split-impression',
   eventAction: 'Evaluate ' + fakeImpressionPayload.impression.feature,
@@ -32,7 +36,11 @@ const fakeEventPayload = {
   key: 'key',
   properties: undefined,
 };
-const fakeEventFieldsObject = {
+const fakeEvent = {
+  type: SPLIT_EVENT,
+  payload: fakeEventPayload,
+};
+const defaultEventFieldsObject = {
   hitType: 'event',
   eventCategory: 'split-event',
   eventAction: fakeEventPayload.eventTypeId,
@@ -59,11 +67,11 @@ tape('SplitToGa', t => {
   });
 
   t.test('SplitToGa.defaultMapper', assert => {
-    assert.deepEqual(SplitToGa.defaultMapper({ payload: fakeImpressionPayload, type: SPLIT_IMPRESSION }),
-      fakeImpressionFieldsObject,
+    assert.deepEqual(SplitToGa.defaultMapper(fakeImpression),
+      defaultImpressionFieldsObject,
       'should return the corresponding FieldsObject for a given impression');
-    assert.deepEqual(SplitToGa.defaultMapper({ payload: fakeEventPayload, type: SPLIT_EVENT }),
-      fakeEventFieldsObject,
+    assert.deepEqual(SplitToGa.defaultMapper(fakeEvent),
+      defaultEventFieldsObject,
       'should return the corresponding FieldsObject for a given event');
 
     assert.end();
@@ -86,13 +94,13 @@ tape('SplitToGa', t => {
 
     /** Default behaviour **/
     const instance = new SplitToGa();
-    instance.queue({ payload: fakeImpressionPayload, type: SPLIT_IMPRESSION });
-    assert.true(ga.lastCall.calledWithExactly('send', SplitToGa.defaultMapper({ payload: fakeImpressionPayload, type: SPLIT_IMPRESSION })),
-      'should queue `ga send` with the default mapped FieldsObject for impressions');
+    instance.queue(fakeImpression);
+    assert.true(ga.lastCall.calledWithExactly('send', { ...defaultImpressionFieldsObject, splitHit: true }),
+      'should queue `ga send` with the default mapped FieldsObject for impressions, appended with `splitHit` field');
 
-    instance.queue({ payload: fakeEventPayload, type: SPLIT_EVENT });
-    assert.true(ga.lastCall.calledWithExactly('send', SplitToGa.defaultMapper({ payload: fakeEventPayload, type: SPLIT_EVENT })),
-      'should queue `ga send` with the default mapped FieldsObject for events');
+    instance.queue(fakeEvent);
+    assert.true(ga.lastCall.calledWithExactly('send', { ...defaultEventFieldsObject, splitHit: true }),
+      'should queue `ga send` with the default mapped FieldsObject for events, appended with `splitHit` field');
 
     assert.equal(ga.callCount, 2);
 
@@ -115,14 +123,14 @@ tape('SplitToGa', t => {
       trackerNames,
     });
     ga.resetHistory();
-    instance2.queue({ payload: fakeImpressionPayload, type: SPLIT_IMPRESSION });
+    instance2.queue(fakeImpression);
     assert.true(ga.notCalled, 'shouldn\'t queue `ga send` if a Split data (impression or event) is filtered');
 
-    instance2.queue({ payload: fakeEventPayload, type: SPLIT_EVENT });
-    assert.true(ga.calledWithExactly('send', customMapper({ payload: fakeEventPayload, type: SPLIT_EVENT })),
-      'should queue `ga send` with the custom trackerName and FieldsObject from customMapper');
-    assert.true(ga.calledWithExactly(`${trackerNames[1]}.send`, customMapper({ payload: fakeEventPayload, type: SPLIT_EVENT })),
-      'should queue `ga send` with the custom trackerName and FieldsObject from customMapper');
+    instance2.queue(fakeEvent);
+    assert.true(ga.calledWithExactly('send', { ...customMapper(fakeImpression, defaultImpressionFieldsObject), splitHit: true }),
+      'should queue `ga send` with the custom trackerName and FieldsObject from customMapper, appended with `splitHit` field');
+    assert.true(ga.calledWithExactly(`${trackerNames[1]}.send`, { ...customMapper(fakeEvent, defaultEventFieldsObject), splitHit: true }),
+      'should queue `ga send` with the custom trackerName and FieldsObject from customMapper, appended with `splitHit` field');
 
     assert.equal(ga.callCount, 2);
 
@@ -134,9 +142,9 @@ tape('SplitToGa', t => {
       mapper: customMapper2,
     });
     ga.resetHistory();
-    instance3.queue({ payload: fakeImpressionPayload, type: SPLIT_IMPRESSION });
-    assert.true(ga.lastCall.calledWithExactly('send', SplitToGa.defaultMapper({ payload: fakeImpressionPayload, type: SPLIT_IMPRESSION })),
-      'should queue `ga send` with the custom FieldsObject from customMapper2');
+    instance3.queue(fakeImpression);
+    assert.true(ga.lastCall.calledWithExactly('send', { ...customMapper2(fakeImpression, defaultImpressionFieldsObject), splitHit: true }),
+      'should queue `ga send` with the custom FieldsObject from customMapper2, appended with `splitHit` field');
 
     assert.equal(ga.callCount, 1);
 
@@ -148,7 +156,7 @@ tape('SplitToGa', t => {
       mapper: customMapper3,
     });
     ga.resetHistory();
-    instance4.queue({ payload: fakeImpressionPayload, type: SPLIT_IMPRESSION });
+    instance4.queue(fakeImpression);
     assert.true(ga.notCalled, 'shouldn\'t queue `ga send` if a custom mapper throw an exception');
 
     gaRemove();

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -599,9 +599,7 @@ declare namespace SplitIO {
      */
     identities?: Identity[],
   }
-  type SPLIT_IMPRESSION = 'IMPRESSION';
-  type SPLIT_EVENT = 'EVENT';
-  type IntegrationData = { type: SPLIT_IMPRESSION, payload: SplitIO.ImpressionData } | { type: SPLIT_EVENT, payload: SplitIO.EventData };
+  type IntegrationData = { type: 'IMPRESSION', payload: SplitIO.ImpressionData } | { type: 'EVENT', payload: SplitIO.EventData };
   /**
    * Enable Split-to-GA integration, to track Split impressions and events as GA hits.
    *
@@ -630,7 +628,7 @@ declare namespace SplitIO {
      *      return defaultMapping;
      *  }`
      *
-     * Default FieldsObject instance for data.type === SPLIT_IMPRESSION:
+     * Default FieldsObject instance for data.type === 'IMPRESSION':
      *  `{
      *    hitType: 'event',
      *    eventCategory: 'split-impression',
@@ -638,7 +636,7 @@ declare namespace SplitIO {
      *    eventLabel: 'Treatment ' + data.payload.impression.treatment + ' Label ' + data.payload.impression.label,
      *    nonInteraction: true,
      *  }`
-     * Default FieldsObject instance for data.type === SPLIT_EVENT:
+     * Default FieldsObject instance for data.type === 'EVENT':
      *  `{
      *    hitType: 'event',
      *    eventCategory: 'split-event',


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

In Ga-to-Split integration, a built-in filter was added for hits coming from Split-to-GA integration.

## How do we test the changes introduced in this PR?

E2E test where both integrations (GA-to-Split and Split-to-GA) are used simultaneously.

## Extra Notes