### PR TITLE
[Push] smart pausing of mySegments when falling back to polling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ deploy:
     acl: public_read
     cache_control: "max-age=31536000, public"
     on:
-      branch: push_synchronization_backoff_retries
+      branch: push_synchronization_mysegments_pausing
   - provider: s3
     access_key_id: ${AWS_ACCESS_KEY_ID_PROD}
     secret_access_key: ${AWS_SECRET_ACCESS_PROD}

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ deploy:
     acl: public_read
     cache_control: "max-age=31536000, public"
     on:
-      branch: push_synchronization_mysegments_pausing
+      branch: development
   - provider: s3
     access_key_id: ${AWS_ACCESS_KEY_ID_PROD}
     secret_access_key: ${AWS_SECRET_ACCESS_PROD}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.12.0-canary.3",
+  "version": "10.12.0-canary.4",
   "description": "Split SDK",
   "files": [
     "README.md",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.12.0-canary.2",
+  "version": "10.12.0-canary.3",
   "description": "Split SDK",
   "files": [
     "README.md",

--- a/src/__tests__/browserSuites/push-synchronization.spec.js
+++ b/src/__tests__/browserSuites/push-synchronization.spec.js
@@ -198,6 +198,9 @@ export function testSynchronization(mock, assert) {
     return [200, splitChangesMock4];
   });
 
+  // initial fetch of mySegments for new client
+  mock.onGet(settings.url('/mySegments/marcio@split.io')).replyOnce(200, mySegmentsMarcio);
+
   // split and mySegment sync after second SSE opened
   mock.onGet(settings.url('/splitChanges?since=1457552650000')).replyOnce(function () {
     const lapse = Date.now() - start;

--- a/src/producer/browser/Full.js
+++ b/src/producer/browser/Full.js
@@ -36,7 +36,6 @@ const FullBrowserProducer = (context) => {
   const mySegmentsUpdaterTask = TaskFactory(synchronizeMySegments, settings.scheduler.segmentsRefreshRate);
 
   const onSplitsArrived = onSplitsArrivedFactory(mySegmentsUpdaterTask, context);
-  splitsEventEmitter.on(splitsEventEmitter.SDK_SPLITS_ARRIVED, onSplitsArrived);
 
   let isSynchronizingSplits = false;
   let isSynchronizingMySegments = false;
@@ -69,6 +68,8 @@ const FullBrowserProducer = (context) => {
 
       splitsUpdaterTask.start(notStartImmediately);
       mySegmentsUpdaterTask.start(notStartImmediately);
+      splitsEventEmitter.on(splitsEventEmitter.SDK_SPLITS_ARRIVED, onSplitsArrived);
+      if (notStartImmediately) onSplitsArrived(); // resuming polling
     },
 
     // Stop periodic fetching (polling)
@@ -77,6 +78,7 @@ const FullBrowserProducer = (context) => {
 
       splitsUpdaterTask.stop();
       mySegmentsUpdaterTask && mySegmentsUpdaterTask.stop();
+      splitsEventEmitter.removeListener(splitsEventEmitter.SDK_SPLITS_ARRIVED, onSplitsArrived);
     },
 
     // Used by SyncManager to know if running in polling mode.

--- a/src/producer/browser/onSplitsArrivedFactory.js
+++ b/src/producer/browser/onSplitsArrivedFactory.js
@@ -2,22 +2,20 @@ import logFactory from '../../utils/logger';
 const log = logFactory('splitio-producer:mySegmentsHandler');
 
 export default function onSplitsArrivedCtx(segmentsUpdaterTask, context) {
-  let syncingSegments = true;
   const splitsStorage = context.get(context.constants.STORAGE).splits;
   const { segments: segmentsEventEmitter } = context.get(context.constants.READINESS);
-  
+
   return function onSplitsArrived() {
     const splitsHaveSegments = splitsStorage.usesSegments();
-  
-    if (splitsHaveSegments !== syncingSegments) {
-      syncingSegments = splitsHaveSegments;
+
+    if (splitsHaveSegments !== segmentsUpdaterTask.isRunning()) {
       log.info(`Turning segments data polling ${splitsHaveSegments ? 'ON' : 'OFF'}.`);
-  
+
       if (splitsHaveSegments) {
         segmentsUpdaterTask.start();
       } else {
         const isReady = context.get(context.constants.READY, true);
-  
+
         if (!isReady) segmentsEventEmitter.emit(segmentsEventEmitter.SDK_SEGMENTS_ARRIVED);
         segmentsUpdaterTask.stop();
       }

--- a/src/sync/browser.js
+++ b/src/sync/browser.js
@@ -25,13 +25,13 @@ export default function BrowserSyncManagerFactory(mainContext) {
 
   function startPolling() {
     if (!mainProducer.isRunning()) {
-      log.info('PUSH down or disconnected. Starting periodic fetch of data.');
+      log.info('Streaming not available. Starting periodic fetch of data.');
       forOwn(contexts, function (context) {
         const producer = context.get(context.constants.PRODUCER);
         producer.start(true); // `fetchers` are scheduled but not called immediately
       });
     } else {
-      log.info('PUSH couldn\'t connect. Continue periodic fetch of data.');
+      log.info('Streaming couldn\'t connect. Continue periodic fetch of data.');
     }
   }
 

--- a/src/sync/browser.js
+++ b/src/sync/browser.js
@@ -21,31 +21,36 @@ export default function BrowserSyncManagerFactory(mainContext) {
   // call `createInstance` before creating PushManager, since it is in charge of creating the full producer and adding it into the main context.
   const syncManager = createInstance(false, mainContext);
   const pushManager = settings.streamingEnabled ? PushManagerFactory(mainContext, contexts) : undefined;
+  const mainProducer = mainContext.get(mainContext.constants.PRODUCER);
 
   function startPolling() {
-    log.info('PUSH down or disconnected. Starting periodic fetch of data.');
-    forOwn(contexts, function (context) {
-      const producer = context.get(context.constants.PRODUCER);
-      if (!producer.isRunning())
+    if (!mainProducer.isRunning()) {
+      log.info('PUSH down or disconnected. Starting periodic fetch of data.');
+      forOwn(contexts, function (context) {
+        const producer = context.get(context.constants.PRODUCER);
         producer.start(true); // `fetchers` are scheduled but not called immediately
-    });
+      });
+    } else {
+      log.info('PUSH couldn\'t connect. Continue periodic fetch of data.');
+    }
   }
 
   function stopPollingAndSyncAll() {
-    log.info('PUSH (re)connected. Syncing and stopping periodic fetch of data.');
-    // if polling, stop
-    forOwn(contexts, function (context) {
-      const producer = context.get(context.constants.PRODUCER);
-      if (producer.isRunning())
+    if (mainProducer.isRunning()) {
+      log.info('PUSH (re)connected. Syncing and stopping periodic fetch of data.');
+      // if polling, stop
+      forOwn(contexts, function (context) {
+        const producer = context.get(context.constants.PRODUCER);
         producer.stop();
-    });
+      });
+    }
     syncAll();
   }
 
   function syncAll() {
     // fetch splits and segments
-    const mainProducer = mainContext.get(mainContext.constants.PRODUCER, true);
-    mainProducer && mainProducer.synchronizeSplits();
+    const mainProducer = mainContext.get(mainContext.constants.PRODUCER);
+    mainProducer.synchronizeSplits();
     forOwn(contexts, function (context) {
       const producer = context.get(context.constants.PRODUCER);
       producer.synchronizeMySegments();
@@ -76,6 +81,10 @@ export default function BrowserSyncManagerFactory(mainContext) {
             syncAll(); // initial syncAll (only when main client is created)
             pushManager.on(PUSH_CONNECT, stopPollingAndSyncAll);
             pushManager.on(PUSH_DISCONNECT, startPolling);
+          } else {
+            // for a shared client we must perform a `producer.synchronizeMySegments` for the initial fetch of its segments
+            // since `syncAll` was already executed when starting the main client
+            producer.synchronizeMySegments();
           }
           pushManager.startNewClient(userKey, context);
         } else {

--- a/src/sync/node.js
+++ b/src/sync/node.js
@@ -19,9 +19,12 @@ export default function NodeSyncManagerFactory(context) {
   const pushManager = settings.streamingEnabled ? PushManagerFactory(context) : undefined;
 
   function startPolling() {
-    log.info('PUSH down or disconnected. Starting periodic fetch of data.');
-    if (!producer.isRunning())
+    if (!producer.isRunning()) {
+      log.info('PUSH down or disconnected. Starting periodic fetch of data.');
       producer.start(true); // `fetchers` are scheduled but not called immediately
+    } else {
+      log.info('PUSH couldn\'t connect. Continue periodic fetch of data.');
+    }
   }
 
   function stopPollingAndSyncAll() {

--- a/src/sync/node.js
+++ b/src/sync/node.js
@@ -20,10 +20,10 @@ export default function NodeSyncManagerFactory(context) {
 
   function startPolling() {
     if (!producer.isRunning()) {
-      log.info('PUSH down or disconnected. Starting periodic fetch of data.');
+      log.info('Streaming not available. Starting periodic fetch of data.');
       producer.start(true); // `fetchers` are scheduled but not called immediately
     } else {
-      log.info('PUSH couldn\'t connect. Continue periodic fetch of data.');
+      log.info('Streaming couldn\'t connect. Continue periodic fetch of data.');
     }
   }
 

--- a/src/utils/__tests__/settings/index.spec.js
+++ b/src/utils/__tests__/settings/index.spec.js
@@ -28,7 +28,7 @@ tape('SETTINGS / check defaults', assert => {
     sdk: 'https://sdk.split.io/api',
     events: 'https://events.split.io/api',
     auth: 'https://auth.split.io/api',
-    streaming: 'https://realtime.ably.io',
+    streaming: 'https://split-realtime.ably.io',
   });
   assert.end();
 });

--- a/src/utils/settings/index.js
+++ b/src/utils/settings/index.js
@@ -71,7 +71,7 @@ const base = {
     // SDK Auth Server
     auth: 'https://auth.split.io/api',
     // Streaming Server
-    streaming: 'https://realtime.ably.io',
+    streaming: 'https://split-realtime.ably.io',
   },
 
   // Defines which kind of storage we should instanciate.


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

- Bug fixes in browser JS:
  - When creating a new client, its segments must be initially fetched to trigger an SDK_READY as soon as possible.
  - When resuming to polling, `mySegments` mustn't be fetched if splits doesn't use segments.

## How do we test the changes introduced in this PR?

- [TODO] e2e tests

## Extra Notes