### PR TITLE
[JS size reduction] Webpack output size limiter

### DIFF
--- a/webpack.ci.prod.js
+++ b/webpack.ci.prod.js
@@ -8,5 +8,9 @@ module.exports = env => merge(common, {
   mode: 'production',
   output: {
     filename: `[name]${env.branch !== 'master' ? `-dev-${env.commit_hash}` : `-${VERSION}`}.min.js`
+  },
+  performance: {
+    hints: 'error', // build fails if asset size exceeded
+    maxAssetSize: 100000 // 120KiB size limit
   }
 });

--- a/webpack.ci.prod.js
+++ b/webpack.ci.prod.js
@@ -11,6 +11,6 @@ module.exports = env => merge(common, {
   },
   performance: {
     hints: 'error', // build fails if asset size exceeded
-    maxAssetSize: 100000 // 120KiB size limit
+    maxAssetSize: 122880 // 120KiB size limit
   }
 });

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -8,5 +8,9 @@ module.exports = merge(common, {
   mode: 'production',
   output: {
     filename: `[name]-${VERSION}.min.js`
+  },
+  performance: {
+    hints: 'error', // build fails if asset size exceeded
+    maxAssetSize: 122880 // 120KiB size limit
   }
 });


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

- Configured Webpack to throw an error when the size of the minified UMD build exceeds a specific limit (120 KiB)

## How do we test the changes introduced in this PR?

## Extra Notes