### PR TITLE
[JS size reduction] add Map ponyfill

### DIFF
--- a/src/engine/__tests__/evaluator/evaluate-features.spec.js
+++ b/src/engine/__tests__/evaluator/evaluate-features.spec.js
@@ -16,6 +16,7 @@ limitations under the License.
 import tape from 'tape';
 import { evaluateFeatures } from '../../evaluator';
 import * as LabelsConstants from '../../../utils/labels';
+import { _Map } from '../../../utils/lang/Maps';
 
 const splitsMock = {
   regular: '{"changeNumber":1487277320548,"trafficAllocationSeed":1667452163,"trafficAllocation":100,"trafficTypeName":"user","name":"always-on","seed":1684183541,"configurations":{},"status":"ACTIVE","killed":false,"defaultTreatment":"off","conditions":[{"conditionType":"ROLLOUT","matcherGroup":{"combiner":"AND","matchers":[{"keySelector":{"trafficType":"user","attribute":""},"matcherType":"ALL_KEYS","negate":false,"userDefinedSegmentMatcherData":{"segmentName":""},"unaryNumericMatcherData":{"dataType":"","value":0},"whitelistMatcherData":{"whitelist":null},"betweenMatcherData":{"dataType":"","start":0,"end":0}}]},"partitions":[{"treatment":"on","size":100},{"treatment":"off","size":0}],"label":"in segment all"}]}',
@@ -37,9 +38,9 @@ const mockStorage = {
       return null;
     },
     fetchMany(names) {
-      const splits = {};
+      const splits = new _Map();
       names.forEach(name => {
-        splits[name] = this.getSplit(name);
+        splits.set(name, this.getSplit(name));
       });
 
       return splits;

--- a/src/engine/__tests__/matchers/dependency.spec.js
+++ b/src/engine/__tests__/matchers/dependency.spec.js
@@ -20,17 +20,18 @@ import tape from 'tape-catch';
 import { types as matcherTypes } from '../../matchers/types';
 import matcherFactory from '../../matchers';
 import { evaluateFeature } from '../../evaluator';
+import { _Map } from '../../../utils/lang/Maps';
 
 const ALWAYS_ON_SPLIT = '{"trafficTypeName":"user","name":"always-on","trafficAllocation":100,"trafficAllocationSeed":1012950810,"seed":-725161385,"status":"ACTIVE","killed":false,"defaultTreatment":"off","changeNumber":1494364996459,"algo":2,"conditions":[{"conditionType":"ROLLOUT","matcherGroup":{"combiner":"AND","matchers":[{"keySelector":{"trafficType":"user","attribute":null},"matcherType":"ALL_KEYS","negate":false,"userDefinedSegmentMatcherData":null,"whitelistMatcherData":null,"unaryNumericMatcherData":null,"betweenMatcherData":null}]},"partitions":[{"treatment":"on","size":100},{"treatment":"off","size":0}],"label":"in segment all"}]}';
 const ALWAYS_OFF_SPLIT = '{"trafficTypeName":"user","name":"always-off","trafficAllocation":100,"trafficAllocationSeed":-331690370,"seed":403891040,"status":"ACTIVE","killed":false,"defaultTreatment":"on","changeNumber":1494365020316,"algo":2,"conditions":[{"conditionType":"ROLLOUT","matcherGroup":{"combiner":"AND","matchers":[{"keySelector":{"trafficType":"user","attribute":null},"matcherType":"ALL_KEYS","negate":false,"userDefinedSegmentMatcherData":null,"whitelistMatcherData":null,"unaryNumericMatcherData":null,"betweenMatcherData":null}]},"partitions":[{"treatment":"on","size":0},{"treatment":"off","size":100}],"label":"in segment all"}]}';
 
-const STORED_SPLITS = {};
-STORED_SPLITS['always-on'] = ALWAYS_ON_SPLIT;
-STORED_SPLITS['always-off'] = ALWAYS_OFF_SPLIT;
+const STORED_SPLITS = new _Map();
+STORED_SPLITS.set('always-on', ALWAYS_ON_SPLIT);
+STORED_SPLITS.set('always-off', ALWAYS_OFF_SPLIT);
 
 const mockStorage = {
   splits: {
-    getSplit: name => STORED_SPLITS[name]
+    getSplit: name => STORED_SPLITS.get(name)
   }
 };
 

--- a/src/engine/evaluator/index.js
+++ b/src/engine/evaluator/index.js
@@ -131,7 +131,7 @@ function getEvaluations(
   const thenables = [];
   splitNames.forEach(splitName => {
     const evaluation = getEvaluation(
-      splits[splitName],
+      splits.get(splitName),
       key,
       attributes,
       storage

--- a/src/storage/SegmentCache/InMemory/browser.js
+++ b/src/storage/SegmentCache/InMemory/browser.js
@@ -1,3 +1,5 @@
+import { _Map } from '../../../utils/lang/Maps';
+
 class SegmentCacheInMemory {
 
   constructor(keys) {
@@ -6,13 +8,13 @@ class SegmentCacheInMemory {
   }
 
   flush() {
-    this.segmentCache = {};
+    this.segmentCache = new _Map();
   }
 
   addToSegment(segmentName/*, segmentKeys: Array<string>*/) {
     const segmentKey = this.keys.buildSegmentNameKey(segmentName);
 
-    this.segmentCache[segmentKey] = true;
+    this.segmentCache.set(segmentKey, true);
 
     return true;
   }
@@ -20,7 +22,7 @@ class SegmentCacheInMemory {
   removeFromSegment(segmentName/*, segmentKeys: Array<string>*/) {
     const segmentKey = this.keys.buildSegmentNameKey(segmentName);
 
-    delete this.segmentCache[segmentKey];
+    this.segmentCache.delete(segmentKey);
 
     return true;
   }
@@ -31,17 +33,15 @@ class SegmentCacheInMemory {
     let isDiff = false;
     let index;
 
-    const storedSegmentKeys = Object.keys(this.segmentCache);
-
     // Extreme fast => everything is empty
-    if (segmentNames.length === 0 && storedSegmentKeys.length === segmentNames.length)
+    if (segmentNames.length === 0 && this.segmentCache.size === segmentNames.length)
       return isDiff;
 
     // Quick path
-    if (storedSegmentKeys.length !== segmentNames.length) {
+    if (this.segmentCache.size !== segmentNames.length) {
       isDiff = true;
 
-      this.segmentCache = {};
+      this.segmentCache = new _Map();
       segmentNames.forEach (s => {
         this.addToSegment(s);
       });
@@ -54,7 +54,7 @@ class SegmentCacheInMemory {
       if (index < segmentNames.length) {
         isDiff = true;
 
-        this.segmentCache = {};
+        this.segmentCache = new Map();
         segmentNames.forEach (s => {
           this.addToSegment(s);
         });
@@ -67,7 +67,7 @@ class SegmentCacheInMemory {
   isInSegment(segmentName/*, key: string*/) {
     const segmentKey = this.keys.buildSegmentNameKey(segmentName);
 
-    return this.segmentCache[segmentKey] === true;
+    return this.segmentCache.get(segmentKey) === true;
   }
 
   setChangeNumber(/*segmentName: string, changeNumber: number*/) {

--- a/src/storage/SegmentCache/InMemory/node.js
+++ b/src/storage/SegmentCache/InMemory/node.js
@@ -1,4 +1,5 @@
 import { numberIsInteger } from '../../../utils/lang';
+import { _Map, mapKeysToArray } from '../../../utils/lang/Maps';
 
 class SegmentCacheInMemory {
 
@@ -8,29 +9,29 @@ class SegmentCacheInMemory {
   }
 
   addToSegment(segmentName, segmentKeys) {
-    const values = this.segmentCache[segmentName];
+    const values = this.segmentCache.get(segmentName);
     const keySet = values ? values : new Set();
 
     segmentKeys.forEach(k => keySet.add(k));
 
-    this.segmentCache[segmentName] = keySet;
+    this.segmentCache.set(segmentName, keySet);
 
     return true;
   }
 
   removeFromSegment(segmentName, segmentKeys) {
-    const values = this.segmentCache[segmentName];
+    const values = this.segmentCache.get(segmentName);
     const keySet = values ? values : new Set();
 
     segmentKeys.forEach(k => keySet.delete(k));
 
-    this.segmentCache[segmentName] = keySet;
+    this.segmentCache.set(segmentName, keySet);
 
     return true;
   }
 
   isInSegment(segmentName, key) {
-    const segmentValues = this.segmentCache[segmentName];
+    const segmentValues = this.segmentCache.get(segmentName);
 
     if (segmentValues) {
       return segmentValues.has(key);
@@ -40,8 +41,8 @@ class SegmentCacheInMemory {
   }
 
   registerSegment(segmentName) {
-    if (!this.segmentCache[segmentName]) {
-      this.segmentCache[segmentName] = new Set();
+    if (!this.segmentCache.has(segmentName)) {
+      this.segmentCache.set(segmentName, new Set);
     }
 
     return true;
@@ -56,27 +57,27 @@ class SegmentCacheInMemory {
   }
 
   getRegisteredSegments() {
-    return Object.keys(this.segmentCache);
+    return mapKeysToArray(this.segmentCache);
   }
 
   setChangeNumber(segmentName, changeNumber) {
     const segmentChangeNumberKey = this.keys.buildSegmentTillKey(segmentName);
 
-    this.segmentChangeNumber[segmentChangeNumberKey] = changeNumber;
+    this.segmentChangeNumber.set(segmentChangeNumberKey, changeNumber);
 
     return true;
   }
 
   getChangeNumber(segmentName) {
     const segmentChangeNumberKey = this.keys.buildSegmentTillKey(segmentName);
-    const value = this.segmentChangeNumber[segmentChangeNumberKey];
+    const value = this.segmentChangeNumber.get(segmentChangeNumberKey);
 
     return numberIsInteger(value) ? value: -1;
   }
 
   flush() {
-    this.segmentCache = {};
-    this.segmentChangeNumber = {};
+    this.segmentCache = new _Map();
+    this.segmentChangeNumber = new _Map();
   }
 }
 

--- a/src/storage/SplitCache/InLocalStorage.js
+++ b/src/storage/SplitCache/InLocalStorage.js
@@ -1,4 +1,5 @@
 import { numberIsFinite, toNumber, numberIsNaN } from '../../utils/lang';
+import { _Map } from '../../utils/lang/Maps';
 import usesSegments from '../../utils/splits/usesSegments';
 import logFactory from '../../utils/logger';
 const log = logFactory('splitio-storage:localstorage');
@@ -205,9 +206,9 @@ class SplitCacheLocalStorage {
    * Fetches multiple splits definitions.
    */
   fetchMany(splitNames) {
-    const splits = {};
+    const splits = new _Map();
     splitNames.forEach(splitName => {
-      splits[splitName] = localStorage.getItem(this.keys.buildSplitKey(splitName));
+      splits.set(splitName, localStorage.getItem(this.keys.buildSplitKey(splitName)));
     });
     return splits;
   }

--- a/src/storage/SplitCache/InMemory.js
+++ b/src/storage/SplitCache/InMemory.js
@@ -1,4 +1,5 @@
 import { numberIsFinite } from '../../utils/lang';
+import { _Map, mapKeysToArray, mapValuesToArray } from '../../utils/lang/Maps';
 import usesSegments from '../../utils/splits/usesSegments';
 import killLocally from './killLocally';
 
@@ -28,7 +29,7 @@ class SplitCacheInMemory {
 
     if (parsedSplit) {
       // Store the Split.
-      this.splitCache[splitName] = split;
+      this.splitCache.set(splitName, split);
       // Update TT cache
       const ttName = parsedSplit.trafficTypeName;
       if (ttName) { // safeguard
@@ -59,7 +60,7 @@ class SplitCacheInMemory {
     const split = this.getSplit(splitName);
     if (split) {
       // Delete the Split
-      delete this.splitCache[splitName];
+      this.splitCache.delete(splitName);
 
       const parsedSplit = JSON.parse(split);
       const ttName = parsedSplit.trafficTypeName;
@@ -85,7 +86,7 @@ class SplitCacheInMemory {
   }
 
   getSplit(splitName) {
-    return this.splitCache[splitName];
+    return this.splitCache.get(splitName);
   }
 
   setChangeNumber(changeNumber) {
@@ -99,11 +100,11 @@ class SplitCacheInMemory {
   }
 
   getAll() {
-    return this.getKeys().map(key => this.splitCache[key]);
+    return mapValuesToArray(this.splitCache);
   }
 
   getKeys() {
-    return Object.keys(this.splitCache);
+    return mapKeysToArray(this.splitCache);
   }
 
   trafficTypeExists(trafficType) {
@@ -115,7 +116,7 @@ class SplitCacheInMemory {
   }
 
   flush() {
-    this.splitCache = {};
+    this.splitCache = new _Map();
     this.ttCache = {};
     this.changeNumber = -1;
     this.splitsWithSegmentsCount = 0;
@@ -125,9 +126,9 @@ class SplitCacheInMemory {
    * Fetches multiple splits definitions.
    */
   fetchMany(splitNames) {
-    const splits = {};
+    const splits = new _Map();
     splitNames.forEach(splitName => {
-      splits[splitName] = this.splitCache[splitName] || null;
+      splits.set(splitName, this.splitCache.get(splitName) || null);
     });
     return splits;
   }

--- a/src/storage/SplitCache/InRedis.js
+++ b/src/storage/SplitCache/InRedis.js
@@ -1,4 +1,5 @@
 import { numberIsFinite, numberIsNaN } from '../../utils/lang';
+import { _Map } from '../../utils/lang/Maps';
 import logFactory from '../../utils/logger';
 const log = logFactory('splitio-storage:redis');
 
@@ -161,12 +162,12 @@ class SplitCacheInRedis {
 
       throw this.redisError;
     }
-    const splits = {};
+    const splits = new _Map();
     const keys = splitNames.map(splitName => this.keys.buildSplitKey(splitName));
     return this.redis.mget(...keys)
       .then(splitDefinitions => {
         splitNames.forEach((splitName, idx) => {
-          splits[splitName] = splitDefinitions[idx];
+          splits.set(splitName, splitDefinitions[idx]);
         });
         return Promise.resolve(splits);
       })

--- a/src/storage/__tests__/SplitCache/InLocalStorage/browser.spec.js
+++ b/src/storage/__tests__/SplitCache/InLocalStorage/browser.spec.js
@@ -13,34 +13,34 @@ tape('SPLIT CACHE / LocalStorage', assert => {
 
   let values = cache.getAll();
 
-  assert.ok( values.indexOf('something') !== -1 );
-  assert.ok( values.indexOf('something else') !== -1 );
+  assert.ok(values.indexOf('something') !== -1);
+  assert.ok(values.indexOf('something else') !== -1);
 
   cache.removeSplit('lol1');
 
   const splits = cache.fetchMany(['lol1', 'lol2']);
-  assert.true(splits['lol1'] === null);
-  assert.true(splits['lol2'] === 'something else');
+  assert.true(splits.get('lol1') === null);
+  assert.true(splits.get('lol2') === 'something else');
 
   values = cache.getAll();
 
-  assert.ok( values.indexOf('something') === -1 );
-  assert.ok( values.indexOf('something else') !== -1 );
+  assert.ok(values.indexOf('something') === -1);
+  assert.ok(values.indexOf('something else') !== -1);
 
-  assert.ok( cache.getSplit('lol1') == null );
-  assert.ok( cache.getSplit('lol2') === 'something else' );
+  assert.ok(cache.getSplit('lol1') == null);
+  assert.ok(cache.getSplit('lol2') === 'something else');
 
-  assert.false( cache.checkCache(), 'checkCache should return false until localstorage has data.' );
+  assert.false(cache.checkCache(), 'checkCache should return false until localstorage has data.');
 
-  assert.ok( cache.getChangeNumber() === -1 );
+  assert.ok(cache.getChangeNumber() === -1);
 
-  assert.false( cache.checkCache(), 'checkCache should return false until localstorage has data.' );
+  assert.false(cache.checkCache(), 'checkCache should return false until localstorage has data.');
 
   cache.setChangeNumber(123);
 
-  assert.true( cache.checkCache(), 'checkCache should return true once localstorage has data.' );
+  assert.true(cache.checkCache(), 'checkCache should return true once localstorage has data.');
 
-  assert.ok( cache.getChangeNumber() === 123 );
+  assert.ok(cache.getChangeNumber() === 123);
 
   assert.end();
 });

--- a/src/storage/__tests__/SplitCache/InMemory.spec.js
+++ b/src/storage/__tests__/SplitCache/InMemory.spec.js
@@ -15,8 +15,8 @@ tape('SPLIT CACHE / In Memory', assert => {
   cache.removeSplit('lol1');
 
   const splits = cache.fetchMany(['lol1', 'lol2']);
-  assert.true(splits['lol1'] === null);
-  assert.true(splits['lol2'] === '{ "name": "something else"}');
+  assert.true(splits.get('lol1') === null);
+  assert.true(splits.get('lol2') === '{ "name": "something else"}');
 
   values = cache.getAll();
 

--- a/src/storage/__tests__/SplitCache/InRedis/node.spec.js
+++ b/src/storage/__tests__/SplitCache/InRedis/node.spec.js
@@ -48,8 +48,8 @@ tape('SPLIT CACHE / Redis', async function (assert) {
   assert.ok( splitNames.indexOf('lol2') !== -1 );
 
   const splits = await cache.fetchMany(['lol1', 'lol2']);
-  assert.ok( splits['lol1'] === null );
-  assert.ok( splits['lol2'] === 'something else' );
+  assert.ok( splits.get('lol1') === null );
+  assert.ok( splits.get('lol2') === 'something else' );
 
   connection.quit();
   assert.end();

--- a/src/utils/lang/Maps.js
+++ b/src/utils/lang/Maps.js
@@ -1,0 +1,76 @@
+/**
+ * Map implementation based on JS objects, with the minimal features used by the SDK.
+ * Support string type as keys and any object as values
+ */
+export class ObjectMap {
+
+  // unlike ES6 `Map`, it doesn't accept an iterable as first argument
+  constructor() {
+    this.clear();
+  }
+
+  clear() {
+    this.items = {};
+  }
+
+
+  set(key, value) {
+    this.items[key] = value;
+    return this;
+  }
+
+  get(key) {
+    return this.items[key];
+  }
+
+  has(key) {
+    return this.items[key] !== undefined;
+  }
+
+  // unlike `Map.prototype.delete`, it doesn't return a boolean indicating if the item was deleted or not
+  delete(key) {
+    delete this.items[key];
+  }
+
+  keys() {
+    return Object.keys(this.items);
+  }
+
+  /** Not used feature */
+  // forEach(callback, thisArg) {
+  //   return Object.keys(this.items).forEach(key => callback.call(thisArg, key, this.items[key]));
+  // }
+
+  get size() {
+    return Object.keys(this.items).length;
+  }
+
+}
+
+export function mapKeysToArray(map) {
+  if (map instanceof ObjectMap) {
+    return Object.keys(map.items);
+  }
+  return Array.from(map.keys());
+}
+
+export function mapValuesToArray(map) {
+  if (map instanceof ObjectMap) {
+    return Object.keys(map.items).map(key => map.items[key]);
+  }
+  // if not using ObjectMap as map, it means both Map and Array.from are supported
+  return Array.from(map.values());
+}
+
+/**
+ * return the Map constructor to use. If native Map is not available or it doesn't support the required features,
+ * a ponyfill with minimal features is returned instead.
+ */
+function getMap() {
+  if(!Array.from || !Map) { //} || new Map(['key', 'value']).size === 0) {
+    return ObjectMap;
+  }
+  return Map;
+}
+
+export const _Map = getMap();

--- a/src/utils/lang/Maps.js
+++ b/src/utils/lang/Maps.js
@@ -13,7 +13,6 @@ export class ObjectMap {
     this.items = {};
   }
 
-
   set(key, value) {
     this.items[key] = value;
     return this;
@@ -66,6 +65,7 @@ export function mapValuesToArray(map) {
  * return the Map constructor to use. If native Map is not available or it doesn't support the required features,
  * a ponyfill with minimal features is returned instead.
  */
+// @TODO review check condition
 function getMap() {
   if(!Array.from || !Map) { //} || new Map(['key', 'value']).size === 0) {
     return ObjectMap;

--- a/src/utils/lang/Maps.js
+++ b/src/utils/lang/Maps.js
@@ -1,76 +1,73 @@
 /**
- * Map implementation based on JS objects, with the minimal features used by the SDK.
- * Support string type as keys and any object as values
+ * Map implementation based on es6-map polyfill (https://github.com/medikoo/es6-map/blob/master/polyfill.js),
+ * with the minimal features used by the SDK.
  */
-export class ObjectMap {
+export class MapPoly {
 
   // unlike ES6 `Map`, it doesn't accept an iterable as first argument
   constructor() {
-    this.clear();
-  }
-
-  clear() {
-    this.items = {};
+    this.__mapKeysData__ = [];
+    this.__mapValuesData__ = [];
   }
 
   set(key, value) {
-    this.items[key] = value;
+    var index = this.__mapKeysData__.indexOf(key);
+    if (index === -1) {
+      index = this.__mapKeysData__.push(key) - 1;
+    }
+    this.__mapValuesData__[index] = value;
     return this;
   }
 
   get(key) {
-    return this.items[key];
+    var index = this.__mapKeysData__.indexOf(key);
+    if (index === -1) return;
+    return this.__mapValuesData__[index];
   }
 
   has(key) {
-    return this.items[key] !== undefined;
+    return this.__mapKeysData__.indexOf(key) !== -1;
   }
 
-  // unlike `Map.prototype.delete`, it doesn't return a boolean indicating if the item was deleted or not
   delete(key) {
-    delete this.items[key];
+    var index = this.__mapKeysData__.indexOf(key);
+    if (index === -1) return false;
+    this.__mapKeysData__.splice(index, 1);
+    this.__mapValuesData__.splice(index, 1);
+    return true;
   }
-
-  keys() {
-    return Object.keys(this.items);
-  }
-
-  /** Not used feature */
-  // forEach(callback, thisArg) {
-  //   return Object.keys(this.items).forEach(key => callback.call(thisArg, key, this.items[key]));
-  // }
 
   get size() {
-    return Object.keys(this.items).length;
+    return this.__mapKeysData__.length;
   }
 
 }
 
 export function mapKeysToArray(map) {
-  if (map instanceof ObjectMap) {
-    return Object.keys(map.items);
+  if (map instanceof MapPoly) {
+    return map.__mapKeysData__.slice();
   }
+  // if not using MapPoly as map, it means both Map.prototype.keys and Array.from are supported
   return Array.from(map.keys());
 }
 
 export function mapValuesToArray(map) {
-  if (map instanceof ObjectMap) {
-    return Object.keys(map.items).map(key => map.items[key]);
+  if (map instanceof MapPoly) {
+    return map.__mapValuesData__.slice();
   }
-  // if not using ObjectMap as map, it means both Map and Array.from are supported
+  // if not using MapPoly as map, it means both Map.prototype.values and Array.from are supported
   return Array.from(map.values());
 }
 
 /**
- * return the Map constructor to use. If native Map is not available or it doesn't support the required features,
+ * return the Map constructor to use. If `Array.from` built-in or native Map is not available or it doesn't support the required features,
  * a ponyfill with minimal features is returned instead.
  */
-// @TODO review check condition
-function getMap() {
-  if(!Array.from || !Map) { //} || new Map(['key', 'value']).size === 0) {
-    return ObjectMap;
+function getMapConstructor() {
+  if (!Array.from || !Map || !Map.prototype.values || !Map.prototype.keys) {
+    return MapPoly;
   }
   return Map;
 }
 
-export const _Map = getMap();
+export const _Map = getMapConstructor();


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

- Added Map polyfill based on popular [ES6 Map Shim](https://www.npmjs.com/package/es6-map), to use if native Map is not available.
- Updated `node/SegmentsCacheInMemory::getRegisteredSegments` to return an array object instead of an iterable (same as the `getRegisteredSegments` method of the other storages)

## How do we test the changes introduced in this PR?

- Suite tests were run with native Map and polyfilled version.

## Extra Notes