### PR TITLE
Streaming enabled by default

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
-10.12.2 (Jun XX, 2020)
+10.13.0 (Jun XX, 2020)
  - Updated client.ready() and manager.ready() functions to be consumed on demand and return a promise reflecting the current status of the SDK at the time the method was invoked.
  - Updated readiness events on consumer mode: the SDK emits SDK_READY event once the connection to Redis cache is successful.
+ - Updated streamingEnabled default value from false to true, to use streaming synchronization by default.
 
 10.12.1 (May 18, 2020)
  - Updated logging messages for streaming notifications to DEBUG log level.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.12.2-canary.0",
+  "version": "10.12.2-canary.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.12.2-canary.0",
+  "version": "10.12.2-canary.4",
   "description": "Split SDK",
   "files": [
     "README.md",

--- a/src/__tests__/browser.spec.js
+++ b/src/__tests__/browser.spec.js
@@ -27,7 +27,8 @@ import mySegmentsMarcio from './mocks/mysegments.marcio@split.io.json';
 const settings = SettingsFactory({
   core: {
     key: 'facundo@split.io'
-  }
+  },
+  streamingEnabled: false
 });
 
 const configInMemory = {
@@ -40,7 +41,8 @@ const configInMemory = {
     segmentsRefreshRate: 1,
     metricsRefreshRate: 3000, // for now I don't want to publish metrics during E2E run.
     impressionsRefreshRate: 3000  // for now I don't want to publish impressions during E2E run.
-  }
+  },
+  streamingEnabled: false
 };
 
 const configInMemoryWithBucketingKey = {
@@ -56,7 +58,8 @@ const configInMemoryWithBucketingKey = {
     segmentsRefreshRate: 1,
     metricsRefreshRate: 3000, // for now I don't want to publish metrics during E2E run.
     impressionsRefreshRate: 3000  // for now I don't want to publish impressions during E2E run.
-  }
+  },
+  streamingEnabled: false
 };
 
 const configInLocalStorage = {
@@ -73,7 +76,8 @@ const configInLocalStorage = {
   storage: {
     type: 'LOCALSTORAGE',
     prefix: 'e2eTEST'    // Avoid storage name clashes
-  }
+  },
+  streamingEnabled: false
 };
 
 tape('## E2E CI Tests ##', function(assert) {

--- a/src/__tests__/browserSuites/events.spec.js
+++ b/src/__tests__/browserSuites/events.spec.js
@@ -4,7 +4,8 @@ import SettingsFactory from '../../utils/settings';
 const settings = SettingsFactory({
   core: {
     key: 'asd'
-  }
+  },
+  streamingEnabled: false
 });
 
 const baseSettings = {
@@ -21,7 +22,8 @@ const baseSettings = {
   },
   startup: {
     eventsFirstPushWindow: 2
-  }
+  },
+  streamingEnabled: false
 };
 
 export function withoutBindingTT(fetchMock, assert) {

--- a/src/__tests__/browserSuites/ignore-ip-addresses-setting.spec.js
+++ b/src/__tests__/browserSuites/ignore-ip-addresses-setting.spec.js
@@ -7,14 +7,18 @@ const HEADER_SPLITSDKMACHINEIP = 'SplitSDKMachineIP';
 const HEADER_SPLITSDKMACHINENAME = 'SplitSDKMachineName';
 
 // Refresh rates are set to 1 second to finish the test quickly. Otherwise, it would finish in 1 minute (60 seconds is the default value)
-const scheduler = {
-  metricsRefreshRate: 1,
-  impressionsRefreshRate: 1,
-  eventsPushRate: 1
+const baseConfig = {
+  scheduler: {
+    metricsRefreshRate: 1,
+    impressionsRefreshRate: 1,
+    eventsPushRate: 1
+  },
+  streamingEnabled: false
 };
 
 // Config with IPAddressesEnabled set to false
 const configWithIPAddressesDisabled = {
+  ...baseConfig,
   core: {
     authorizationKey: '<fake-token>',
     key: 'nicolas@split.io',
@@ -23,12 +27,12 @@ const configWithIPAddressesDisabled = {
   urls: {
     sdk: 'https://sdk.split-ipdisabled.io/api',
     events: 'https://events.split-ipdisabled.io/api'
-  },
-  scheduler
+  }
 };
 
 // Config with IPAddressesEnabled set to true
 const configWithIPAddressesEnabled = {
+  ...baseConfig,
   core: {
     authorizationKey: '<fake-token>',
     key: 'nicolas@split.io',
@@ -37,12 +41,12 @@ const configWithIPAddressesEnabled = {
   urls: {
     sdk: 'https://sdk.split-ipenabled.io/api',
     events: 'https://events.split-ipenabled.io/api'
-  },
-  scheduler
+  }
 };
 
 // Config with default IPAddressesEnabled (true)
 const configWithIPAddressesDefault = {
+  ...baseConfig,
   core: {
     authorizationKey: '<fake-token>',
     key: 'nicolas@split.io'
@@ -50,8 +54,7 @@ const configWithIPAddressesDefault = {
   urls: {
     sdk: 'https://sdk.split-ipdefault.io/api',
     events: 'https://events.split-ipdefault.io/api'
-  },
-  scheduler
+  }
 };
 
 const configSamples = [

--- a/src/__tests__/browserSuites/impressions-listener.spec.js
+++ b/src/__tests__/browserSuites/impressions-listener.spec.js
@@ -5,7 +5,8 @@ import SettingsFactory from '../../utils/settings';
 const settings = SettingsFactory({
   core: {
     key: '<fake id>'
-  }
+  },
+  streamingEnabled: false
 });
 
 const listener = {
@@ -26,7 +27,8 @@ const config = {
   startup: {
     eventsFirstPushWindow: 3000
   },
-  impressionListener: listener
+  impressionListener: listener,
+  streamingEnabled: false
 };
 
 export default function(assert) {

--- a/src/__tests__/browserSuites/impressions.spec.js
+++ b/src/__tests__/browserSuites/impressions.spec.js
@@ -13,7 +13,8 @@ const settings = SettingsFactory({
   core: {
     key: 'asd'
   },
-  urls: baseUrls
+  urls: baseUrls,
+  streamingEnabled: false
 });
 
 export default function (fetchMock, assert) {
@@ -36,7 +37,8 @@ export default function (fetchMock, assert) {
     startup: {
       eventsFirstPushWindow: 3000
     },
-    urls: baseUrls
+    urls: baseUrls,
+    streamingEnabled: false
   });
 
   const client = splitio.client();

--- a/src/__tests__/browserSuites/manager.spec.js
+++ b/src/__tests__/browserSuites/manager.spec.js
@@ -11,7 +11,8 @@ export default async function(settings, fetchMock, assert) {
     core: {
       authorizationKey: '<fake-token-1>',
       key: 'marcio@split.io'
-    }
+    },
+    streamingEnabled: false
   });
   const client = splitio.client();
   const manager = splitio.manager();

--- a/src/__tests__/browserSuites/metrics.spec.js
+++ b/src/__tests__/browserSuites/metrics.spec.js
@@ -21,7 +21,8 @@ const config = {
   urls: baseUrls,
   startup: {
     eventsFirstPushWindow: 3000
-  }
+  },
+  streamingEnabled: false
 };
 
 export default async function metricsBrowserSuite(fetchMock, assert) {

--- a/src/__tests__/browserSuites/readiness.spec.js
+++ b/src/__tests__/browserSuites/readiness.spec.js
@@ -23,7 +23,8 @@ const baseConfig = {
   },
   startup: {
     eventsFirstPushWindow: 3000 // We use default for the readiness related ones.
-  }
+  },
+  streamingEnabled: false
 };
 
 export default function (fetchMock, assert) {

--- a/src/__tests__/browserSuites/ready-from-cache.spec.js
+++ b/src/__tests__/browserSuites/ready-from-cache.spec.js
@@ -57,7 +57,8 @@ const baseConfig = {
     readyTimeout: 10,
     requestTimeoutBeforeReady: 10,
     eventsFirstPushWindow: 3000
-  }
+  },
+  streamingEnabled: false
 };
 
 export default function (fetchMock, assert) {

--- a/src/__tests__/browserSuites/ready-promise.spec.js
+++ b/src/__tests__/browserSuites/ready-promise.spec.js
@@ -20,7 +20,8 @@ const baseConfig = {
     authorizationKey: '<fake-token-3>',
     key: 'facundo@split.io',
   },
-  debug: 'WARN'
+  debug: 'WARN',
+  streamingEnabled: false
 };
 
 function assertGetTreatmentWhenReady(assert, client) {

--- a/src/__tests__/browserSuites/ready-promise.spec.js
+++ b/src/__tests__/browserSuites/ready-promise.spec.js
@@ -1,5 +1,5 @@
 import sinon from 'sinon';
-import { nearlyEqual } from '../testUtils/index';
+import { nearlyEqual } from '../testUtils';
 
 function fromSecondsToMillis(n) {
   return Math.round(n * 1000);

--- a/src/__tests__/browserSuites/shared-instantiation.spec.js
+++ b/src/__tests__/browserSuites/shared-instantiation.spec.js
@@ -3,7 +3,8 @@ import SettingsFactory from '../../utils/settings';
 const settings = SettingsFactory({
   core: {
     key: 'asd'
-  }
+  },
+  streamingEnabled: false
 });
 
 export default function (startWithTT, fetchMock, assert) {
@@ -20,7 +21,8 @@ export default function (startWithTT, fetchMock, assert) {
     startup: {
       eventsFirstPushWindow: 3,
       readyTimeout: 0.15
-    }
+    },
+    streamingEnabled: false
   });
   let mainClient = factory.client();
   assert.equal(mainClient, factory.client(), 'If we call factory.client() (no params) more than once, it is just a get of the main client.');

--- a/src/__tests__/browserSuites/use-beacon-api.spec.js
+++ b/src/__tests__/browserSuites/use-beacon-api.spec.js
@@ -12,7 +12,8 @@ const config = {
   urls: {
     sdk: 'https://sdk.baseurlbeacon',
     events: 'https://sdk.baseurlbeacon'
-  }
+  },
+  streamingEnabled: false
 };
 
 const settings = SettingsFactory(config);

--- a/src/__tests__/destroy/browser.spec.js
+++ b/src/__tests__/destroy/browser.spec.js
@@ -13,7 +13,8 @@ import impressionsMock from './impressions.json';
 const settings = SettingsFactory({
   core: {
     key: 'facundo@split.io'
-  }
+  },
+  streamingEnabled: false
 });
 
 fetchMock.getOnce(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
@@ -29,7 +30,8 @@ tape('SDK destroy for BrowserJS', async function (assert) {
       authorizationKey: 'fake-key',
       key: 'ut1'
     },
-    debug: true
+    debug: true,
+    streamingEnabled: false
   };
 
   const factory = SplitFactory(config);

--- a/src/__tests__/destroy/node.spec.js
+++ b/src/__tests__/destroy/node.spec.js
@@ -8,7 +8,8 @@ import SettingsFactory from '../../utils/settings';
 const settings = SettingsFactory({
   core: {
     key: 'facundo@split.io'
-  }
+  },
+  streamingEnabled: false
 });
 
 import splitChangesMock1 from './splitChanges.since.-1.json';
@@ -24,7 +25,8 @@ tape('SDK destroy for NodeJS', async function (assert) {
       authorizationKey: 'fake-key',
       key: 'facundo@split.io'
     },
-    mode: 'standalone'
+    mode: 'standalone',
+    streamingEnabled: false
   };
 
   const factory = SplitFactory(config);

--- a/src/__tests__/errorCatching/browser.spec.js
+++ b/src/__tests__/errorCatching/browser.spec.js
@@ -12,7 +12,8 @@ import SettingsFactory from '../../utils/settings';
 const settings = SettingsFactory({
   core: {
     authorizationKey: '<fake-token>'
-  }
+  },
+  streamingEnabled: false
 });
 
 fetchMock.get(settings.url('/splitChanges?since=-1'), function () {
@@ -41,7 +42,8 @@ const factory = SplitFactory({
     metricsRefreshRate: 100000,
     impressionsRefreshRate: 100000,
     eventsPushRate: 100000
-  }
+  },
+  streamingEnabled: false
 });
 
 tape('Error catching on callbacks - Browsers', assert => {

--- a/src/__tests__/errorCatching/node.spec.js
+++ b/src/__tests__/errorCatching/node.spec.js
@@ -16,7 +16,8 @@ const responseDelay = { delay: 1500 };
 const settings = SettingsFactory({
   core: {
     authorizationKey: '<fake-token>'
-  }
+  },
+  streamingEnabled: false
 });
 
 fetchMock.get(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 }, responseDelay);
@@ -42,7 +43,8 @@ tape('Error catching on callbacks', assert => {
       impressionsRefreshRate: 10000,
       eventsPushRate: 10000
     },
-    debug: false
+    debug: false,
+    streamingEnabled: false
   });
   const client = factory.client();
 

--- a/src/__tests__/gaIntegration/both-integrations.spec.js
+++ b/src/__tests__/gaIntegration/both-integrations.spec.js
@@ -17,7 +17,8 @@ const config = {
     type: 'GOOGLE_ANALYTICS_TO_SPLIT',
   }, {
     type: 'SPLIT_TO_GOOGLE_ANALYTICS',
-  }]
+  }],
+  streamingEnabled: false
 };
 const settings = SettingsFactory(config);
 

--- a/src/__tests__/gaIntegration/ga-to-split.spec.js
+++ b/src/__tests__/gaIntegration/ga-to-split.spec.js
@@ -14,7 +14,8 @@ const config = {
   }],
   startup: {
     eventsFirstPushWindow: 0.2,
-  }
+  },
+  streamingEnabled: false
 };
 const settings = SettingsFactory(config);
 

--- a/src/__tests__/gaIntegration/split-to-ga.spec.js
+++ b/src/__tests__/gaIntegration/split-to-ga.spec.js
@@ -22,6 +22,7 @@ const config = {
     impressionsRefreshRate: 0.2,
     eventsQueueSize: 1,
   },
+  streamingEnabled: false
 };
 
 const settings = SettingsFactory(config);

--- a/src/__tests__/node.spec.js
+++ b/src/__tests__/node.spec.js
@@ -18,7 +18,8 @@ import splitChangesMock2 from './mocks/splitchanges.since.1457552620999.json';
 const settings = SettingsFactory({
   core: {
     authorizationKey: '<fake-token>'
-  }
+  },
+  streamingEnabled: false
 });
 
 const config = {
@@ -30,7 +31,8 @@ const config = {
     segmentsRefreshRate: 1,
     metricsRefreshRate: 3000, // for now I don't want to publish metrics during E2E run.
     impressionsRefreshRate: 3000  // for now I don't want to publish impressions during E2E run.
-  }
+  },
+  streamingEnabled: false
 };
 
 const key = 'facundo@split.io';

--- a/src/__tests__/nodeSuites/events.spec.js
+++ b/src/__tests__/nodeSuites/events.spec.js
@@ -5,7 +5,8 @@ import SettingsFactory from '../../utils/settings';
 const settings = SettingsFactory({
   core: {
     key: 'asd'
-  }
+  },
+  streamingEnabled: false
 });
 
 const baseSettings = {
@@ -21,7 +22,8 @@ const baseSettings = {
   },
   startup: {
     eventsFirstPushWindow: 2
-  }
+  },
+  streamingEnabled: false
 };
 
 export default function trackAssertions(fetchMock, assert) {

--- a/src/__tests__/nodeSuites/impressions-listener.spec.js
+++ b/src/__tests__/nodeSuites/impressions-listener.spec.js
@@ -5,7 +5,8 @@ import SettingsFactory from '../../utils/settings';
 const settings = SettingsFactory({
   core: {
     key: '<fake id>'
-  }
+  },
+  streamingEnabled: false
 });
 
 const listener = {
@@ -25,7 +26,8 @@ const config = {
   startup: {
     eventsFirstPushWindow: 3000
   },
-  impressionListener: listener
+  impressionListener: listener,
+  streamingEnabled: false
 };
 
 export default function(assert) {

--- a/src/__tests__/nodeSuites/impressions.spec.js
+++ b/src/__tests__/nodeSuites/impressions.spec.js
@@ -13,7 +13,8 @@ const settings = SettingsFactory({
   core: {
     key: '<fake id>'
   },
-  urls: baseUrls
+  urls: baseUrls,
+  streamingEnabled: false
 });
 
 const config = {
@@ -29,7 +30,8 @@ const config = {
   urls: baseUrls,
   startup: {
     eventsFirstPushWindow: 3000
-  }
+  },
+  streamingEnabled: false
 };
 
 export default async function(key, fetchMock, assert) {

--- a/src/__tests__/nodeSuites/ip-addresses-setting.spec.js
+++ b/src/__tests__/nodeSuites/ip-addresses-setting.spec.js
@@ -13,14 +13,18 @@ const HOSTNAME_VALUE = osFunction.hostname();
 const NA = 'NA';
 
 // Refresh rates are set to 1 second to finish the test quickly. Otherwise, it would finish in 1 minute (60 seconds is the default value)
-const scheduler = {
-  metricsRefreshRate: 1,
-  impressionsRefreshRate: 1,
-  eventsPushRate: 1
+const baseConfig = {
+  scheduler: {
+    metricsRefreshRate: 1,
+    impressionsRefreshRate: 1,
+    eventsPushRate: 1
+  },
+  streamingEnabled: false
 };
 
 // Config with IPAddressesEnabled set to false
 const configWithIPAddressesDisabled = {
+  ...baseConfig,
   core: {
     authorizationKey: '<fake-token>',
     IPAddressesEnabled: false
@@ -28,12 +32,12 @@ const configWithIPAddressesDisabled = {
   urls: {
     sdk: 'https://sdk.split-ipdisabled.io/api',
     events: 'https://events.split-ipdisabled.io/api'
-  },
-  scheduler
+  }
 };
 
 // Config with IPAddressesEnabled set to true
 const configWithIPAddressesEnabled = {
+  ...baseConfig,
   core: {
     authorizationKey: '<fake-token>',
     IPAddressesEnabled: true
@@ -41,20 +45,19 @@ const configWithIPAddressesEnabled = {
   urls: {
     sdk: 'https://sdk.split-ipenabled.io/api',
     events: 'https://events.split-ipenabled.io/api'
-  },
-  scheduler
+  }
 };
 
 // Config with default IPAddressesEnabled (true)
 const configWithIPAddressesDefault = {
+  ...baseConfig,
   core: {
     authorizationKey: '<fake-token>'
   },
   urls: {
     sdk: 'https://sdk.split-ipdefault.io/api',
     events: 'https://events.split-ipdefault.io/api'
-  },
-  scheduler
+  }
 };
 
 const configSamples = [

--- a/src/__tests__/nodeSuites/manager.spec.js
+++ b/src/__tests__/nodeSuites/manager.spec.js
@@ -10,7 +10,8 @@ export default async function(settings, fetchMock, assert) {
   const splitio = SplitFactory({
     core: {
       authorizationKey: '<fake-token-1>'
-    }
+    },
+    streamingEnabled: false
   });
   const client = splitio.client();
   const manager = splitio.manager();

--- a/src/__tests__/nodeSuites/metrics.spec.js
+++ b/src/__tests__/nodeSuites/metrics.spec.js
@@ -12,7 +12,8 @@ const settings = SettingsFactory({
   core: {
     key: '<fake id>'
   },
-  urls: baseUrls
+  urls: baseUrls,
+  streamingEnabled: false
 });
 
 const config = {
@@ -28,7 +29,8 @@ const config = {
   urls: baseUrls,
   startup: {
     eventsFirstPushWindow: 3000
-  }
+  },
+  streamingEnabled: false
 };
 
 export default async function(key, fetchMock, assert) {

--- a/src/__tests__/nodeSuites/ready-promise.spec.js
+++ b/src/__tests__/nodeSuites/ready-promise.spec.js
@@ -17,7 +17,8 @@ const baseConfig = {
   core: {
     authorizationKey: '<fake-token-3>'
   },
-  debug: 'WARN'
+  debug: 'WARN',
+  streamingEnabled: false
 };
 
 function assertGetTreatmentWhenReady(assert, client, key) {

--- a/src/readiness/__tests__/node.spec.js
+++ b/src/readiness/__tests__/node.spec.js
@@ -118,7 +118,7 @@ tape('Readiness Callbacks handler - Event emitter and returned handler', t => {
 
     loggerMock.error.resetHistory();
     addListenerCB(gateMock.SDK_READY_TIMED_OUT);
-    assert.true(loggerMock.error.calledOnceWithExactly('A listener was added for SDK_READY_TIMED_OUT on the SDK, which has already fired and won\'t be emitted again. The callback won\'t be executed.'), 'If we try to add a listener to SDK_READY we get the corresponding warning.');
+    assert.true(loggerMock.error.calledOnceWithExactly('A listener was added for SDK_READY_TIMED_OUT on the SDK, which has already fired and won\'t be emitted again. The callback won\'t be executed.'), 'If we try to add a listener to SDK_READY_TIMED_OUT we get the corresponding warning.');
 
     resetStubs();
     assert.end();

--- a/src/readiness/statusManager.js
+++ b/src/readiness/statusManager.js
@@ -62,6 +62,7 @@ export default function callbackHandlerContext(context, internalReadyCbCount = 0
         resolve();
       });
       gate.once(SDK_READY_TIMED_OUT, (error) => {
+        context.put(context.constants.HAS_TIMEDOUT, true);
         hasTimedout = true;
         reject(error);
       });
@@ -91,7 +92,9 @@ export default function callbackHandlerContext(context, internalReadyCbCount = 0
           }
         }
         return readyPromise;
-      }
+      },
+      // Expose context for internal purposes only. Not considered part of the public API, and will be removed eventually.
+      context
     }
   );
 }

--- a/src/readiness/statusManager.js
+++ b/src/readiness/statusManager.js
@@ -94,7 +94,7 @@ export default function callbackHandlerContext(context, internalReadyCbCount = 0
         return readyPromise;
       },
       // Expose context for internal purposes only. Not considered part of the public API, and will be removed eventually.
-      context
+      __context: context
     }
   );
 }

--- a/src/sync/browser.js
+++ b/src/sync/browser.js
@@ -67,6 +67,7 @@ export default function BrowserSyncManagerFactory(mainContext) {
   function createInstance(isSharedClient, context) {
     const producer = isSharedClient ? PartialProducerFactory(context) : FullProducerFactory(context);
     const settings = context.get(context.constants.SETTINGS);
+    // we need to stringify the user key (or matching key) in case it is not an string, to hash and pass as query param for authentication
     const userKey = toString(matching(settings.core.key));
 
     context.put(context.constants.PRODUCER, producer);

--- a/src/sync/browser.js
+++ b/src/sync/browser.js
@@ -2,7 +2,7 @@ import PushManagerFactory from './PushManager';
 import FullProducerFactory from '../producer';
 import PartialProducerFactory from '../producer/browser/Partial';
 import { matching } from '../utils/key/factory';
-import { forOwn } from '../utils/lang';
+import { forOwn, toString } from '../utils/lang';
 import logFactory from '../utils/logger';
 import { PUSH_DISCONNECT, PUSH_CONNECT } from './constants';
 const log = logFactory('splitio-sync:sync-manager');
@@ -67,7 +67,7 @@ export default function BrowserSyncManagerFactory(mainContext) {
   function createInstance(isSharedClient, context) {
     const producer = isSharedClient ? PartialProducerFactory(context) : FullProducerFactory(context);
     const settings = context.get(context.constants.SETTINGS);
-    const userKey = matching(settings.core.key);
+    const userKey = toString(matching(settings.core.key));
 
     context.put(context.constants.PRODUCER, producer);
     if (contexts[userKey]) log.warn('A client with the same user key has already been created. Only the new instance will be properly synchronized.');

--- a/src/utils/__tests__/settings/node.spec.js
+++ b/src/utils/__tests__/settings/node.spec.js
@@ -91,7 +91,7 @@ tape('SETTINGS / IPAddressesEnabled should be overwritable and true by default',
       authorizationKey: 'dummy token'
     },
     mode: CONSUMER_MODE
-  });  
+  });
 
   assert.equal(settingsWithIPAddressDisabled.core.IPAddressesEnabled, false, 'When creating a setting instance, it will have the provided value for IPAddressesEnabled');
   assert.equal(settingsWithIPAddressEnabled.core.IPAddressesEnabled, true, 'and if no IPAddressesEnabled was provided, it will be true.');
@@ -101,6 +101,25 @@ tape('SETTINGS / IPAddressesEnabled should be overwritable and true by default',
 
   assert.deepEqual({ ip: IP_VALUE, hostname: HOSTNAME_VALUE }, settingsWithIPAddressEnabled.runtime, 'When IP address is enabled, the runtime setting will have the current ip and hostname values.');
   assert.deepEqual({ ip: IP_VALUE, hostname: HOSTNAME_VALUE }, settingsWithIPAddressEnabledAndConsumerMode.runtime, 'When IP address is enabled, the runtime setting will have the current ip and hostname values.');
+
+  assert.end();
+});
+
+tape('SETTINGS / streamingEnabled should be overwritable and true by default', assert => {
+  const settingsWithStreamingDisabled = SettingsFactory({
+    core: {
+      authorizationKey: 'dummy token',
+    },
+    streamingEnabled: false
+  });
+  const settingsWithStreamingEnabled = SettingsFactory({
+    core: {
+      authorizationKey: 'dummy token'
+    }
+  });
+
+  assert.equal(settingsWithStreamingDisabled.streamingEnabled, false, 'When creating a setting instance, it will have the provided value for streamingEnabled');
+  assert.equal(settingsWithStreamingEnabled.streamingEnabled, true, 'If streamingEnabled is not provided, it will be true.');
 
   assert.end();
 });

--- a/src/utils/context/constants.js
+++ b/src/utils/context/constants.js
@@ -1,6 +1,7 @@
 export const COLLECTORS = 'metrics_collectors';
 export const DESTROYED = 'is_destroyed';
 export const EVENTS = 'events_publisher';
+export const HAS_TIMEDOUT = 'has_timedout';
 export const INTEGRATIONS_MANAGER = 'integrations_manager';
 export const MY_SEGMENTS_CHANGE_WORKER = 'my_segments_change_worker';
 export const PRODUCER = 'producer';
@@ -12,5 +13,5 @@ export const STATUS_MANAGER = 'status_manager';
 export const STORAGE = 'storage';
 
 export default {
-  COLLECTORS, DESTROYED, EVENTS, INTEGRATIONS_MANAGER, MY_SEGMENTS_CHANGE_WORKER, PRODUCER, READINESS, READY, READY_FROM_CACHE, SETTINGS, STATUS_MANAGER, STORAGE
+  COLLECTORS, DESTROYED, EVENTS, HAS_TIMEDOUT, INTEGRATIONS_MANAGER, MY_SEGMENTS_CHANGE_WORKER, PRODUCER, READINESS, READY, READY_FROM_CACHE, SETTINGS, STATUS_MANAGER, STORAGE
 };

--- a/src/utils/settings/index.js
+++ b/src/utils/settings/index.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **/
 
-import { merge, isBoolean } from '../lang';
+import { merge } from '../lang';
 import language from './language';
 import runtime from './runtime';
 import overridesPerPlatform from './defaults';
@@ -96,7 +96,7 @@ const base = {
   integrations: undefined,
 
   // toggle using (true) or not using (false) Server-Side Events for synchronizing storage
-  streamingEnabled: false,
+  streamingEnabled: true,
 };
 
 function fromSecondsToMillis(n) {
@@ -147,7 +147,7 @@ function defaults(custom) {
   withDefaults.integrations = integrations(withDefaults);
 
   // validate push options
-  if (!isBoolean(withDefaults.streamingEnabled)) withDefaults.streamingEnabled = false;
+  if (withDefaults.streamingEnabled !== false) withDefaults.streamingEnabled = true;
   if (withDefaults.streamingEnabled) {
     // Backoff bases.
     // We are not checking if bases are positive numbers. Thus, we might be reauthenticating immediately (`setTimeout` with NaN or negative number)

--- a/ts-tests/index.ts
+++ b/ts-tests/index.ts
@@ -479,7 +479,7 @@ let fullNodeSettings: SplitIO.INodeSettings = {
   impressionListener: impressionListener,
   mode: 'standalone',
   debug: false,
-  streamingEnabled: true
+  streamingEnabled: false
 };
 fullNodeSettings.storage.type = 'MEMORY';
 fullNodeSettings.mode = 'consumer';

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -135,7 +135,7 @@ interface ISharedSettings {
    * Boolean flag to enable the streaming service as default synchronization mechanism. In the event of any issue with streaming,
    * the SDK would fallback to the polling mechanism. If false, the SDK would poll for changes as usual without attempting to use streaming.
    * @property {boolean} streamingEnabled
-   * @default false
+   * @default true
    */
   streamingEnabled?: boolean,
 }


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

- Updated `streamingEnabled` default value to `true`, to use streaming by default.
- Stringify user keys for streaming in client-side, to support other types of user key (e.g., number)

## How do we test the changes introduced in this PR?

Added a single UT.

## Extra Notes