### PR TITLE
Fetch specific splits: InLocalStorage cache

### DIFF
--- a/src/__tests__/mocks/fetchSpecificSplits.js
+++ b/src/__tests__/mocks/fetchSpecificSplits.js
@@ -1,6 +1,7 @@
 export const valuesExamples = [
   ['\u0223abc', 'abc\u0223asd', 'abc\u0223'],
-  ['ausgefüllt']
+  ['ausgefüllt'],
+  ['abc\u0223', 'abc\u0223asd', 'ausgefüllt', '\u0223abc'] // [0] + [1] ordered
 ];
 
 export const splitFilters = [
@@ -26,4 +27,19 @@ export const queryStrings = [
   'names=abc%C8%A3,abc%C8%A3asd,ausgef%C3%BCllt,%C8%A3abc',
   'prefixes=abc%C8%A3,abc%C8%A3asd,ausgef%C3%BCllt,%C8%A3abc',
   'names=abc%C8%A3,abc%C8%A3asd,ausgef%C3%BCllt,%C8%A3abc&prefixes=abc%C8%A3,abc%C8%A3asd,ausgef%C3%BCllt,%C8%A3abc'
+];
+
+export const filters = [
+  {
+    byName: valuesExamples[2],
+    byPrefix: undefined
+  },
+  {
+    byName: undefined,
+    byPrefix: valuesExamples[2]
+  },
+  {
+    byName: valuesExamples[2],
+    byPrefix: valuesExamples[2]
+  },
 ];

--- a/src/producer/updater/SplitChanges.js
+++ b/src/producer/updater/SplitChanges.js
@@ -81,9 +81,10 @@ export default function SplitChangesUpdaterFactory(context, isNode = false) {
           // Write into storage
           // @TODO if allowing custom storages, wrap errors as SplitErrors to distinguish from user callback errors
           return Promise.all([
+            // calling first `setChangenumber` method, to perform cache flush if split filter queryString changed
+            storage.splits.setChangeNumber(splitChanges.till),
             storage.splits.addSplits(mutation.added),
             storage.splits.removeSplits(mutation.removed),
-            storage.splits.setChangeNumber(splitChanges.till),
             storage.segments.registerSegments(mutation.segments)
           ]).then(() => {
             if (since !== splitChanges.till || readyOnAlreadyExistentState) {

--- a/src/storage/KeysLocalStorage.js
+++ b/src/storage/KeysLocalStorage.js
@@ -31,6 +31,10 @@ class KeyBuilderForLocalStorage extends KeyBuilder {
   isSplitCacheKey(key) {
     return this.regexSplitCacheKey.test(key);
   }
+
+  buildFilterQueryKey() {
+    return `${this.settings.storage.prefix}.splits.filterQuery`;
+  }
 }
 
 export default KeyBuilderForLocalStorage;

--- a/src/storage/browser.js
+++ b/src/storage/browser.js
@@ -64,7 +64,7 @@ const BrowserStorageFactory = context => {
       const expirationTimestamp = Date.now() - DEFAULT_CACHE_EXPIRATION_IN_MILLIS;
 
       return {
-        splits: new SplitCacheInLocalStorage(keys, expirationTimestamp),
+        splits: new SplitCacheInLocalStorage(keys, expirationTimestamp, settings.sync.splitFilters),
         segments: new SegmentCacheInLocalStorage(keys),
         impressions: new ImpressionsCacheInMemory,
         metrics: new LatencyCacheInMemory,

--- a/src/utils/__tests__/settings/splitFilters.node.spec.js
+++ b/src/utils/__tests__/settings/splitFilters.node.spec.js
@@ -24,7 +24,7 @@ const { splitFiltersBuilder } = proxyquireStrict('../../settings/splitFilters', 
 });
 
 // Split filter and QueryStrings examples
-import { splitFilters, queryStrings } from '../../../__tests__/mocks/fetchSpecificSplits';
+import { splitFilters, queryStrings, filters } from '../../../__tests__/mocks/fetchSpecificSplits';
 
 tape('splitFiltersBuilder', t => {
 
@@ -61,7 +61,7 @@ tape('splitFiltersBuilder', t => {
       { type: 'byName', values: [] },
       { type: 'byName', values: [] },
       { type: 'byPrefix', values: [] }];
-    let output = [...splitFilters]; output.queryString = undefined;
+    let output = [...splitFilters]; output.queryString = undefined; output.filters = { byName: undefined, byPrefix: undefined };
     assert.deepEqual(splitFiltersBuilder({ sync: { splitFilters }, mode: STANDALONE_MODE }), output, 'filters without values');
     assert.true(loggerMock.warn.getCall(0).calledWithExactly('Ignoring byName filter. It has no valid values (no-empty strings).'));
     assert.true(loggerMock.warn.getCall(1).calledWithExactly('Ignoring byPrefix filter. It has no valid values (no-empty strings).'));
@@ -94,6 +94,7 @@ tape('splitFiltersBuilder', t => {
     for (let i = 0; i < splitFilters.length; i++) {
       const output = [...splitFilters[i]];
       output.queryString = queryStrings[i];
+      output.filters = filters[i];
       assert.deepEqual(splitFiltersBuilder({ sync: { splitFilters: splitFilters[i] }, mode: STANDALONE_MODE }), output, `splitFilters #${i}`);
       assert.true(loggerMock.debug.calledWith(`Splits filtering criteria: '${queryStrings[i]}'`));
     }

--- a/src/utils/settings/splitFilters.js
+++ b/src/utils/settings/splitFilters.js
@@ -106,6 +106,7 @@ export function splitFiltersBuilder(settings) {
   // build query string
   validFilters.queryString = queryStringBuilder(filters.byName, filters.byPrefix);
   if (validFilters.queryString) log.debug(`Splits filtering criteria: '${validFilters.queryString}'`);
+  validFilters.filters = filters;
 
   return validFilters;
 }


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

- Updated InLocalStorage cache, to properly handle split data when splits filter query changes.

## How do we test the changes introduced in this PR?

- [TODO] E2E tests

## Extra Notes