### PR TITLE
Remove usage of Promise.prototype.finally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ deploy:
     acl: public_read
     cache_control: "max-age=31536000, public"
     on:
-      branch: development
+      branch: replace_promise_finally
   - provider: s3
     access_key_id: ${AWS_ACCESS_KEY_ID_PROD}
     secret_access_key: ${AWS_SECRET_ACCESS_PROD}

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@
  - Updated client.ready() and manager.ready() functions to be consumed on demand and return a promise reflecting the current status of the SDK at the time the method was invoked.
  - Updated readiness events on consumer mode: the SDK emits SDK_READY event once the connection to Redis cache is successful.
  - Updated streamingEnabled default value from false to true, to use streaming synchronization by default.
+ - Removed the use of Promise.prototype.finally to avoid issues with some promise polyfills.
 
 10.12.1 (May 18, 2020)
  - Updated logging messages for streaming notifications to DEBUG log level.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.12.2-canary.4",
+  "version": "10.12.2-canary.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.12.2-canary.4",
+  "version": "10.12.2-canary.5",
   "description": "Split SDK",
   "files": [
     "README.md",

--- a/src/__tests__/browserSuites/push-refresh-token.spec.js
+++ b/src/__tests__/browserSuites/push-refresh-token.spec.js
@@ -84,6 +84,7 @@ export function testRefreshToken(fetchMock, assert) {
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_REFRESH_TOKEN + MILLIS_SSE_OPEN), 'sync after SSE connection is reopened');
+    return { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } };
   });
   fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 
@@ -102,6 +103,7 @@ export function testRefreshToken(fetchMock, assert) {
     client.destroy().then(() => {
       assert.end();
     });
+    return { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } };
   });
   fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 

--- a/src/__tests__/browserSuites/push-refresh-token.spec.js
+++ b/src/__tests__/browserSuites/push-refresh-token.spec.js
@@ -103,7 +103,7 @@ export function testRefreshToken(fetchMock, assert) {
     client.destroy().then(() => {
       assert.end();
     });
-    return { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } };
+    return { status: 500, body: 'server error' };
   });
   fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 

--- a/src/__tests__/browserSuites/push-synchronization-retries.spec.js
+++ b/src/__tests__/browserSuites/push-synchronization-retries.spec.js
@@ -63,12 +63,12 @@ const MILLIS_THIRD_RETRY_FOR_SPLIT_KILL_EVENT = 1600;
  *  0.4 secs: SPLIT_UPDATE event with old changeNumber -> SDK_UPDATE not triggered
  *
  *  0.5 secs: MY_SEGMENTS_UPDATE event -> /mySegments/nicolas@split.io: network error
- *  0.6 secs: MY_SEGMENTS_UPDATE event -> /mySegments/nicolas@split.io retry: network error
+ *  0.6 secs: MY_SEGMENTS_UPDATE event -> /mySegments/nicolas@split.io retry: invalid JSON response
  *  0.8 secs: MY_SEGMENTS_UPDATE event -> /mySegments/nicolas@split.io retry: success -> SDK_UPDATE triggered
  *
- *  0.9 secs: SPLIT_KILL event -> /splitChanges: bad response -> SDK_UPDATE triggered although fetches fail
+ *  0.9 secs: SPLIT_KILL event -> /splitChanges: outdated response -> SDK_UPDATE triggered although fetches fail
  *  1.0 secs: SPLIT_KILL event -> /splitChanges retry: network error
- *  1.2 secs: SPLIT_KILL event -> /splitChanges retry: network error
+ *  1.2 secs: SPLIT_KILL event -> /splitChanges retry: invalid JSON response
  *  1.6 secs: SPLIT_KILL event -> /splitChanges retry: 408 request timeout
  *    (we destroy the client here, to assert that all scheduled tasks are clean)
  */
@@ -163,7 +163,7 @@ export function testSynchronizationRetries(fetchMock, assert) {
   // fetch due to first MY_SEGMENTS_UPDATE event
   fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { throws: new TypeError('Network error') });
   // fetch retry for MY_SEGMENTS_UPDATE event, due to previous fail
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { throws: new TypeError('Network error') });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: '%^%$#%$%&$%&$%&$%&' }); // invalid JSON response
   // second fetch retry for MY_SEGMENTS_UPDATE event, due to previous fail
   fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), function () {
     const lapse = Date.now() - start;
@@ -181,7 +181,7 @@ export function testSynchronizationRetries(fetchMock, assert) {
   // first fetch retry for SPLIT_KILL event, due to previous unexpected response (response till minor than SPLIT_KILL changeNumber)
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), { throws: new TypeError('Network error') });
   // second fetch retry for SPLIT_KILL event
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), { throws: new TypeError('Network error') });
+  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), { status: 200, body: '%^%$#%$%&$%&$%&$%&' }); // invalid JSON response
   // third fetch retry for SPLIT_KILL event
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), function () {
     const lapse = Date.now() - start;

--- a/src/__tests__/nodeSuites/push-refresh-token.spec.js
+++ b/src/__tests__/nodeSuites/push-refresh-token.spec.js
@@ -80,6 +80,7 @@ export function testRefreshToken(fetchMock, assert) {
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_REFRESH_TOKEN + MILLIS_SSE_OPEN), 'sync after SSE connection is reopened');
+    return { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } };
   });
 
   // second re-auth due to refresh token
@@ -97,6 +98,7 @@ export function testRefreshToken(fetchMock, assert) {
     client.destroy().then(() => {
       assert.end();
     });
+    return { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } };
   });
 
   mockSegmentChanges(fetchMock, new RegExp(`${settings.url('/segmentChanges')}/*`), [key]);

--- a/src/__tests__/nodeSuites/push-refresh-token.spec.js
+++ b/src/__tests__/nodeSuites/push-refresh-token.spec.js
@@ -98,7 +98,7 @@ export function testRefreshToken(fetchMock, assert) {
     client.destroy().then(() => {
       assert.end();
     });
-    return { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } };
+    return { status: 500, body: 'server error' };
   });
 
   mockSegmentChanges(fetchMock, new RegExp(`${settings.url('/segmentChanges')}/*`), [key]);

--- a/src/__tests__/nodeSuites/push-synchronization-retries.spec.js
+++ b/src/__tests__/nodeSuites/push-synchronization-retries.spec.js
@@ -43,10 +43,10 @@ const MILLIS_RETRY_FOR_FIRST_SPLIT_UPDATE_EVENT = 300;
 const MILLIS_SECOND_SPLIT_UPDATE_EVENT = 400;
 
 const MILLIS_SEGMENT_UPDATE_EVENT = 500;
-const MILLIS_SECOND_RETRY_FOR_SEGMENT_UPDATE_EVENT = 800;
+const MILLIS_THIRD_RETRY_FOR_SEGMENT_UPDATE_EVENT = 1200;
 
-const MILLIS_SPLIT_KILL_EVENT = 900;
-const MILLIS_THIRD_RETRY_FOR_SPLIT_KILL_EVENT = 1600;
+const MILLIS_SPLIT_KILL_EVENT = 1300;
+const MILLIS_THIRD_RETRY_FOR_SPLIT_KILL_EVENT = 2000;
 
 /**
  * Sequence of calls:
@@ -58,14 +58,15 @@ const MILLIS_THIRD_RETRY_FOR_SPLIT_KILL_EVENT = 1600;
  *
  *  0.4 secs: SPLIT_UPDATE event with old changeNumber -> SDK_UPDATE not triggered
  *
- *  0.5 secs: SEGMENT_UPDATE event -> /segmentChanges/*: invalid JSON response
+ *  0.5 secs: SEGMENT_UPDATE event -> /segmentChanges/*: outdated response
  *  0.6 secs: SEGMENT_UPDATE event -> /segmentChanges/* retry: network error
- *  0.8 secs: SEGMENT_UPDATE event -> /segmentChanges/* retry: success -> SDK_UPDATE triggered
+ *  0.8 secs: SEGMENT_UPDATE event -> /segmentChanges/* retry: invalid JSON response
+ *  1.2 secs: SEGMENT_UPDATE event -> /segmentChanges/* retry: success -> SDK_UPDATE triggered
  *
- *  0.9 secs: SPLIT_KILL event -> /splitChanges: outdated response -> SDK_UPDATE triggered although fetches fail
- *  1.0 secs: SPLIT_KILL event -> /splitChanges retry: invalid JSON response
- *  1.2 secs: SPLIT_KILL event -> /splitChanges retry: network error
- *  1.6 secs: SPLIT_KILL event -> /splitChanges retry: 408 request timeout
+ *  1.3 secs: SPLIT_KILL event -> /splitChanges: outdated response -> SDK_UPDATE triggered although fetches fail
+ *  1.4 secs: SPLIT_KILL event -> /splitChanges retry: invalid JSON response
+ *  1.6 secs: SPLIT_KILL event -> /splitChanges retry: network error
+ *  2.0 secs: SPLIT_KILL event -> /splitChanges retry: 408 request timeout
  *    (we destroy the client here, to assert that all scheduled tasks are clean)
  */
 export function testSynchronizationRetries(fetchMock, assert) {
@@ -105,7 +106,7 @@ export function testSynchronizationRetries(fetchMock, assert) {
       assert.equal(client.getTreatment(key, 'splitters'), 'on', 'evaluation with initial segment');
       client.once(client.Event.SDK_UPDATE, () => {
         const lapse = Date.now() - start;
-        assert.true(nearlyEqual(lapse, MILLIS_SECOND_RETRY_FOR_SEGMENT_UPDATE_EVENT), 'SDK_UPDATE due to SEGMENT_UPDATE event');
+        assert.true(nearlyEqual(lapse, MILLIS_THIRD_RETRY_FOR_SEGMENT_UPDATE_EVENT), 'SDK_UPDATE due to SEGMENT_UPDATE event');
         assert.equal(client.getTreatment(key, 'splitters'), 'off', 'evaluation with updated segment');
       });
       eventSourceInstance.emitMessage(segmentUpdateMessage);
@@ -121,7 +122,7 @@ export function testSynchronizationRetries(fetchMock, assert) {
         });
       });
       eventSourceInstance.emitMessage(splitKillMessage);
-    }, MILLIS_SPLIT_KILL_EVENT); // send a SPLIT_KILL event with a new changeNumber after 0.5 seconds
+    }, MILLIS_SPLIT_KILL_EVENT); // send a SPLIT_KILL event with a new changeNumber after 1.3 seconds
 
   });
 
@@ -165,14 +166,16 @@ export function testSynchronizationRetries(fetchMock, assert) {
   fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=1457552620999'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_SEGMENT_UPDATE_EVENT), 'sync due to SEGMENT_UPDATE event');
-    return { status: 200, body: '{ "since": 1457552620999, "till": 1457552620999, "name": "splitters", "add' }; // invalid JSON
+    return { status: 200, body: { since: 1457552620999, till: 1457552620999, name: 'splitters', added: [], removed: [] } }; // outdated response
   });
   // first fetch retry for SEGMENT_UPDATE event, due to previous unexpected response (response till minor than SEGMENT_UPDATE changeNumber)
   fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=1457552620999'), { throws: new TypeError('Network error') });
   // second fetch retry for SEGMENT_UPDATE event, due to previous network error
+  fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=1457552620999'), { status: 200, body: '{ "since": 1457552620999, "til' });
+  // third fetch retry for SEGMENT_UPDATE event, due to previous unexpected response (invalid JSON)
   fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=1457552620999'), function () {
     const lapse = Date.now() - start;
-    assert.true(nearlyEqual(lapse, MILLIS_SECOND_RETRY_FOR_SEGMENT_UPDATE_EVENT), 'sync second retry for SEGMENT_UPDATE event');
+    assert.true(nearlyEqual(lapse, MILLIS_THIRD_RETRY_FOR_SEGMENT_UPDATE_EVENT), 'sync third retry for SEGMENT_UPDATE event');
     return { status: 200, body: { since: 1457552620999, till: 1457552640000, name: 'splitters', added: [], removed: [key] } };
   });
   // extra retry (fetch until since === till)
@@ -186,7 +189,7 @@ export function testSynchronizationRetries(fetchMock, assert) {
     return { status: 200, body: { since: 1457552649999, till: 1457552649999, splits: [] } }; // returning old state
   });
   // first fetch retry for SPLIT_KILL event, due to previous unexpected response (response till minor than SPLIT_KILL changeNumber)
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), { status: 200, body: '{ "since: 1457552649999, "till": 1457552649999, "splits": [] }' }); // invalid JSON
+  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), { status: 200, body: '{ "since": 1457552620999, "til' }); // invalid JSON
   // second fetch retry for SPLIT_KILL event
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), { throws: new TypeError('Network error') });
   // third fetch retry for SPLIT_KILL event

--- a/src/__tests__/nodeSuites/push-synchronization-retries.spec.js
+++ b/src/__tests__/nodeSuites/push-synchronization-retries.spec.js
@@ -31,7 +31,7 @@ const config = {
   },
   urls: baseUrls,
   streamingEnabled: true,
-  // debug: true,
+  debug: true,
 };
 const settings = SettingsFactory(config);
 
@@ -58,12 +58,12 @@ const MILLIS_THIRD_RETRY_FOR_SPLIT_KILL_EVENT = 1600;
  *
  *  0.4 secs: SPLIT_UPDATE event with old changeNumber -> SDK_UPDATE not triggered
  *
- *  0.5 secs: SEGMENT_UPDATE event -> /segmentChanges/*: bad response
+ *  0.5 secs: SEGMENT_UPDATE event -> /segmentChanges/*: invalid JSON response
  *  0.6 secs: SEGMENT_UPDATE event -> /segmentChanges/* retry: network error
  *  0.8 secs: SEGMENT_UPDATE event -> /segmentChanges/* retry: success -> SDK_UPDATE triggered
  *
- *  0.9 secs: SPLIT_KILL event -> /splitChanges: bad response -> SDK_UPDATE triggered although fetches fail
- *  1.0 secs: SPLIT_KILL event -> /splitChanges retry: network error
+ *  0.9 secs: SPLIT_KILL event -> /splitChanges: outdated response -> SDK_UPDATE triggered although fetches fail
+ *  1.0 secs: SPLIT_KILL event -> /splitChanges retry: invalid JSON response
  *  1.2 secs: SPLIT_KILL event -> /splitChanges retry: network error
  *  1.6 secs: SPLIT_KILL event -> /splitChanges retry: 408 request timeout
  *    (we destroy the client here, to assert that all scheduled tasks are clean)
@@ -165,7 +165,7 @@ export function testSynchronizationRetries(fetchMock, assert) {
   fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=1457552620999'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_SEGMENT_UPDATE_EVENT), 'sync due to SEGMENT_UPDATE event');
-    return { status: 200, body: { since: 1457552620999, till: 1457552620999, name: 'splitters', added: [], removed: [] } };
+    return { status: 200, body: '{ "since": 1457552620999, "till": 1457552620999, "name": "splitters", "add' }; // invalid JSON
   });
   // first fetch retry for SEGMENT_UPDATE event, due to previous unexpected response (response till minor than SEGMENT_UPDATE changeNumber)
   fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=1457552620999'), { throws: new TypeError('Network error') });
@@ -186,7 +186,7 @@ export function testSynchronizationRetries(fetchMock, assert) {
     return { status: 200, body: { since: 1457552649999, till: 1457552649999, splits: [] } }; // returning old state
   });
   // first fetch retry for SPLIT_KILL event, due to previous unexpected response (response till minor than SPLIT_KILL changeNumber)
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), { throws: new TypeError('Network error') });
+  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), { status: 200, body: '{ "since: 1457552649999, "till": 1457552649999, "splits": [] }' }); // invalid JSON
   // second fetch retry for SPLIT_KILL event
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), { throws: new TypeError('Network error') });
   // third fetch retry for SPLIT_KILL event

--- a/src/__tests__/nodeSuites/push-synchronization-retries.spec.js
+++ b/src/__tests__/nodeSuites/push-synchronization-retries.spec.js
@@ -31,7 +31,7 @@ const config = {
   },
   urls: baseUrls,
   streamingEnabled: true,
-  debug: true,
+  // debug: true,
 };
 const settings = SettingsFactory(config);
 

--- a/src/producer/browser/Full.js
+++ b/src/producer/browser/Full.js
@@ -37,7 +37,7 @@ const FullBrowserProducer = (context) => {
 
   function synchronizeSplits() {
     isSynchronizingSplits = true;
-    return splitsUpdater().finally(function () {
+    return splitsUpdater().then(function () {
       isSynchronizingSplits = false;
     });
   }

--- a/src/producer/browser/Full.js
+++ b/src/producer/browser/Full.js
@@ -37,8 +37,9 @@ const FullBrowserProducer = (context) => {
 
   function synchronizeSplits() {
     isSynchronizingSplits = true;
-    return splitsUpdater().then(function () {
+    return splitsUpdater().then(function (result) {
       isSynchronizingSplits = false;
+      return result; // false if the task fail fetching or storing mySegments
     });
   }
 

--- a/src/producer/browser/Full.js
+++ b/src/producer/browser/Full.js
@@ -37,9 +37,10 @@ const FullBrowserProducer = (context) => {
 
   function synchronizeSplits() {
     isSynchronizingSplits = true;
-    return splitsUpdater().then(function (result) {
+    // `splitsUpdater` promise always resolves, and with a false value if it fails to fetch or store splits
+    return splitsUpdater().then(function (res) {
       isSynchronizingSplits = false;
-      return result; // false if `splitsUpdater` fails to fetch or store splits
+      return res;
     });
   }
 

--- a/src/producer/browser/Full.js
+++ b/src/producer/browser/Full.js
@@ -39,7 +39,7 @@ const FullBrowserProducer = (context) => {
     isSynchronizingSplits = true;
     return splitsUpdater().then(function (result) {
       isSynchronizingSplits = false;
-      return result; // false if the task fail fetching or storing mySegments
+      return result; // false if `splitsUpdater` fails to fetch or store splits
     });
   }
 

--- a/src/producer/browser/Partial.js
+++ b/src/producer/browser/Partial.js
@@ -43,9 +43,10 @@ const PartialBrowserProducer = (context) => {
    */
   function synchronizeMySegments(segmentList) {
     isSynchronizingMySegments = true;
-    return mySegmentsUpdater(0, segmentList).then(function (result) {
+    // `mySegmentsUpdater` promise always resolves, and with a false value if it fails to fetch or store mySegments
+    return mySegmentsUpdater(0, segmentList).then(function (res) {
       isSynchronizingMySegments = false;
-      return result; // false if `mySegmentsUpdater` fails to fetch or store mySegments
+      return res;
     });
   }
 

--- a/src/producer/browser/Partial.js
+++ b/src/producer/browser/Partial.js
@@ -43,7 +43,7 @@ const PartialBrowserProducer = (context) => {
    */
   function synchronizeMySegments(segmentList) {
     isSynchronizingMySegments = true;
-    return mySegmentsUpdater(0, segmentList).finally(function () {
+    return mySegmentsUpdater(0, segmentList).then(function () {
       isSynchronizingMySegments = false;
     });
   }

--- a/src/producer/browser/Partial.js
+++ b/src/producer/browser/Partial.js
@@ -45,7 +45,7 @@ const PartialBrowserProducer = (context) => {
     isSynchronizingMySegments = true;
     return mySegmentsUpdater(0, segmentList).then(function (result) {
       isSynchronizingMySegments = false;
-      return result; // false if the task fail fetching or storing mySegments
+      return result; // false if `mySegmentsUpdater` fails to fetch or store mySegments
     });
   }
 

--- a/src/producer/browser/Partial.js
+++ b/src/producer/browser/Partial.js
@@ -43,8 +43,9 @@ const PartialBrowserProducer = (context) => {
    */
   function synchronizeMySegments(segmentList) {
     isSynchronizingMySegments = true;
-    return mySegmentsUpdater(0, segmentList).then(function () {
+    return mySegmentsUpdater(0, segmentList).then(function (result) {
       isSynchronizingMySegments = false;
+      return result; // false if the task fail fetching or storing mySegments
     });
   }
 

--- a/src/producer/fetcher/MySegments.js
+++ b/src/producer/fetcher/MySegments.js
@@ -32,9 +32,8 @@ const mySegmentsFetcher = (settings, startingUp = false, metricCollectors) => {
 
   // Extract segment names
   return mySegmentsPromise
-    .then(resp => resp.json())
     // JSON parsing errors are handled as SplitErrors, to distinguish from user callback errors
-    .catch(error => { throw new SplitError(error.message); })
+    .then(resp => resp.json().catch(error => { throw new SplitError(error.message); }))
     .then(json => json.mySegments.map(segment => segment.name));
 };
 

--- a/src/producer/fetcher/MySegments.js
+++ b/src/producer/fetcher/MySegments.js
@@ -16,6 +16,7 @@ limitations under the License.
 
 import timeout from '../../utils/promise/timeout';
 import tracker from '../../utils/timeTracker';
+import { SplitError } from '../../utils/lang/Errors';
 import mySegmentsService from '../../services/mySegments';
 import mySegmentsRequest from '../../services/mySegments/get';
 
@@ -32,6 +33,8 @@ const mySegmentsFetcher = (settings, startingUp = false, metricCollectors) => {
   // Extract segment names
   return mySegmentsPromise
     .then(resp => resp.json())
+    // JSON parsing errors are handled as SplitErrors, to distinguish from user callback errors
+    .catch(error => { throw new SplitError(error.message); })
     .then(json => json.mySegments.map(segment => segment.name));
 };
 

--- a/src/producer/fetcher/SplitChanges.js
+++ b/src/producer/fetcher/SplitChanges.js
@@ -31,9 +31,8 @@ function splitChangesFetcher(settings, since, startingUp = false, metricCollecto
   }
 
   return splitsPromise
-    .then(resp => resp.json())
     // JSON parsing errors are handled as SplitErrors, to distinguish from user callback errors
-    .catch(error => { throw new SplitError(error.message); });
+    .then(resp => resp.json().catch(error => { throw new SplitError(error.message); }));
 }
 
 export default splitChangesFetcher;

--- a/src/producer/fetcher/SplitChanges.js
+++ b/src/producer/fetcher/SplitChanges.js
@@ -16,6 +16,7 @@ limitations under the License.
 
 import timeout from '../../utils/promise/timeout';
 import tracker from '../../utils/timeTracker';
+import { SplitError } from '../../utils/lang/Errors';
 import splitChangesService from '../../services/splitChanges';
 import splitChangesRequest from '../../services/splitChanges/get';
 
@@ -29,7 +30,10 @@ function splitChangesFetcher(settings, since, startingUp = false, metricCollecto
     splitsPromise = timeout(settings.startup.requestTimeoutBeforeReady, splitsPromise);
   }
 
-  return splitsPromise.then(resp => resp.json());
+  return splitsPromise
+    .then(resp => resp.json())
+    // JSON parsing errors are handled as SplitErrors, to distinguish from user callback errors
+    .catch(error => { throw new SplitError(error.message); });
 }
 
 export default splitChangesFetcher;

--- a/src/producer/node.js
+++ b/src/producer/node.js
@@ -40,7 +40,6 @@ const NodeUpdater = (context) => {
     return splitsUpdater().then(function () {
       // Mark splits as ready (track first successfull call to start downloading segments)
       splitFetchCompleted = true;
-    }).finally(function () {
       isSynchronizingSplits = false;
     });
   }
@@ -50,7 +49,7 @@ const NodeUpdater = (context) => {
    */
   function synchronizeSegment(segmentNames) {
     isSynchronizingSegments = true;
-    return segmentsUpdater(segmentNames).finally(function () {
+    return segmentsUpdater(segmentNames).then(function () {
       isSynchronizingSegments = false;
     });
   }

--- a/src/producer/node.js
+++ b/src/producer/node.js
@@ -37,11 +37,12 @@ const NodeUpdater = (context) => {
 
   function synchronizeSplits() {
     isSynchronizingSplits = true;
-    return splitsUpdater().then(function (result) {
+    // `splitsUpdater` promise always resolves, and with a false value if it fails to fetch or store splits
+    return splitsUpdater().then(function (res) {
       // Mark splits as ready (track first successfull call to start downloading segments)
       splitFetchCompleted = true;
       isSynchronizingSplits = false;
-      return result; // false if `splitsUpdater` fails to fetch or store splits
+      return res;
     });
   }
 
@@ -50,9 +51,10 @@ const NodeUpdater = (context) => {
    */
   function synchronizeSegment(segmentNames) {
     isSynchronizingSegments = true;
-    return segmentsUpdater(segmentNames).then(function (result) {
+    // `segmentsUpdater` promise always resolves, and with a false value if it fails to fetch or store segments
+    return segmentsUpdater(segmentNames).then(function (res) {
       isSynchronizingSegments = false;
-      return result; // false if `segmentsUpdater` fails to fetch or store segments
+      return res;
     });
   }
 

--- a/src/producer/node.js
+++ b/src/producer/node.js
@@ -41,7 +41,7 @@ const NodeUpdater = (context) => {
       // Mark splits as ready (track first successfull call to start downloading segments)
       splitFetchCompleted = true;
       isSynchronizingSplits = false;
-      return result; // false if the task fail fetching or storing mySegments
+      return result; // false if `splitsUpdater` fails to fetch or store splits
     });
   }
 
@@ -52,7 +52,7 @@ const NodeUpdater = (context) => {
     isSynchronizingSegments = true;
     return segmentsUpdater(segmentNames).then(function (result) {
       isSynchronizingSegments = false;
-      return result; // false if the task fail fetching or storing mySegments
+      return result; // false if `segmentsUpdater` fails to fetch or store segments
     });
   }
 

--- a/src/producer/node.js
+++ b/src/producer/node.js
@@ -37,10 +37,11 @@ const NodeUpdater = (context) => {
 
   function synchronizeSplits() {
     isSynchronizingSplits = true;
-    return splitsUpdater().then(function () {
+    return splitsUpdater().then(function (result) {
       // Mark splits as ready (track first successfull call to start downloading segments)
       splitFetchCompleted = true;
       isSynchronizingSplits = false;
+      return result; // false if the task fail fetching or storing mySegments
     });
   }
 
@@ -49,8 +50,9 @@ const NodeUpdater = (context) => {
    */
   function synchronizeSegment(segmentNames) {
     isSynchronizingSegments = true;
-    return segmentsUpdater(segmentNames).then(function () {
+    return segmentsUpdater(segmentNames).then(function (result) {
       isSynchronizingSegments = false;
+      return result; // false if the task fail fetching or storing mySegments
     });
   }
 

--- a/src/producer/updater/MySegments.js
+++ b/src/producer/updater/MySegments.js
@@ -51,17 +51,20 @@ export default function MySegmentsUpdaterFactory(context) {
    * @param {string[] | undefined} segmentList list of mySegment names to sync in the storage. If the list is `undefined`, it fetches them before syncing in the storage.
    */
   return function MySegmentsUpdater(retry = 0, segmentList) {
-    const updaterPromise = segmentList ?
+    let updaterPromise;
+
+    if (segmentList) {
       // If segmentList is provided, there is no need to fetch mySegments
-      new Promise(() => { updateSegments(segmentList); }) :
+      updaterPromise = new Promise(() => { updateSegments(segmentList); });
+    } else {
       // NOTE: We only collect metrics on startup.
-      mySegmentsFetcher(settings, startingUp, metricCollectors).then(segments => {
-        // Only when we have downloaded segments completely, we should not keep
-        // retrying anymore
+      updaterPromise = mySegmentsFetcher(settings, startingUp, metricCollectors).then(segments => {
+        // Only when we have downloaded segments completely, we should not keep retrying anymore
         startingUp = false;
 
         updateSegments(segments);
       });
+    }
 
     return updaterPromise.catch(error => {
       // handle user callback errors

--- a/src/producer/updater/MySegments.js
+++ b/src/producer/updater/MySegments.js
@@ -19,7 +19,7 @@ import { SplitError } from '../../utils/lang/Errors';
 const log = logFactory('splitio-producer:my-segments');
 import mySegmentsFetcher from '../fetcher/MySegments';
 
-function MySegmentsUpdaterFactory(context) {
+export default function MySegmentsUpdaterFactory(context) {
   const {
     [context.constants.SETTINGS]: settings,
     [context.constants.READINESS]: readiness,
@@ -32,6 +32,7 @@ function MySegmentsUpdaterFactory(context) {
   let readyOnAlreadyExistentState = true;
   let startingUp = true;
 
+  // @TODO when modularizing storage, handle possible errors and async execution of storage.segments.resetSegments
   function updateSegments(segments) {
     // Update the list of segment names available
     const shouldNotifyUpdate = storage.segments.resetSegments(segments);
@@ -43,6 +44,12 @@ function MySegmentsUpdaterFactory(context) {
     }
   }
 
+  /**
+   * MySegments updater returns a promise that resolves with a `false` boolean value if it fails to fetch mySegments or synchronize them with the storage.
+   *
+   * @param {number | undefined} retry current number of retry attemps. this param is only set by SplitChangesUpdater itself.
+   * @param {string[] | undefined} segmentList list of mySegment names to sync in the storage. If the list is `undefined`, it fetches them before syncing in the storage.
+   */
   return function MySegmentsUpdater(retry = 0, segmentList) {
     // If segmentList is provided, there is no need to fetch mySegments
     if (segmentList) {
@@ -74,5 +81,3 @@ function MySegmentsUpdaterFactory(context) {
   };
 
 }
-
-export default MySegmentsUpdaterFactory;

--- a/src/producer/updater/SegmentChanges.js
+++ b/src/producer/updater/SegmentChanges.js
@@ -93,6 +93,7 @@ export default function SegmentChangesUpdaterFactory(context) {
             segmentsEventEmitter.emit(segmentsEventEmitter.SDK_SEGMENTS_ARRIVED);
           }
         }).catch(error => {
+          // handle user callback errors
           if (!(error instanceof SplitError)) setTimeout(() => { throw error; }, 0);
 
           if (error.statusCode === 403) {

--- a/src/producer/updater/SegmentChanges.js
+++ b/src/producer/updater/SegmentChanges.js
@@ -22,7 +22,7 @@ import { findIndex } from '../../utils/lang';
 import { SplitError } from '../../utils/lang/Errors';
 import thenable from '../../utils/promise/thenable';
 
-const SegmentChangesUpdaterFactory = context => {
+export default function SegmentChangesUpdaterFactory(context) {
   const {
     [context.constants.SETTINGS]: settings,
     [context.constants.READINESS]: readiness,
@@ -34,6 +34,8 @@ const SegmentChangesUpdaterFactory = context => {
   let readyOnAlreadyExistentState = true;
 
   /**
+   * Segments updater returns a promise that resolves with a `false` boolean value if it fails to fetch segments or synchronize them with the storage.
+   *
    * @param {string[] | undefined} segmentNames list of segment names to fetch. By passing `undefined` it fetches the list of segments registered at the storage
    */
   return function SegmentChangesUpdater(segmentNames) {
@@ -97,6 +99,8 @@ const SegmentChangesUpdaterFactory = context => {
             context.put(context.constants.DESTROYED, true);
             inputValidationLog.error('Factory instantiation: you passed a Browser type authorizationKey, please grab an Api Key from the Split web console that is of type SDK.');
           }
+
+          return false;
         });
       });
     }
@@ -106,6 +110,4 @@ const SegmentChangesUpdaterFactory = context => {
     return thenable(segments) ? segments.then(segmentsUpdater) : segmentsUpdater(segments);
   };
 
-};
-
-export default SegmentChangesUpdaterFactory;
+}

--- a/src/producer/updater/SplitChanges.js
+++ b/src/producer/updater/SplitChanges.js
@@ -45,7 +45,7 @@ function computeSplitsMutation(entries) {
   return computed;
 }
 
-function SplitChangesUpdaterFactory(context, isNode = false) {
+export default function SplitChangesUpdaterFactory(context, isNode = false) {
   const {
     [context.constants.SETTINGS]: settings,
     [context.constants.READINESS]: readiness,
@@ -57,6 +57,11 @@ function SplitChangesUpdaterFactory(context, isNode = false) {
   let startingUp = true;
   let readyOnAlreadyExistentState = true;
 
+  /**
+   * Split updater returns a promise that resolves with a `false` boolean value if it fails to fetch splits or synchronize them with the storage.
+   *
+   * @param {number | undefined} retry current number of retry attemps. this param is only set by SplitChangesUpdater itself.
+   */
   return function SplitChangesUpdater(retry = 0) {
 
     function splitChanges(since) {
@@ -116,5 +121,3 @@ function SplitChangesUpdaterFactory(context, isNode = false) {
     return sincePromise.then(splitChanges);
   };
 }
-
-export default SplitChangesUpdaterFactory;

--- a/src/producer/updater/SplitChanges.js
+++ b/src/producer/updater/SplitChanges.js
@@ -96,7 +96,7 @@ export default function SplitChangesUpdaterFactory(context, isNode = false) {
             startingUp = false; // Stop retrying.
           }
 
-          log.warn(`Error while doing fetch of Splits ${error}`);
+          log.warn(`Error while doing fetch of Splits. ${error}`);
 
           if (startingUp && settings.startup.retriesOnFailureBeforeReady > retry) {
             retry += 1;

--- a/src/producer/updater/SplitChanges.js
+++ b/src/producer/updater/SplitChanges.js
@@ -78,6 +78,7 @@ export default function SplitChangesUpdaterFactory(context, isNode = false) {
           log.debug(`Segment names collected ${mutation.segments}`);
 
           // Write into storage
+          // @TODO if allowing custom storages, wrap errors as SplitErrors to distinguish from user callback errors
           return Promise.all([
             storage.splits.addSplits(mutation.added),
             storage.splits.removeSplits(mutation.removed),
@@ -91,6 +92,7 @@ export default function SplitChangesUpdaterFactory(context, isNode = false) {
           });
         })
         .catch(error => {
+          // handle user callback errors
           if (!(error instanceof SplitError)) {
             setTimeout(() => { throw error; }, 0);
             startingUp = false; // Stop retrying.

--- a/src/sync/SegmentUpdateWorker/MySegmentUpdateWorker.js
+++ b/src/sync/SegmentUpdateWorker/MySegmentUpdateWorker.js
@@ -29,7 +29,7 @@ export default class MySegmentUpdateWorker {
       this.handleNewEvent = false;
       const currentMaxChangeNumber = this.maxChangeNumber;
       this.mySegmentsProducer.synchronizeMySegments(this.segmentList).then((result) => {
-        if (result !== false) // @TODO remove when revamping producers to use MySegments change number. Currently `MySegmentsUpdater` is resolved with a "false" value if the fetch fails.
+        if (result !== false) // Unlike `Split\SegmentUpdateWorker`, we cannot use `mySegmentsStorage.getChangeNumber` since `/mySegments` endpoint doesn't provide this value.
           this.currentChangeNumber = Math.max(this.currentChangeNumber, currentMaxChangeNumber); // use `currentMaxChangeNumber`, in case that `this.maxChangeNumber` was updated during fetch.
         if (this.handleNewEvent) {
           this.__handleMySegmentUpdateCall();

--- a/src/sync/SegmentUpdateWorker/MySegmentUpdateWorker.js
+++ b/src/sync/SegmentUpdateWorker/MySegmentUpdateWorker.js
@@ -29,7 +29,7 @@ export default class MySegmentUpdateWorker {
       this.handleNewEvent = false;
       const currentMaxChangeNumber = this.maxChangeNumber;
       this.mySegmentsProducer.synchronizeMySegments(this.segmentList).then((result) => {
-        if (result !== false) // @TODO remove when revamping producers. Currently `MySegmentsUpdater` is resolved with a "false" value if the fetch fails.
+        if (result !== false) // @TODO remove when revamping producers to use MySegments change number. Currently `MySegmentsUpdater` is resolved with a "false" value if the fetch fails.
           this.currentChangeNumber = Math.max(this.currentChangeNumber, currentMaxChangeNumber); // use `currentMaxChangeNumber`, in case that `this.maxChangeNumber` was updated during fetch.
         if (this.handleNewEvent) {
           this.__handleMySegmentUpdateCall();


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

- Removed usage of Promise.prototype.finally, to avoid redundant code with promise polyfills.
- Handle JSON parsing errors as `SplitError`, in SplitChanges and MySegments fetchers, to distinguish from errors on user callbacks.
- Updated `SplitChanges\SegmentChanges\MySegmentsUpdater` to be consistent among them: all of them returns a promise that always resolves, and with a `false` value if the updater task fails (either fetch or sync with storage fail).
- Updated `MySegmentsUpdater` to handle `updateSegments` promise uniformly. It is required to properly handle user errors on SKD_UPDATE callbacks.

## How do we test the changes introduced in this PR?

- Updated E2E tests to assert the changes.

## Extra Notes