### PR TITLE
GA integration feedback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.11.0-canary.2",
+  "version": "10.11.0-canary.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.11.0-canary.2",
+  "version": "10.11.0-canary.3",
   "description": "Split SDK",
   "files": [
     "README.md",

--- a/src/__tests__/gaIntegration/both-integrations.spec.js
+++ b/src/__tests__/gaIntegration/both-integrations.spec.js
@@ -14,9 +14,9 @@ const config = {
     trafficType: 'user',
   },
   integrations: [{
-    type: 'GA_TO_SPLIT',
+    type: 'GOOGLE_ANALYTICS_TO_SPLIT',
   }, {
-    type: 'SPLIT_TO_GA',
+    type: 'SPLIT_TO_GOOGLE_ANALYTICS',
   }],
   urls: {
     sdk: 'https://sdk.both-integrations.io/api',

--- a/src/__tests__/gaIntegration/ga-to-split.spec.js
+++ b/src/__tests__/gaIntegration/ga-to-split.spec.js
@@ -10,7 +10,7 @@ const config = {
     trafficType: 'user',
   },
   integrations: [{
-    type: 'GA_TO_SPLIT',
+    type: 'GOOGLE_ANALYTICS_TO_SPLIT',
   }],
   startup: {
     eventsFirstPushWindow: 0.2,
@@ -161,7 +161,7 @@ export default function (mock, assert) {
       ...config,
       core: { key: config.core.key },
       integrations: [{
-        type: 'GA_TO_SPLIT',
+        type: 'GOOGLE_ANALYTICS_TO_SPLIT',
         identities: identities,
       }],
     });
@@ -211,7 +211,7 @@ export default function (mock, assert) {
       ...config,
       core: { key: config.core.key },
       integrations: [{
-        type: 'GA_TO_SPLIT',
+        type: 'GOOGLE_ANALYTICS_TO_SPLIT',
         identities: identitiesSdkOpts,
       }],
     });
@@ -264,7 +264,7 @@ export default function (mock, assert) {
     const factory = SplitFactory({
       ...config,
       integrations: [{
-        type: 'GA_TO_SPLIT',
+        type: 'GOOGLE_ANALYTICS_TO_SPLIT',
         filter: model => model.get('hitType') === 'pageview', // accepts only pageviews
         mapper: () => ({ eventTypeId: 'mapperSdkOpts' }), // return a fixed event instance
         prefix: prefixSdkOpts,

--- a/src/__tests__/gaIntegration/split-to-ga.spec.js
+++ b/src/__tests__/gaIntegration/split-to-ga.spec.js
@@ -18,7 +18,7 @@ const config = {
     trafficType: 'user',
   },
   integrations: [{
-    type: 'SPLIT_TO_GA',
+    type: 'SPLIT_TO_GOOGLE_ANALYTICS',
   }],
   scheduler: {
     impressionsRefreshRate: 0.2,
@@ -141,10 +141,10 @@ export default function (mock, assert) {
         authorizationKey: '<some-token-2>',
       },
       integrations: [{
-        type: 'SPLIT_TO_GA',
+        type: 'SPLIT_TO_GOOGLE_ANALYTICS',
         trackerNames: ['myTracker1'],
       }, {
-        type: 'SPLIT_TO_GA',
+        type: 'SPLIT_TO_GOOGLE_ANALYTICS',
         trackerNames: ['myTracker2'],
       }],
     });
@@ -230,11 +230,11 @@ export default function (mock, assert) {
         eventsQueueSize: numOfEvents,
       },
       integrations: [{
-        type: 'SPLIT_TO_GA',
+        type: 'SPLIT_TO_GOOGLE_ANALYTICS',
         trackerNames: ['myTracker3'],
         filter: onlyImpressionsFilter,
       }, {
-        type: 'SPLIT_TO_GA',
+        type: 'SPLIT_TO_GOOGLE_ANALYTICS',
         trackerNames: ['myTracker4'],
         mapper: onlyEventsMapper,
       }],
@@ -297,14 +297,14 @@ export default function (mock, assert) {
       ...config,
       debug: true,
       integrations: [{
-        type: 'SPLIT_TO_GA',
+        type: 'SPLIT_TO_GOOGLE_ANALYTICS',
         mapper: function () { throw error; },
       }, {
-        type: 'SPLIT_TO_GA',
+        type: 'SPLIT_TO_GOOGLE_ANALYTICS',
         trackerNames: ['myTracker1'],
         mapper: function () { return {}; },
       }, {
-        type: 'SPLIT_TO_GA',
+        type: 'SPLIT_TO_GOOGLE_ANALYTICS',
         trackerNames: ['myTracker2'],
         mapper: function () { return { hitType: 'event', eventCategory: 'my-split-impression', eventAction: 'some-action' }; },
       }],

--- a/src/integrations/__tests__/node.spec.js
+++ b/src/integrations/__tests__/node.spec.js
@@ -4,7 +4,7 @@
 import tape from 'tape';
 import sinon from 'sinon';
 import proxyquire from 'proxyquire';
-import { GOOGLE_ANALYTICS_TO_SPLIT, SPLIT_TO_GOOGLE_ANALYTICS } from '../../../lib/utils/constants';
+import { GOOGLE_ANALYTICS_TO_SPLIT, SPLIT_TO_GOOGLE_ANALYTICS } from '../../utils/constants';
 import { SPLIT_IMPRESSION, SPLIT_EVENT } from '../../utils/constants';
 const proxyquireStrict = proxyquire.noCallThru();
 

--- a/src/integrations/__tests__/node.spec.js
+++ b/src/integrations/__tests__/node.spec.js
@@ -4,7 +4,7 @@
 import tape from 'tape';
 import sinon from 'sinon';
 import proxyquire from 'proxyquire';
-import { GA_TO_SPLIT, SPLIT_TO_GA } from '../../../lib/utils/constants';
+import { GOOGLE_ANALYTICS_TO_SPLIT, SPLIT_TO_GOOGLE_ANALYTICS } from '../../../lib/utils/constants';
 import { SPLIT_IMPRESSION, SPLIT_EVENT } from '../../utils/constants';
 const proxyquireStrict = proxyquire.noCallThru();
 
@@ -60,7 +60,7 @@ tape('IntegrationsManagerFactory for browser', t => {
     const instance1 = browserIMF(contextMock1);
     assert.equal(instance1, undefined, 'The instance should be undefined if settings.integrations does not contain integrations that register a listener.');
 
-    const contextMock2 = new ContextMock(null, { integrations: [{ type: GA_TO_SPLIT }, { type: SPLIT_TO_GA }] });
+    const contextMock2 = new ContextMock(null, { integrations: [{ type: GOOGLE_ANALYTICS_TO_SPLIT }, { type: SPLIT_TO_GOOGLE_ANALYTICS }] });
     const instance2 = browserIMF(contextMock2);
     assert.true(GaToSplitMock.calledOnce, 'GaToSplit invoked once');
     assert.true(SplitToGaMock.calledOnce, 'SplitToGa invoked once');
@@ -70,7 +70,7 @@ tape('IntegrationsManagerFactory for browser', t => {
     resetStubs();
 
     const contextMock3 = new ContextMock(null, { integrations:
-      [{ type: GA_TO_SPLIT }, { type: SPLIT_TO_GA }, { type: GA_TO_SPLIT }, { type: SPLIT_TO_GA }, { type: SPLIT_TO_GA }] });
+      [{ type: GOOGLE_ANALYTICS_TO_SPLIT }, { type: SPLIT_TO_GOOGLE_ANALYTICS }, { type: GOOGLE_ANALYTICS_TO_SPLIT }, { type: SPLIT_TO_GOOGLE_ANALYTICS }, { type: SPLIT_TO_GOOGLE_ANALYTICS }] });
     browserIMF(contextMock3);
     assert.true(GaToSplitMock.calledTwice, 'GaToSplit invoked twice');
     assert.true(SplitToGaMock.calledThrice, 'SplitToGa invoked thrice');
@@ -82,7 +82,7 @@ tape('IntegrationsManagerFactory for browser', t => {
   t.test('Interaction with GaToSplit integration module', assert => {
     const coreSetting = { key: 'emiliano', trafficType: 'user' };
     const gaToSplitOptions = {
-      type: 'GA_TO_SPLIT',
+      type: 'GOOGLE_ANALYTICS_TO_SPLIT',
       param1: 'param1',
       param2: 'param2',
     };
@@ -98,7 +98,7 @@ tape('IntegrationsManagerFactory for browser', t => {
 
   t.test('Interaction with SplitToGa integration module', assert => {
     const splitToGaOptions = {
-      type: 'SPLIT_TO_GA',
+      type: 'SPLIT_TO_GOOGLE_ANALYTICS',
       param1: 'param1',
       param2: 'param2',
     };

--- a/src/integrations/browser.js
+++ b/src/integrations/browser.js
@@ -1,6 +1,6 @@
 import GaToSplit from './ga/GaToSplit';
 import SplitToGa from './ga/SplitToGa';
-import { GA_TO_SPLIT, SPLIT_TO_GA, SPLIT_IMPRESSION, SPLIT_EVENT } from '../utils/constants';
+import { GOOGLE_ANALYTICS_TO_SPLIT, SPLIT_TO_GOOGLE_ANALYTICS, SPLIT_IMPRESSION, SPLIT_EVENT } from '../utils/constants';
 
 /**
  * Factory function for browser IntegrationsManager.
@@ -21,14 +21,14 @@ const integrationsManagerFactory = context => {
     let integration;
 
     switch (type) {
-      case GA_TO_SPLIT: {
+      case GOOGLE_ANALYTICS_TO_SPLIT: {
         const storage = context.get(context.constants.STORAGE);
         const coreSettings = settings.core;
         integration = GaToSplit(integrationOptions, storage, coreSettings);
         break;
       }
 
-      case SPLIT_TO_GA: {
+      case SPLIT_TO_GOOGLE_ANALYTICS: {
         integration = new SplitToGa(integrationOptions);
         break;
       }

--- a/src/integrations/ga/GaToSplit.js
+++ b/src/integrations/ga/GaToSplit.js
@@ -219,8 +219,8 @@ function GaToSplit(sdkOptions, storage, coreSettings) {
       tracker.set('sendHitTask', function (model) {
         originalSendHitTask(model);
 
-        // filter hit if `trackEvents` flag is false or if it comes from Split-to-GA integration
-        if (opts.trackEvents === false || model.get('splitHit')) return;
+        // filter hit if `events` flag is false or if it comes from Split-to-GA integration
+        if (opts.events === false || model.get('splitHit')) return;
         try {
           if (opts.filter && !opts.filter(model)) return;
         } catch (err) {

--- a/src/integrations/ga/GaToSplit.js
+++ b/src/integrations/ga/GaToSplit.js
@@ -149,16 +149,18 @@ const INVALID_SUBSTRING_REGEX = /[^-_.:a-zA-Z0-9]+/g;
 export function fixEventTypeId(eventTypeId) {
   // set a default eventTypeId if it is not a string or is an empty one.
   if (!isString(eventTypeId) || eventTypeId.length === 0) {
+    log.warn('EventTypeId was assigned `event` value because it must be a non-empty string.');
     return DEFAULT_EVENT_TYPE;
   }
 
   // replace invalid substrings and truncate
   const fixed = eventTypeId
     .replace(INVALID_PREFIX_REGEX, '')
-    .replace(INVALID_SUBSTRING_REGEX, '_')
-    .slice(0, 80);
+    .replace(INVALID_SUBSTRING_REGEX, '_');
+  const truncated = fixed.slice(0, 80);
+  if (truncated.length < fixed.length) log.warn('EventTypeId was truncated because it cannot be more than 80 characters long.');
   // return DEFAULT_EVENT_TYPE if fixed string is empty
-  return fixed ? fixed : DEFAULT_EVENT_TYPE;
+  return truncated ? truncated : DEFAULT_EVENT_TYPE;
 }
 
 /**

--- a/src/integrations/ga/GaToSplit.js
+++ b/src/integrations/ga/GaToSplit.js
@@ -219,8 +219,8 @@ function GaToSplit(sdkOptions, storage, coreSettings) {
       tracker.set('sendHitTask', function (model) {
         originalSendHitTask(model);
 
-        // filter hit if it comes from Split-to-GA integration
-        if (model.get('splitHit')) return;
+        // filter hit if `trackEvents` flag is false or if it comes from Split-to-GA integration
+        if (opts.trackEvents === false || model.get('splitHit')) return;
         try {
           if (opts.filter && !opts.filter(model)) return;
         } catch (err) {

--- a/src/integrations/ga/SplitToGa.js
+++ b/src/integrations/ga/SplitToGa.js
@@ -69,6 +69,10 @@ class SplitToGa {
       // We don't warn if a tracker does not exist, since the user might create it after the SDK is initialized.
       // Note: GA allows to create and get trackers using a string or number as tracker name, and does nothing if other types are used.
       if (Array.isArray(options.trackerNames)) this.trackerNames = uniq(options.trackerNames);
+
+      // No need to validate `trackImpressions` and `trackEvents` flags. Any other value than `false` is ignored.
+      this.trackImpressions = options.trackImpressions;
+      this.trackEvents = options.trackEvents;
     }
 
     log.info('Started Split-to-GA integration');
@@ -79,6 +83,9 @@ class SplitToGa {
     // the global `ga` reference was not yet mutated by analytics.js.
     const ga = SplitToGa.getGa();
     if (ga) {
+
+      if(this.trackImpressions === false && data.type === SPLIT_IMPRESSION) return;
+      if(this.trackEvents === false && data.type === SPLIT_EVENT) return;
 
       let fieldsObject;
       try { // only try/catch filter and mapper, which might be defined by the user

--- a/src/integrations/ga/SplitToGa.js
+++ b/src/integrations/ga/SplitToGa.js
@@ -70,9 +70,9 @@ class SplitToGa {
       // Note: GA allows to create and get trackers using a string or number as tracker name, and does nothing if other types are used.
       if (Array.isArray(options.trackerNames)) this.trackerNames = uniq(options.trackerNames);
 
-      // No need to validate `trackImpressions` and `trackEvents` flags. Any other value than `false` is ignored.
-      this.trackImpressions = options.trackImpressions;
-      this.trackEvents = options.trackEvents;
+      // No need to validate `impressions` and `events` flags. Any other value than `false` is ignored.
+      this.impressions = options.impressions;
+      this.events = options.events;
     }
 
     log.info('Started Split-to-GA integration');
@@ -84,8 +84,8 @@ class SplitToGa {
     const ga = SplitToGa.getGa();
     if (ga) {
 
-      if(this.trackImpressions === false && data.type === SPLIT_IMPRESSION) return;
-      if(this.trackEvents === false && data.type === SPLIT_EVENT) return;
+      if(this.impressions === false && data.type === SPLIT_IMPRESSION) return;
+      if(this.events === false && data.type === SPLIT_EVENT) return;
 
       let fieldsObject;
       try { // only try/catch filter and mapper, which might be defined by the user

--- a/src/integrations/ga/__tests__/GaToSplit.spec.js
+++ b/src/integrations/ga/__tests__/GaToSplit.spec.js
@@ -106,7 +106,7 @@ tape('defaultMapper', assert => {
 });
 
 const sdkOptions = {
-  type: 'GA_TO_SPLIT',
+  type: 'GOOGLE_ANALYTICS_TO_SPLIT',
 };
 const coreSettings = {
   key: 'key',
@@ -179,7 +179,7 @@ tape('GaToSplit', assert => {
 
   // provide a new SplitTracker plugin with custom SDK options
   GaToSplit({
-    type: 'GA_TO_SPLIT', mapper: customMapper2, filter: customFilter, identities: customIdentities, prefix: '', trackEvents: true
+    type: 'GOOGLE_ANALYTICS_TO_SPLIT', mapper: customMapper2, filter: customFilter, identities: customIdentities, prefix: '', events: true
   }, fakeStorage, coreSettings);
   assert.true(ga.lastCall.calledWith('provide', 'splitTracker'));
   SplitTracker = ga.lastCall.args[2];
@@ -204,7 +204,7 @@ tape('GaToSplit', assert => {
   assert.end();
 });
 
-tape('GaToSplit: `trackEvents` flag param', assert => {
+tape('GaToSplit: `events` flag param', assert => {
 
   // test setup
   const { ga, tracker } = gaMock();
@@ -212,7 +212,7 @@ tape('GaToSplit: `trackEvents` flag param', assert => {
   let SplitTracker = ga.lastCall.args[2];
 
   // init plugin with custom options
-  new SplitTracker(tracker, { trackEvents: false });
+  new SplitTracker(tracker, { events: false });
 
   // send hit and assert that it was not tracked as a Split event
   fakeStorage.events.track.resetHistory();

--- a/src/integrations/ga/__tests__/GaToSplit.spec.js
+++ b/src/integrations/ga/__tests__/GaToSplit.spec.js
@@ -133,6 +133,7 @@ const customIdentities = [{ key: 'key2', trafficType: 'tt2' }];
 
 tape('GaToSplit', assert => {
 
+  // test setup
   const { ga, tracker } = gaMock();
 
   // provide SplitTracker plugin
@@ -178,7 +179,7 @@ tape('GaToSplit', assert => {
 
   // provide a new SplitTracker plugin with custom SDK options
   GaToSplit({
-    type: 'GA_TO_SPLIT', mapper: customMapper2, filter: customFilter, identities: customIdentities, prefix: ''
+    type: 'GA_TO_SPLIT', mapper: customMapper2, filter: customFilter, identities: customIdentities, prefix: '', trackEvents: true
   }, fakeStorage, coreSettings);
   assert.true(ga.lastCall.calledWith('provide', 'splitTracker'));
   SplitTracker = ga.lastCall.args[2];
@@ -198,7 +199,27 @@ tape('GaToSplit', assert => {
       timestamp: event.timestamp,
     }, 'should track the event using a custom mapper and identity from the SDK options');
 
+  // test teardown
   gaRemove();
+  assert.end();
+});
 
+tape('GaToSplit: `trackEvents` flag param', assert => {
+
+  // test setup
+  const { ga, tracker } = gaMock();
+  GaToSplit(sdkOptions, fakeStorage, coreSettings);
+  let SplitTracker = ga.lastCall.args[2];
+
+  // init plugin with custom options
+  new SplitTracker(tracker, { trackEvents: false });
+
+  // send hit and assert that it was not tracked as a Split event
+  fakeStorage.events.track.resetHistory();
+  window.ga('send', hitSample);
+  assert.true(fakeStorage.events.track.notCalled);
+
+  // test teardown
+  gaRemove();
   assert.end();
 });

--- a/src/integrations/ga/__tests__/GaToSplit.spec.js
+++ b/src/integrations/ga/__tests__/GaToSplit.spec.js
@@ -59,9 +59,9 @@ tape('validateEventData', assert => {
   assert.throws(() => { validateEventData(undefined); }, 'throws exception if passed object is undefined');
   assert.throws(() => { validateEventData(null); }, 'throws exception if passed object is null');
 
-  assert.equal(validateEventData({}), true, 'does not validates eventTypeId');
-  assert.equal(validateEventData({ eventTypeId: 'type' }), true, 'does not validates eventTypeId');
-  assert.equal(validateEventData({ eventTypeId: 123 }), true, 'does not validates eventTypeId');
+  assert.equal(validateEventData({}), false, 'event must have a valid eventTypeId');
+  assert.equal(validateEventData({ eventTypeId: 'type' }), true, 'event must have a valid eventTypeId');
+  assert.equal(validateEventData({ eventTypeId: 123 }), false, 'event must have a valid eventTypeId');
 
   assert.equal(validateEventData({ eventTypeId: 'type', value: 'value' }), false, 'event must have a valid value if present');
   assert.equal(validateEventData({ eventTypeId: 'type', value: 0 }), true, 'event must have a valid value if present');
@@ -82,12 +82,11 @@ tape('validateEventData', assert => {
 });
 
 tape('fixEventTypeId', assert => {
-  const DEFAULT_EVENT_TYPE = 'event';
-  assert.equal(fixEventTypeId(undefined), DEFAULT_EVENT_TYPE);
-  assert.equal(fixEventTypeId(111), DEFAULT_EVENT_TYPE);
-  assert.equal(fixEventTypeId(''), DEFAULT_EVENT_TYPE);
-  assert.equal(fixEventTypeId('()'), DEFAULT_EVENT_TYPE);
-  assert.equal(fixEventTypeId('()+_'), DEFAULT_EVENT_TYPE);
+  assert.equal(fixEventTypeId(undefined), undefined);
+  assert.equal(fixEventTypeId(111), 111);
+  assert.equal(fixEventTypeId(''), '');
+  assert.equal(fixEventTypeId('()'), '');
+  assert.equal(fixEventTypeId('()+_'), '');
   assert.equal(fixEventTypeId('  some   event '), 'some_event_');
   assert.equal(fixEventTypeId('  -*- some  -.%^ event =+ '), 'some_-._event_');
   assert.end();

--- a/src/integrations/ga/__tests__/SplitToGa.spec.js
+++ b/src/integrations/ga/__tests__/SplitToGa.spec.js
@@ -160,21 +160,21 @@ tape('SplitToGa', t => {
     instance4.queue(fakeImpression);
     assert.true(ga.notCalled, 'shouldn\'t queue `ga send` if a custom mapper throw an exception');
 
-    // `trackImpressions` flags
+    // `impressions` flags
     const instance5 = new SplitToGa({
-      trackImpressions: false,
+      impressions: false,
     });
     ga.resetHistory();
     instance5.queue(fakeImpression);
-    assert.true(ga.notCalled, 'shouldn\'t queue `ga send` for an impression if `trackImpressions` flag is false');
+    assert.true(ga.notCalled, 'shouldn\'t queue `ga send` for an impression if `impressions` flag is false');
 
-    // `trackImpressions` flags
+    // `impressions` flags
     const instance6 = new SplitToGa({
-      trackEvents: false,
+      events: false,
     });
     ga.resetHistory();
     instance6.queue(fakeEvent);
-    assert.true(ga.notCalled, 'shouldn\'t queue `ga send` for a event if `trackEvents` flag is false');
+    assert.true(ga.notCalled, 'shouldn\'t queue `ga send` for a event if `events` flag is false');
 
     // test teardown
     gaRemove();

--- a/src/integrations/ga/__tests__/SplitToGa.spec.js
+++ b/src/integrations/ga/__tests__/SplitToGa.spec.js
@@ -90,6 +90,7 @@ tape('SplitToGa', t => {
 
   t.test('SplitToGa (constructor and queue method)', assert => {
 
+    // test setup
     const { ga } = gaMock();
 
     /** Default behaviour **/
@@ -159,6 +160,23 @@ tape('SplitToGa', t => {
     instance4.queue(fakeImpression);
     assert.true(ga.notCalled, 'shouldn\'t queue `ga send` if a custom mapper throw an exception');
 
+    // `trackImpressions` flags
+    const instance5 = new SplitToGa({
+      trackImpressions: false,
+    });
+    ga.resetHistory();
+    instance5.queue(fakeImpression);
+    assert.true(ga.notCalled, 'shouldn\'t queue `ga send` for an impression if `trackImpressions` flag is false');
+
+    // `trackImpressions` flags
+    const instance6 = new SplitToGa({
+      trackEvents: false,
+    });
+    ga.resetHistory();
+    instance6.queue(fakeEvent);
+    assert.true(ga.notCalled, 'shouldn\'t queue `ga send` for a event if `trackEvents` flag is false');
+
+    // test teardown
     gaRemove();
     assert.end();
   });

--- a/src/integrations/ga/__tests__/SplitToGa.spec.js
+++ b/src/integrations/ga/__tests__/SplitToGa.spec.js
@@ -1,6 +1,6 @@
 import tape from 'tape';
 import SplitToGa from '../SplitToGa';
-import { SPLIT_IMPRESSION, SPLIT_EVENT } from '../../../../lib/utils/constants';
+import { SPLIT_IMPRESSION, SPLIT_EVENT } from '../../../utils/constants';
 import { gaMock, gaRemove } from './gaMock';
 
 const fakeImpressionPayload = {

--- a/src/utils/constants/index.js
+++ b/src/utils/constants/index.js
@@ -17,8 +17,8 @@ export const CONTROL_WITH_CONFIG = {
 export const UNKNOWN = 'unknown';
 export const NA = 'NA';
 // Integration types
-export const GA_TO_SPLIT = 'GA_TO_SPLIT';
-export const SPLIT_TO_GA = 'SPLIT_TO_GA';
+export const GOOGLE_ANALYTICS_TO_SPLIT = 'GOOGLE_ANALYTICS_TO_SPLIT';
+export const SPLIT_TO_GOOGLE_ANALYTICS = 'SPLIT_TO_GOOGLE_ANALYTICS';
 // Integration data types
 export const SPLIT_IMPRESSION = 'IMPRESSION';
 export const SPLIT_EVENT = 'EVENT';

--- a/src/utils/settings/integrations/browser.js
+++ b/src/utils/settings/integrations/browser.js
@@ -1,8 +1,8 @@
-import { GA_TO_SPLIT, SPLIT_TO_GA } from '../../../utils/constants';
+import { GOOGLE_ANALYTICS_TO_SPLIT, SPLIT_TO_GOOGLE_ANALYTICS } from '../../../utils/constants';
 import validateIntegrationsSettings from './common';
 
 const validateBrowserIntegrationsSettings = settings => {
-  return validateIntegrationsSettings(settings, [GA_TO_SPLIT, SPLIT_TO_GA]);
+  return validateIntegrationsSettings(settings, [GOOGLE_ANALYTICS_TO_SPLIT, SPLIT_TO_GOOGLE_ANALYTICS]);
 };
 
 export default validateBrowserIntegrationsSettings;

--- a/ts-tests/index.ts
+++ b/ts-tests/index.ts
@@ -389,24 +389,24 @@ let fieldsObjectSample: UniversalAnalytics.FieldsObject = { hitType: 'event', ev
 let eventDataSample: SplitIO.EventData = { eventTypeId: 'someEventTypeId', value: 10, properties: {} }
 
 let gaToSplitIntegration: SplitIO.GaToSplitIntegration = {
-  type: 'GA_TO_SPLIT',
+  type: 'GOOGLE_ANALYTICS_TO_SPLIT',
 };
 let splitToGaIntegration: SplitIO.SplitToGaIntegration = {
-  type: 'SPLIT_TO_GA',
+  type: 'SPLIT_TO_GOOGLE_ANALYTICS',
 };
 
 let customGaToSplitIntegration: SplitIO.GaToSplitIntegration = {
-  type: 'GA_TO_SPLIT',
-  trackEvents: false,
+  type: 'GOOGLE_ANALYTICS_TO_SPLIT',
+  events: false,
   filter: function (model: UniversalAnalytics.Model): boolean { return true; },
   mapper: function (model: UniversalAnalytics.Model, defaultMapping: SplitIO.EventData): SplitIO.EventData { return eventDataSample; },
   prefix: 'PREFIX',
   identities: [{ key: 'key1', trafficType: 'tt1'}, { key: 'key2', trafficType: 'tt2'}],
 };
 let customSplitToGaIntegration: SplitIO.SplitToGaIntegration = {
-  type: 'SPLIT_TO_GA',
-  trackEvents: false,
-  trackImpressions: true,
+  type: 'SPLIT_TO_GOOGLE_ANALYTICS',
+  events: false,
+  impressions: true,
   filter: function (model: SplitIO.IntegrationData): boolean { return true; },
   mapper: function (model: SplitIO.IntegrationData, defaultMapping: UniversalAnalytics.FieldsObject): UniversalAnalytics.FieldsObject { return fieldsObjectSample; },
   trackerNames: ['t0', 'myTracker'],
@@ -444,7 +444,7 @@ let fullBrowserSettings: SplitIO.IBrowserSettings = {
   integrations: [gaToSplitIntegration, splitToGaIntegration, customGaToSplitIntegration, customSplitToGaIntegration]
 };
 fullBrowserSettings.storage.type = 'MEMORY';
-fullBrowserSettings.integrations[0].type = 'GA_TO_SPLIT';
+fullBrowserSettings.integrations[0].type = 'GOOGLE_ANALYTICS_TO_SPLIT';
 
 let fullNodeSettings: SplitIO.INodeSettings = {
   core: {

--- a/ts-tests/index.ts
+++ b/ts-tests/index.ts
@@ -404,6 +404,8 @@ let customGaToSplitIntegration: SplitIO.GaToSplitIntegration = {
 };
 let customSplitToGaIntegration: SplitIO.SplitToGaIntegration = {
   type: 'SPLIT_TO_GA',
+  trackEvents: false,
+  trackImpressions: true,
   filter: function (model: SplitIO.IntegrationData): boolean { return true; },
   mapper: function (model: SplitIO.IntegrationData, defaultMapping: UniversalAnalytics.FieldsObject): UniversalAnalytics.FieldsObject { return fieldsObjectSample; },
   trackerNames: ['t0', 'myTracker'],

--- a/ts-tests/index.ts
+++ b/ts-tests/index.ts
@@ -397,6 +397,7 @@ let splitToGaIntegration: SplitIO.SplitToGaIntegration = {
 
 let customGaToSplitIntegration: SplitIO.GaToSplitIntegration = {
   type: 'GA_TO_SPLIT',
+  trackEvents: false,
   filter: function (model: UniversalAnalytics.Model): boolean { return true; },
   mapper: function (model: UniversalAnalytics.Model, defaultMapping: SplitIO.EventData): SplitIO.EventData { return eventDataSample; },
   prefix: 'PREFIX',

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -564,7 +564,13 @@ declare namespace SplitIO {
   interface GaToSplitIntegration {
     type: 'GA_TO_SPLIT',
     /**
-     * Optional predicate used to filter GA hits from being tracked as Split events.
+     * Optional flag to filter GA hits from being tracked as Split events.
+     * @property {boolean} trackEvents
+     * @default true
+     */
+    trackEvents?: boolean,
+    /**
+     * Optional predicate used to define a custom filter for tracking GA hits as Split events.
      * For example, the following filter allows to track only 'event' hits:
      *  `(model) => model.get('hitType') === 'event'`
      * By default, all hits are tracked as Split events.

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -562,13 +562,13 @@ declare namespace SplitIO {
    * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#ga-to-split-integration}
    */
   interface GaToSplitIntegration {
-    type: 'GA_TO_SPLIT',
+    type: 'GOOGLE_ANALYTICS_TO_SPLIT',
     /**
      * Optional flag to filter GA hits from being tracked as Split events.
-     * @property {boolean} trackEvents
+     * @property {boolean} events
      * @default true
      */
-    trackEvents?: boolean,
+    events?: boolean,
     /**
      * Optional predicate used to define a custom filter for tracking GA hits as Split events.
      * For example, the following filter allows to track only 'event' hits:
@@ -613,22 +613,22 @@ declare namespace SplitIO {
    * @see {@link https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#split-to-ga-integration}
    */
   interface SplitToGaIntegration {
-    type: 'SPLIT_TO_GA',
+    type: 'SPLIT_TO_GOOGLE_ANALYTICS',
     /**
      * Optional flag to filter Split impressions from being tracked as GA hits.
-     * @property {boolean} trackImpressions
+     * @property {boolean} impressions
      * @default true
      */
-    trackImpressions?: boolean,
+    impressions?: boolean,
     /**
      * Optional flag to filter Split events from being tracked as GA hits.
-     * @property {boolean} trackEvents
+     * @property {boolean} events
      * @default true
      */
-    trackEvents?: boolean,
+    events?: boolean,
     /**
      * Optional predicate used to define a custom filter for tracking Split data (events and impressions) as GA hits.
-     * For example, the following filter allows to track only impressions, equivalent to setting `trackEvents` to `false`:
+     * For example, the following filter allows to track only impressions, equivalent to setting `events` to `false`:
      *  `(data) => data.type === 'IMPRESSION'`
      */
     filter?: (data: SplitIO.IntegrationData) => boolean,

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -609,10 +609,21 @@ declare namespace SplitIO {
   interface SplitToGaIntegration {
     type: 'SPLIT_TO_GA',
     /**
-     * Optional predicate used to filter data instances (Split events and impressions) from being tracked as GA hits.
-     * For example, the following filter allows to track only impressions:
+     * Optional flag to filter Split impressions from being tracked as GA hits.
+     * @property {boolean} trackImpressions
+     * @default true
+     */
+    trackImpressions?: boolean,
+    /**
+     * Optional flag to filter Split events from being tracked as GA hits.
+     * @property {boolean} trackEvents
+     * @default true
+     */
+    trackEvents?: boolean,
+    /**
+     * Optional predicate used to define a custom filter for tracking Split data (events and impressions) as GA hits.
+     * For example, the following filter allows to track only impressions, equivalent to setting `trackEvents` to `false`:
      *  `(data) => data.type === 'IMPRESSION'`
-     * By default, all impressions and events are tracked as GA hits.
      */
     filter?: (data: SplitIO.IntegrationData) => boolean,
     /**


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

- GaToSplit: added warning logs for fixed malformed EventTypeId values.
- GaToSplit: added optional `events` flag param to filter GA hits.
- SplitToGa: added optional `impressions` and `events` flag params to filter Split data.
- Renamed integration types to `GOOGLE_ANALYTICS_TO_SPLIT` and `SPLIT_TO_GOOGLE_ANALYTICS`

## How do we test the changes introduced in this PR?

- Unit tests for the new SplitToGa and GaToSplit flag params.

## Extra Notes