### PR TITLE
SDKS-1167: handle user ids containing forward slash or other special characters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,4 +62,4 @@ deploy:
     acl: public_read
     cache_control: "max-age=31536000, public"
     on:
-      branch: temporal_replacement
+      branch: master

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+10.14.1 (Aug XX, 2020)
+ - Bugfixing - added URI encoding of user keys to avoid HTTP errors when fetching MySegments for keys with special characters.
+
 10.14.0 (Jul 31, 2020)
  - Added `sync.splitFilters` property to SDK configuration to pass a list of filters for the splits that will be downloaded. Read more in our docs.
  - Added expiration policy to split cache for browsers using localStorage: cache is cleared after 10 days of the last successful update.

--- a/src/__tests__/browser.spec.js
+++ b/src/__tests__/browser.spec.js
@@ -87,9 +87,9 @@ tape('## E2E CI Tests ##', function(assert) {
 
   fetchMock.get(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
   fetchMock.get(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock2 });
-  fetchMock.get(settings.url('/mySegments/facundo@split.io'), { status: 200, body: mySegmentsFacundo });
-  fetchMock.get(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolas });
-  fetchMock.get(settings.url('/mySegments/marcio@split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.get(settings.url('/mySegments/facundo%40split.io'), { status: 200, body: mySegmentsFacundo });
+  fetchMock.get(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolas });
+  fetchMock.get(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
   fetchMock.post(settings.url('/testImpressions/bulk'), 200);
 
   /* Check client evaluations. */

--- a/src/__tests__/browserSuites/fetch-specific-splits.spec.js
+++ b/src/__tests__/browserSuites/fetch-specific-splits.spec.js
@@ -33,7 +33,7 @@ export default function fetchSpecificSplits(fetchMock, assert) {
         });
         return { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } };
       });
-      fetchMock.get(urls.sdk + '/mySegments/nicolas@split.io', { status: 200, body: { 'mySegments': [] } });
+      fetchMock.get(urls.sdk + '/mySegments/nicolas%40split.io', { status: 200, body: { 'mySegments': [] } });
 
       factory = SplitFactory(config);
 

--- a/src/__tests__/browserSuites/ignore-ip-addresses-setting.spec.js
+++ b/src/__tests__/browserSuites/ignore-ip-addresses-setting.spec.js
@@ -101,7 +101,7 @@ export default function (fetchMock, assert) {
     const settings = SettingsFactory(config);
     fetchMock.getOnce(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
     fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
-    fetchMock.getOnce(settings.url(`/mySegments/${config.core.key}`), { status: 200, body: { mySegments: [] } });
+    fetchMock.getOnce(settings.url(`/mySegments/${encodeURIComponent(config.core.key)}`), { status: 200, body: { mySegments: [] } });
 
     // Init Split client
     const splitio = SplitFactory(config);

--- a/src/__tests__/browserSuites/impressions.spec.js
+++ b/src/__tests__/browserSuites/impressions.spec.js
@@ -21,7 +21,7 @@ export default function (fetchMock, assert) {
   // Mocking this specific route to make sure we only get the items we want to test from the handlers.
   fetchMock.getOnce(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
   fetchMock.get(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock2 });
-  fetchMock.get(settings.url('/mySegments/facundo@split.io'), { status: 200, body: mySegmentsFacundo });
+  fetchMock.get(settings.url('/mySegments/facundo%40split.io'), { status: 200, body: mySegmentsFacundo });
 
   const splitio = SplitFactory({
     core: {

--- a/src/__tests__/browserSuites/push-fallbacking.spec.js
+++ b/src/__tests__/browserSuites/push-fallbacking.spec.js
@@ -189,36 +189,36 @@ export function testFallbacking(fetchMock, assert) {
 
   // initial split and mySegment sync
   fetchMock.getOnce(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 
   // split and segment sync after SSE opened
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 
   // fetches due to first fallback to polling
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_STREAMING_DOWN_OCCUPANCY + settings.scheduler.featuresRefreshRate), 'fetch due to first fallback to polling');
     return { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } };
   });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 
   // split and segment sync due to streaming up (OCCUPANCY event)
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 
   // creating of second client during streaming: initial mysegment sync, reauth and syncAll due to new client
-  fetchMock.getOnce(settings.url('/mySegments/marcio@split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
   fetchMock.getOnce(settings.url(`/auth?users=${encodeURIComponent(userKey)}&users=${encodeURIComponent(secondUserKey)}`), function (url, opts) {
     if (!opts.headers['Authorization']) assert.fail('`/auth` request must include `Authorization` header');
     assert.pass('second auth success');
     return { status: 200, body: authPushEnabledNicolasAndMarcio };
   });
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
-  fetchMock.getOnce(settings.url('/mySegments/marcio@split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
 
   // fetch due to SPLIT_UPDATE event
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
@@ -229,11 +229,11 @@ export function testFallbacking(fetchMock, assert) {
 
   // fetches due to second fallback to polling
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), { status: 200, body: { splits: [], since: 1457552649999, till: 1457552649999 } });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
-  fetchMock.getOnce(settings.url('/mySegments/marcio@split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
 
   // creation of third client during polling: initial mysegment sync and authentication
-  fetchMock.getOnce(settings.url('/mySegments/facundo@split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(settings.url('/mySegments/facundo%40split.io'), { status: 200, body: mySegmentsMarcio });
   // authentication fail, so we keep polling. next auth attempt is scheduled in one second (after the test finishes)
   fetchMock.getOnce(settings.url(`/auth?users=${encodeURIComponent(userKey)}&users=${encodeURIComponent(secondUserKey)}&users=${encodeURIComponent(thirdUserKey)}`), { throws: new TypeError('Network error') });
 
@@ -243,18 +243,18 @@ export function testFallbacking(fetchMock, assert) {
     assert.true(nearlyEqual(lapse, MILLIS_STREAMING_PAUSED_CONTROL + settings.scheduler.featuresRefreshRate), 'fetch due to second fallback to polling');
     return { status: 200, body: { splits: [], since: 1457552649999, till: 1457552649999 } };
   });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
-  fetchMock.getOnce(settings.url('/mySegments/marcio@split.io'), { status: 200, body: mySegmentsMarcio });
-  fetchMock.getOnce(settings.url('/mySegments/facundo@split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(settings.url('/mySegments/facundo%40split.io'), { status: 200, body: mySegmentsMarcio });
 
   // split and segment sync due to streaming up (CONTROL event)
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), { status: 200, body: { splits: [], since: 1457552649999, till: 1457552649999 } });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
-  fetchMock.getOnce(settings.url('/mySegments/marcio@split.io'), { status: 200, body: mySegmentsMarcio });
-  fetchMock.getOnce(settings.url('/mySegments/facundo@split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(settings.url('/mySegments/facundo%40split.io'), { status: 200, body: mySegmentsMarcio });
 
   // fetch due to MY_SEGMENTS_UPDATE event
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), function () {
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_MY_SEGMENTS_UPDATE_EVENT_DURING_PUSH), 'sync due to MY_SEGMENTS_UPDATE event');
     return { status: 200, body: mySegmentsNicolasMock2 };
@@ -262,9 +262,9 @@ export function testFallbacking(fetchMock, assert) {
 
   // fetches due to third fallback to polling (mySegments is not fetched after the first iteration)
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), { status: 200, body: { splits: [], since: 1457552649999, till: 1457552649999 } });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
-  fetchMock.getOnce(settings.url('/mySegments/marcio@split.io'), { status: 200, body: mySegmentsMarcio });
-  fetchMock.getOnce(settings.url('/mySegments/facundo@split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(settings.url('/mySegments/facundo%40split.io'), { status: 200, body: mySegmentsMarcio });
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_STREAMING_DISABLED_CONTROL + settings.scheduler.featuresRefreshRate), 'fetch due to third fallback to polling');

--- a/src/__tests__/browserSuites/push-initialization-nopush.spec.js
+++ b/src/__tests__/browserSuites/push-initialization-nopush.spec.js
@@ -42,7 +42,7 @@ const settings = SettingsFactory(config);
 function testInitializationFail(fetchMock, assert, fallbackToPolling) {
   let start, splitio, client, ready = false;
 
-  fetchMock.get(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolas });
+  fetchMock.get(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolas });
   fetchMock.getOnce(settings.url('/splitChanges?since=-1'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, 0), 'initial sync');

--- a/src/__tests__/browserSuites/push-initialization-retries.spec.js
+++ b/src/__tests__/browserSuites/push-initialization-retries.spec.js
@@ -66,7 +66,7 @@ export function testAuthRetries(fetchMock, assert) {
     assert.true(nearlyEqual(lapse, expected), 'third auth attempt (aproximately in 0.3 seconds from first attempt)');
     return { status: 200, body: authPushDisabled };
   });
-  fetchMock.get({ url: settings.url('/mySegments/nicolas@split.io'), repeat: 4 }, { status: 200, body: mySegmentsNicolasMock });
+  fetchMock.get({ url: settings.url('/mySegments/nicolas%40split.io'), repeat: 4 }, { status: 200, body: mySegmentsNicolasMock });
 
   fetchMock.getOnce(settings.url('/splitChanges?since=-1'), function () {
     console.log('split changes');
@@ -137,7 +137,7 @@ export function testSSERetries(fetchMock, assert) {
     assert.pass('auth success');
     return { status: 200, body: authPushEnabledNicolas };
   });
-  fetchMock.get({ url: settings.url('/mySegments/nicolas@split.io'), repeat: 4 }, { status: 200, body: mySegmentsNicolasMock });
+  fetchMock.get({ url: settings.url('/mySegments/nicolas%40split.io'), repeat: 4 }, { status: 200, body: mySegmentsNicolasMock });
 
   fetchMock.getOnce(settings.url('/splitChanges?since=-1'), function () {
     const lapse = Date.now() - start;
@@ -193,7 +193,7 @@ export function testSdkDestroyWhileAuthSuccess(fetchMock, assert) {
 
   fetchMock.getOnce(settings.url(`/auth?users=${encodeURIComponent(userKey)}`), { status: 200, body: authPushEnabledNicolas }, { delay: 100 });
 
-  fetchMock.get({ url: settings.url('/mySegments/nicolas@split.io'), repeat: 2 }, { status: 200, body: mySegmentsNicolasMock });
+  fetchMock.get({ url: settings.url('/mySegments/nicolas%40split.io'), repeat: 2 }, { status: 200, body: mySegmentsNicolasMock });
   fetchMock.getOnce(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
 
   setTimeout(() => {
@@ -232,7 +232,7 @@ export function testSdkDestroyWhileAuthRetries(fetchMock, assert) {
   fetchMock.getOnce(settings.url(`/auth?users=${encodeURIComponent(userKey)}`), { status: 200, body: authPushBadToken });
   fetchMock.getOnce(settings.url(`/auth?users=${encodeURIComponent(userKey)}`), { throws: new TypeError('Network error') }, { delay: 100 });
 
-  fetchMock.get({ url: settings.url('/mySegments/nicolas@split.io'), repeat: 2 }, { status: 200, body: mySegmentsNicolasMock });
+  fetchMock.get({ url: settings.url('/mySegments/nicolas%40split.io'), repeat: 2 }, { status: 200, body: mySegmentsNicolasMock });
   fetchMock.getOnce(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock2 });
 

--- a/src/__tests__/browserSuites/push-refresh-token.spec.js
+++ b/src/__tests__/browserSuites/push-refresh-token.spec.js
@@ -59,7 +59,7 @@ export function testRefreshToken(fetchMock, assert) {
 
   // initial sync
   fetchMock.getOnce(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 
   // first auth
   fetchMock.getOnce(settings.url(`/auth?users=${encodeURIComponent(userKey)}`), function (url, opts) {
@@ -70,7 +70,7 @@ export function testRefreshToken(fetchMock, assert) {
 
   // sync after SSE opened
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock2 });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 
   // re-auth due to refresh token
   fetchMock.getOnce(settings.url(`/auth?users=${encodeURIComponent(userKey)}`), function (url, opts) {
@@ -86,7 +86,7 @@ export function testRefreshToken(fetchMock, assert) {
     assert.true(nearlyEqual(lapse, MILLIS_REFRESH_TOKEN + MILLIS_SSE_OPEN), 'sync after SSE connection is reopened');
     return { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } };
   });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 
   // second re-auth due to refresh token
   fetchMock.getOnce(settings.url(`/auth?users=${encodeURIComponent(userKey)}`), function (url, opts) {
@@ -105,7 +105,7 @@ export function testRefreshToken(fetchMock, assert) {
     });
     return { status: 500, body: 'server error' };
   });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 
   fetchMock.get(new RegExp('.*'), function (url) {
     assert.fail('unexpected GET request with url: ' + url);

--- a/src/__tests__/browserSuites/push-synchronization-retries.spec.js
+++ b/src/__tests__/browserSuites/push-synchronization-retries.spec.js
@@ -142,7 +142,7 @@ export function testSynchronizationRetries(fetchMock, assert) {
 
   // initial split and mySegments sync
   fetchMock.getOnce(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 
   // split and segment sync after SSE opened
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
@@ -150,7 +150,7 @@ export function testSynchronizationRetries(fetchMock, assert) {
     assert.true(nearlyEqual(lapse, MILLIS_SSE_OPEN), 'sync after SSE connection is opened');
     return { status: 200, body: splitChangesMock2 };
   });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 
   // fetch due to SPLIT_UPDATE event
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock2 });
@@ -162,13 +162,13 @@ export function testSynchronizationRetries(fetchMock, assert) {
   });
 
   // fetch due to first MY_SEGMENTS_UPDATE event
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { throws: new TypeError('Network error') });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { throws: new TypeError('Network error') });
   // fetch retry for MY_SEGMENTS_UPDATE event, due to previous fail
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: '{ "since": 1457552620999, "til' }); // invalid JSON response
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: '{ "since": 1457552620999, "til' }); // invalid JSON response
   // fetch retry for MY_SEGMENTS_UPDATE event, due to previous fail
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 500, body: 'server error' });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 500, body: 'server error' });
   // second fetch retry for MY_SEGMENTS_UPDATE event, due to previous fail
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), function () {
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_THIRD_RETRY_FOR_MYSEGMENT_UPDATE_EVENT), 'sync second retry for MY_SEGMENTS_UPDATE event');
     return { status: 200, body: mySegmentsNicolasMock2 };

--- a/src/__tests__/browserSuites/push-synchronization.spec.js
+++ b/src/__tests__/browserSuites/push-synchronization.spec.js
@@ -201,7 +201,7 @@ export function testSynchronization(fetchMock, assert) {
     assert.true(nearlyEqual(lapse, 0), 'initial sync');
     return { status: 200, body: splitChangesMock1 };
   });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 
   // split and segment sync after SSE opened
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
@@ -209,13 +209,13 @@ export function testSynchronization(fetchMock, assert) {
     assert.true(nearlyEqual(lapse, MILLIS_SSE_OPEN), 'sync after SSE connection is opened');
     return { status: 200, body: splitChangesMock2 };
   });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 
   // fetch due to SPLIT_UPDATE event
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock3 });
 
   // fetch due to first MY_SEGMENTS_UPDATE event
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock2 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock2 });
 
   // fetch due to SPLIT_KILL event
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), function () {
@@ -224,7 +224,7 @@ export function testSynchronization(fetchMock, assert) {
   });
 
   // initial fetch of mySegments for new client
-  fetchMock.getOnce(settings.url('/mySegments/marcio@split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
 
   // split and mySegment sync after second SSE opened
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552650000'), function () {
@@ -232,8 +232,8 @@ export function testSynchronization(fetchMock, assert) {
     assert.true(nearlyEqual(lapse, MILLIS_SECOND_SSE_OPEN), 'sync after second SSE connection is opened');
     return { status: 200, body: { splits: [], since: 1457552650000, till: 1457552650000 } };
   });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas@split.io'), { status: 200, body: mySegmentsNicolasMock2 });
-  fetchMock.getOnce(settings.url('/mySegments/marcio@split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock2 });
+  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
 
   fetchMock.get(new RegExp('.*'), function (url) {
     assert.fail('unexpected GET request with url: ' + url);

--- a/src/__tests__/browserSuites/readiness.spec.js
+++ b/src/__tests__/browserSuites/readiness.spec.js
@@ -36,7 +36,7 @@ export default function (fetchMock, assert) {
     fetchMock.get(testUrls.sdk + '/splitChanges?since=-1', function () {
       return new Promise((res) => { setTimeout(() => { res({ status: 200, body: splitChangesMock1, headers: {} }); }, 5100); });
     });
-    fetchMock.get(testUrls.sdk + '/mySegments/nicolas@split.io', function () {
+    fetchMock.get(testUrls.sdk + '/mySegments/nicolas%40split.io', function () {
       return new Promise((res) => { setTimeout(() => { res({ status: 200, body: mySegmentsNicolas, headers: {} }); }, 4900); });
     });
     fetchMock.get(testUrls.sdk + '/splitChanges?since=1457552620999', { status: 200, body: splitChangesMock2 });
@@ -65,7 +65,7 @@ export default function (fetchMock, assert) {
     fetchMock.get(testUrls.sdk + '/splitChanges?since=-1', function () {
       return new Promise((res) => { setTimeout(() => { res({ status: 200, body: splitChangesMock1, headers: {} }); }, 4900); });
     });
-    fetchMock.get(testUrls.sdk + '/mySegments/nicolas@split.io', function () {
+    fetchMock.get(testUrls.sdk + '/mySegments/nicolas%40split.io', function () {
       return new Promise((res) => { setTimeout(() => { res({ status: 200, body: mySegmentsNicolas, headers: {} }); }, 5100); });
     });
     fetchMock.get(testUrls.sdk + '/splitChanges?since=1457552620999', { status: 200, body: splitChangesMock2 });
@@ -96,7 +96,7 @@ export default function (fetchMock, assert) {
     fetchMock.getOnce(testUrls.sdk + '/splitChanges?since=-1', function () {
       return new Promise((res) => { setTimeout(() => { res({ status: 200, body: splitChangesMock1, headers: {} }); }, 4900); }); // Faster, it should get ready on the retry.
     });
-    fetchMock.get(testUrls.sdk + '/mySegments/nicolas@split.io', function () {
+    fetchMock.get(testUrls.sdk + '/mySegments/nicolas%40split.io', function () {
       return new Promise((res) => { setTimeout(() => { res({ status: 200, body: mySegmentsNicolas, headers: {} }); }, 4900); });
     });
     fetchMock.get(testUrls.sdk + '/splitChanges?since=1457552620999', { status: 200, body: splitChangesMock2 });
@@ -120,7 +120,7 @@ export default function (fetchMock, assert) {
   function mockForSegmentsPauseTest(testUrls, startWithSegments = false) {
     let mySegmentsHits = 0;
 
-    fetchMock.get(new RegExp(`${testUrls.sdk}/mySegments/nicolas\\d?@split.io`), function () { // Mock any mySegments call, so we can test with multiple clients.
+    fetchMock.get(new RegExp(`${testUrls.sdk}/mySegments/nicolas\\d?%40split.io`), function () { // Mock any mySegments call, so we can test with multiple clients.
       mySegmentsHits++;
       return new Promise((res) => { setTimeout(() => { res({ status: 200, body: { mySegments: [] } }); }, mySegmentsEndpointDelay); });
     });

--- a/src/__tests__/browserSuites/ready-from-cache.spec.js
+++ b/src/__tests__/browserSuites/ready-from-cache.spec.js
@@ -94,9 +94,9 @@ export default function (fetchMock, assert) {
 
     fetchMock.get(testUrls.sdk + '/splitChanges?since=-1', { status: 200, body: splitChangesMock1 });
     fetchMock.get(testUrls.sdk + '/splitChanges?since=1457552620999', { status: 200, body: splitChangesMock2 });
-    fetchMock.get(testUrls.sdk + '/mySegments/nicolas@split.io', { status: 200, body: mySegmentsNicolas });
-    fetchMock.get(testUrls.sdk + '/mySegments/nicolas2@split.io', { status: 200, body: { 'mySegments': [] } });
-    fetchMock.get(testUrls.sdk + '/mySegments/nicolas3@split.io', { status: 200, body: { 'mySegments': [] } });
+    fetchMock.get(testUrls.sdk + '/mySegments/nicolas%40split.io', { status: 200, body: mySegmentsNicolas });
+    fetchMock.get(testUrls.sdk + '/mySegments/nicolas2%40split.io', { status: 200, body: { 'mySegments': [] } });
+    fetchMock.get(testUrls.sdk + '/mySegments/nicolas3%40split.io', { status: 200, body: { 'mySegments': [] } });
 
     const splitio = SplitFactory({
       ...baseConfig,
@@ -147,13 +147,13 @@ export default function (fetchMock, assert) {
       return new Promise(res => { setTimeout(() => res({ status: 200, body: { ...splitChangesMock1, since: 25 }, headers: {} }), 200); }); // 400ms is how long it'll take to reply with Splits, no SDK_READY should be emitted before that.
     });
     fetchMock.get(testUrls.sdk + '/splitChanges?since=1457552620999', { status: 200, body: splitChangesMock2 });
-    fetchMock.get(testUrls.sdk + '/mySegments/nicolas@split.io', function () {
+    fetchMock.get(testUrls.sdk + '/mySegments/nicolas%40split.io', function () {
       return new Promise(res => { setTimeout(() => res({ status: 200, body: mySegmentsNicolas, headers: {} }), 400); }); // First client gets segments before splits. No segment cache loading (yet)
     });
-    fetchMock.get(testUrls.sdk + '/mySegments/nicolas2@split.io', function () {
+    fetchMock.get(testUrls.sdk + '/mySegments/nicolas2%40split.io', function () {
       return new Promise(res => { setTimeout(() => res({ status: 200, body: { 'mySegments': [] }, headers: {} }), 700); }); // Second client gets segments after 700ms
     });
-    fetchMock.get(testUrls.sdk + '/mySegments/nicolas3@split.io', function () {
+    fetchMock.get(testUrls.sdk + '/mySegments/nicolas3%40split.io', function () {
       return new Promise(res => { setTimeout(() => res({ status: 200, body: { 'mySegments': [] }, headers: {} }), 1000); }); // Third client mySegments will come after 1s
     });
     fetchMock.postOnce(testUrls.events + '/testImpressions/bulk', 200);
@@ -254,13 +254,13 @@ export default function (fetchMock, assert) {
       return new Promise(res => { setTimeout(() => res({ status: 200, body: { ...splitChangesMock1, since: 25 }, headers: {} }), 200); }); // 400ms is how long it'll take to reply with Splits, no SDK_READY should be emitted before that.
     });
     fetchMock.get(testUrls.sdk + '/splitChanges?since=1457552620999', { status: 200, body: splitChangesMock2 });
-    fetchMock.get(testUrls.sdk + '/mySegments/nicolas@split.io', function () {
+    fetchMock.get(testUrls.sdk + '/mySegments/nicolas%40split.io', function () {
       return new Promise(res => { setTimeout(() => res({ status: 200, body: mySegmentsNicolas, headers: {} }), 400); }); // First client gets segments before splits. No segment cache loading (yet)
     });
-    fetchMock.get(testUrls.sdk + '/mySegments/nicolas2@split.io', function () {
+    fetchMock.get(testUrls.sdk + '/mySegments/nicolas2%40split.io', function () {
       return new Promise(res => { setTimeout(() => res({ status: 200, body: { 'mySegments': [] }, headers: {} }), 700); }); // Second client gets segments after 700ms
     });
-    fetchMock.get(testUrls.sdk + '/mySegments/nicolas3@split.io', function () {
+    fetchMock.get(testUrls.sdk + '/mySegments/nicolas3%40split.io', function () {
       return new Promise(res => { setTimeout(() => res({ status: 200, body: { 'mySegments': [] }, headers: {} }), 1000); }); // Third client mySegments will come after 1s
     });
     fetchMock.postOnce(testUrls.events + '/testImpressions/bulk', 200);
@@ -363,13 +363,13 @@ export default function (fetchMock, assert) {
       return { status: 200, body: splitChangesMock1 };
     });
     fetchMock.get(testUrls.sdk + '/splitChanges?since=1457552620999', { status: 200, body: splitChangesMock2 });
-    fetchMock.get(testUrls.sdk + '/mySegments/nicolas@split.io', function () {
+    fetchMock.get(testUrls.sdk + '/mySegments/nicolas%40split.io', function () {
       return new Promise(res => { setTimeout(() => res({ status: 200, body: mySegmentsNicolas, headers: {} }), 400); }); // First client gets segments before splits. No segment cache loading (yet)
     });
-    fetchMock.get(testUrls.sdk + '/mySegments/nicolas2@split.io', function () {
+    fetchMock.get(testUrls.sdk + '/mySegments/nicolas2%40split.io', function () {
       return new Promise(res => { setTimeout(() => res({ status: 200, body: { 'mySegments': [] }, headers: {} }), 700); }); // Second client gets segments after 700ms
     });
-    fetchMock.get(testUrls.sdk + '/mySegments/nicolas3@split.io', function () {
+    fetchMock.get(testUrls.sdk + '/mySegments/nicolas3%40split.io', function () {
       return new Promise(res => { setTimeout(() => res({ status: 200, body: { 'mySegments': [] }, headers: {} }), 1000); }); // Third client mySegments will come after 1s
     });
     fetchMock.postOnce(testUrls.events + '/testImpressions/bulk', 200);
@@ -470,7 +470,7 @@ export default function (fetchMock, assert) {
 
     fetchMock.getOnce(testUrls.sdk + '/splitChanges?since=-1&names=p1__split,p2__split', { status: 200, body: { splits: [splitDeclarations.p1__split, splitDeclarations.p2__split], since: -1, till: 1457552620999 } }, { delay: 10 }); // short delay to let emit SDK_READY_FROM_CACHE
     // fetchMock.getOnce(testUrls.sdk + '/splitChanges?since=1457552620999&names=p1__split', { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
-    fetchMock.getOnce(testUrls.sdk + '/mySegments/nicolas@split.io', { status: 200, body: { mySegments: [] } });
+    fetchMock.getOnce(testUrls.sdk + '/mySegments/nicolas%40split.io', { status: 200, body: { mySegments: [] } });
 
     localStorage.setItem('some_user_item', 'user_item');
     localStorage.setItem('readyFromCache_5.SPLITIO.splits.till', 25);
@@ -519,7 +519,7 @@ export default function (fetchMock, assert) {
     t.plan(5);
 
     fetchMock.getOnce(testUrls.sdk + '/splitChanges?since=-1&names=p1__split,p2__split', { status: 200, body: { splits: [splitDeclarations.p1__split, splitDeclarations.p2__split], since: -1, till: 1457552620999 } }, { delay: 10 }); // short delay to let emit SDK_READY_FROM_CACHE
-    fetchMock.getOnce(testUrls.sdk + '/mySegments/nicolas@split.io', { status: 200, body: { mySegments: [] } });
+    fetchMock.getOnce(testUrls.sdk + '/mySegments/nicolas%40split.io', { status: 200, body: { mySegments: [] } });
 
     const splitio = SplitFactory({
       ...baseConfig,
@@ -563,7 +563,7 @@ export default function (fetchMock, assert) {
     t.plan(7);
 
     fetchMock.getOnce(testUrls.sdk + '/splitChanges?since=25&names=p2__split&prefixes=p1', { status: 200, body: { splits: [splitDeclarations.p1__split, splitDeclarations.p2__split], since: 25, till: 1457552620999 } }, { delay: 10 }); // short delay to let emit SDK_READY_FROM_CACHE
-    fetchMock.getOnce(testUrls.sdk + '/mySegments/nicolas@split.io', { status: 200, body: { mySegments: [] } });
+    fetchMock.getOnce(testUrls.sdk + '/mySegments/nicolas%40split.io', { status: 200, body: { mySegments: [] } });
 
     localStorage.setItem('some_user_item', 'user_item');
     localStorage.setItem('readyFromCache_6.SPLITIO.splits.till', 25);
@@ -613,7 +613,7 @@ export default function (fetchMock, assert) {
     t.plan(6);
 
     fetchMock.getOnce(testUrls.sdk + '/splitChanges?since=-1&prefixes=p1,p2', { status: 200, body: { splits: [splitDeclarations.p1__split, splitDeclarations.p2__split], since: -1, till: 1457552620999 } }, { delay: 10 }); // short delay to let emit SDK_READY_FROM_CACHE
-    fetchMock.getOnce(testUrls.sdk + '/mySegments/nicolas@split.io', { status: 200, body: { mySegments: [] } });
+    fetchMock.getOnce(testUrls.sdk + '/mySegments/nicolas%40split.io', { status: 200, body: { mySegments: [] } });
 
     localStorage.setItem('some_user_item', 'user_item');
     localStorage.setItem('readyFromCache_7.SPLITIO.splits.till', 25);
@@ -678,7 +678,7 @@ export default function (fetchMock, assert) {
         t.plan(7);
 
         fetchMock.getOnce(testUrls.sdk + '/splitChanges?since=-1', { status: 200, body: { splits: [splitDeclarations.p1__split, splitDeclarations.p2__split, splitDeclarations.p3__split], since: -1, till: 1457552620999 } }, { delay: 10 }); // short delay to let emit SDK_READY_FROM_CACHE
-        fetchMock.getOnce(testUrls.sdk + '/mySegments/nicolas@split.io', { status: 200, body: { mySegments: [] } });
+        fetchMock.getOnce(testUrls.sdk + '/mySegments/nicolas%40split.io', { status: 200, body: { mySegments: [] } });
 
         localStorage.setItem('some_user_item', 'user_item');
         localStorage.setItem('readyFromCache_8.SPLITIO.splits.till', 25);
@@ -732,7 +732,7 @@ export default function (fetchMock, assert) {
     t.plan(7);
 
     fetchMock.getOnce(testUrls.sdk + '/splitChanges?since=-1&names=no%20exist%20trim,no_exist,p3__split&prefixes=no%20exist%20trim,p2', { status: 200, body: { splits: [splitDeclarations.p2__split, splitDeclarations.p3__split], since: -1, till: 1457552620999 } }, { delay: 10 }); // short delay to let emit SDK_READY_FROM_CACHE
-    fetchMock.getOnce(testUrls.sdk + '/mySegments/nicolas@split.io', { status: 200, body: { mySegments: [] } });
+    fetchMock.getOnce(testUrls.sdk + '/mySegments/nicolas%40split.io', { status: 200, body: { mySegments: [] } });
 
     localStorage.setItem('some_user_item', 'user_item');
     localStorage.setItem('readyFromCache_9.SPLITIO.splits.till', 25);

--- a/src/__tests__/browserSuites/ready-promise.spec.js
+++ b/src/__tests__/browserSuites/ready-promise.spec.js
@@ -61,7 +61,7 @@ export default function readyPromiseAssertions(fetchMock, assert) {
     // /splitChanges takes longer than 'requestTimeoutBeforeReady' in both attempts
     fetchMock.getOnce(config.urls.sdk + '/splitChanges?since=-1', splitChangesMock1, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) + 20 });
     fetchMock.getOnce(config.urls.sdk + '/splitChanges?since=-1', splitChangesMock1, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) + 20 });
-    fetchMock.get(config.urls.sdk + '/mySegments/facundo@split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
+    fetchMock.get(config.urls.sdk + '/mySegments/facundo%40split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
     fetchMock.postOnce(config.urls.events + '/testImpressions/bulk', 200);
 
     const splitio = SplitFactory(config);
@@ -108,7 +108,7 @@ export default function readyPromiseAssertions(fetchMock, assert) {
     // /splitChanges takes longer than 'requestTimeoutBeforeReady' only for the first attempt
     fetchMock.getOnce(config.urls.sdk + '/splitChanges?since=-1', splitChangesMock1, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) + 20 });
     fetchMock.getOnce(config.urls.sdk + '/splitChanges?since=-1', splitChangesMock1, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
-    fetchMock.get(config.urls.sdk + '/mySegments/facundo@split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
+    fetchMock.get(config.urls.sdk + '/mySegments/facundo%40split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
     fetchMock.postOnce(config.urls.events + '/testImpressions/bulk', 200);
 
     const splitio = SplitFactory(config);
@@ -157,7 +157,7 @@ export default function readyPromiseAssertions(fetchMock, assert) {
     // /splitChanges takes longer than 'requestTimeoutBeforeReady' only for the first attempt
     fetchMock.getOnce(config.urls.sdk + '/splitChanges?since=-1', splitChangesMock1, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) + 20 });
     fetchMock.getOnce(config.urls.sdk + '/splitChanges?since=-1', splitChangesMock1, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
-    fetchMock.get(config.urls.sdk + '/mySegments/facundo@split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
+    fetchMock.get(config.urls.sdk + '/mySegments/facundo%40split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
     fetchMock.postOnce(config.urls.events + '/testImpressions/bulk', 200);
 
     const splitio = SplitFactory(config);
@@ -227,12 +227,12 @@ export default function readyPromiseAssertions(fetchMock, assert) {
     fetchMock.getOnce(config.urls.sdk + '/splitChanges?since=-1', splitChangesMock1, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) + 20 });
     fetchMock.getOnce(config.urls.sdk + '/splitChanges?since=-1', splitChangesMock1, { delay: refreshTimeMillis });
     // main client endpoint configured to fetch segments before request timeout
-    fetchMock.get(config.urls.sdk + '/mySegments/facundo@split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
+    fetchMock.get(config.urls.sdk + '/mySegments/facundo%40split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
     fetchMock.get(config.urls.sdk + '/splitChanges?since=1457552620999', { splits: [], since: 1457552620999, till: 1457552620999 });
     // shared client endpoint configured to fetch segments immediately, in order to emit SDK_READY as soon as splits arrives
-    fetchMock.get(config.urls.sdk + '/mySegments/nicolas@split.io', mySegmentsFacundo);
+    fetchMock.get(config.urls.sdk + '/mySegments/nicolas%40split.io', mySegmentsFacundo);
     // shared client endpoint configured to emit SDK_READY_TIMED_OUT
-    fetchMock.get(config.urls.sdk + '/mySegments/emiliano@split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.readyTimeout) + 20 });
+    fetchMock.get(config.urls.sdk + '/mySegments/emiliano%40split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.readyTimeout) + 20 });
 
     fetchMock.postOnce(config.urls.events + '/testImpressions/bulk', 200);
 
@@ -307,7 +307,7 @@ export default function readyPromiseAssertions(fetchMock, assert) {
 
     // /splitChanges takes longer than 'requestTimeoutBeforeReady'
     fetchMock.get(config.urls.sdk + '/splitChanges?since=-1', splitChangesMock1, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) + 20 });
-    fetchMock.get(config.urls.sdk + '/mySegments/facundo@split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
+    fetchMock.get(config.urls.sdk + '/mySegments/facundo%40split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
     fetchMock.postOnce(config.urls.events + '/testImpressions/bulk', 200);
 
     const splitio = SplitFactory(config);
@@ -356,7 +356,7 @@ export default function readyPromiseAssertions(fetchMock, assert) {
 
     // Both /splitChanges and /mySegments take less than 'requestTimeoutBeforeReady'
     fetchMock.get(config.urls.sdk + '/splitChanges?since=-1', splitChangesMock1, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
-    fetchMock.get(config.urls.sdk + '/mySegments/facundo@split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
+    fetchMock.get(config.urls.sdk + '/mySegments/facundo%40split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
     fetchMock.postOnce(config.urls.events + '/testImpressions/bulk', 200);
 
     const splitio = SplitFactory(config);
@@ -403,7 +403,7 @@ export default function readyPromiseAssertions(fetchMock, assert) {
     // /splitChanges takes longer than 'requestTimeoutBeforeReady' only for the first attempt
     fetchMock.getOnce(config.urls.sdk + '/splitChanges?since=-1', splitChangesMock1, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) + 20 });
     fetchMock.getOnce(config.urls.sdk + '/splitChanges?since=-1', splitChangesMock1, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
-    fetchMock.get(config.urls.sdk + '/mySegments/facundo@split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
+    fetchMock.get(config.urls.sdk + '/mySegments/facundo%40split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
     fetchMock.postOnce(config.urls.events + '/testImpressions/bulk', 200);
 
     const splitio = SplitFactory(config);
@@ -494,9 +494,9 @@ export default function readyPromiseAssertions(fetchMock, assert) {
     // /splitChanges takes longer than 'requestTimeoutBeforeReady' only for the first attempt
     fetchMock.getOnce(config.urls.sdk + '/splitChanges?since=-1', splitChangesMock1, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) + 20 });
     fetchMock.getOnce(config.urls.sdk + '/splitChanges?since=-1', splitChangesMock1, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
-    fetchMock.get(config.urls.sdk + '/mySegments/facundo@split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
-    fetchMock.get(config.urls.sdk + '/mySegments/nicolas@split.io', mySegmentsFacundo);
-    fetchMock.get(config.urls.sdk + '/mySegments/emiliano@split.io', mySegmentsFacundo);
+    fetchMock.get(config.urls.sdk + '/mySegments/facundo%40split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
+    fetchMock.get(config.urls.sdk + '/mySegments/nicolas%40split.io', mySegmentsFacundo);
+    fetchMock.get(config.urls.sdk + '/mySegments/emiliano%40split.io', mySegmentsFacundo);
     fetchMock.postOnce(config.urls.events + '/testImpressions/bulk', 200);
 
     const splitio = SplitFactory(config);
@@ -578,8 +578,8 @@ export default function readyPromiseAssertions(fetchMock, assert) {
 
     // /splitChanges takes longer than 'requestTimeoutBeforeReady'
     fetchMock.get(config.urls.sdk + '/splitChanges?since=-1', splitChangesMock1, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) + 20 });
-    fetchMock.get(config.urls.sdk + '/mySegments/facundo@split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
-    fetchMock.get(config.urls.sdk + '/mySegments/nicolas@split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
+    fetchMock.get(config.urls.sdk + '/mySegments/facundo%40split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
+    fetchMock.get(config.urls.sdk + '/mySegments/nicolas%40split.io', mySegmentsFacundo, { delay: fromSecondsToMillis(config.startup.requestTimeoutBeforeReady) - 20 });
     fetchMock.postOnce(config.urls.events + '/testImpressions/bulk', 200);
 
     const splitio = SplitFactory(config);

--- a/src/__tests__/browserSuites/shared-instantiation.spec.js
+++ b/src/__tests__/browserSuites/shared-instantiation.spec.js
@@ -9,8 +9,8 @@ const settings = SettingsFactory({
 
 export default function (startWithTT, fetchMock, assert) {
   // mocking mySegments endpoints with delays for new clients
-  fetchMock.get(settings.url('/mySegments/emiliano@split.io'), { status: 200, body: { mySegments: [] } }, { delay: 100 });
-  fetchMock.get(settings.url('/mySegments/matias@split.io'), { status: 200, body: { mySegments: [] } }, { delay: 200 });
+  fetchMock.get(settings.url('/mySegments/emiliano%40split.io'), { status: 200, body: { mySegments: [] } }, { delay: 100 });
+  fetchMock.get(settings.url('/mySegments/matias%40split.io'), { status: 200, body: { mySegments: [] } }, { delay: 200 });
 
   const factory = SplitFactory({
     core: {

--- a/src/__tests__/browserSuites/shared-instantiation.spec.js
+++ b/src/__tests__/browserSuites/shared-instantiation.spec.js
@@ -9,8 +9,8 @@ const settings = SettingsFactory({
 
 export default function (startWithTT, fetchMock, assert) {
   // mocking mySegments endpoints with delays for new clients
-  fetchMock.get(settings.url('/mySegments/emiliano%40split.io'), { status: 200, body: { mySegments: [] } }, { delay: 100 });
-  fetchMock.get(settings.url('/mySegments/matias%40split.io'), { status: 200, body: { mySegments: [] } }, { delay: 200 });
+  fetchMock.get(settings.url('/mySegments/emiliano%2Fsplit.io'), { status: 200, body: { mySegments: [] } }, { delay: 100 });
+  fetchMock.get(settings.url('/mySegments/matias%25split.io'), { status: 200, body: { mySegments: [] } }, { delay: 200 });
 
   const factory = SplitFactory({
     core: {
@@ -30,8 +30,8 @@ export default function (startWithTT, fetchMock, assert) {
 
   let nicolasClient = factory.client('nicolas@split.io', 'nico_tt');
   let marcioClient = factory.client('marcio@split.io');
-  let emilianoClient = factory.client('emiliano@split.io');
-  let matiasClient = factory.client('matias@split.io');
+  let emilianoClient = factory.client('emiliano/split.io');
+  let matiasClient = factory.client('matias%split.io');
 
   assert.throws(factory.client.bind(factory, null), 'Calling factory.client() with a key parameter that is not a valid key should throw.');
   assert.throws(factory.client.bind(factory, {}), 'Calling factory.client() with a key parameter that is not a valid key should throw.');
@@ -140,7 +140,7 @@ export default function (startWithTT, fetchMock, assert) {
     getTreatmentsAssertions(emilianoClient, expectControls);
 
     emilianoClient.ready().then(() => {
-      assert.comment('Shared instance - emiliano@split.io');
+      assert.comment('Shared instance - emiliano/split.io');
       getTreatmentsAssertions(emilianoClient, ['off', 'on', 'off', 'off']);
     });
   });
@@ -160,11 +160,11 @@ export default function (startWithTT, fetchMock, assert) {
     matiasClient.on(matiasClient.Event.SDK_READY, () => {
       getTreatmentsAssertions(matiasClient, ['off', 'on', 'off', 'off']);
       matiasClient.ready().then(() => {
-        assert.comment('Shared instance - matias@split.io');
+        assert.comment('Shared instance - matias%split.io');
         getTreatmentsAssertions(matiasClient, ['off', 'on', 'off', 'off']);
       });
     });
-    assert.comment('Shared instance - matias@split.io');
+    assert.comment('Shared instance - matias%split.io');
     getTreatmentsAssertions(matiasClient, expectControls);
   });
 }

--- a/src/__tests__/browserSuites/use-beacon-api.spec.js
+++ b/src/__tests__/browserSuites/use-beacon-api.spec.js
@@ -68,7 +68,7 @@ function beaconApiNotSendTest(fetchMock, assert) {
   // Mocking this specific route to make sure we only get the items we want to test from the handlers.
   fetchMock.get(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
   fetchMock.get(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
-  fetchMock.get(settings.url('/mySegments/facundo@split.io'), { status: 200, body: mySegmentsFacundo });
+  fetchMock.get(settings.url('/mySegments/facundo%40split.io'), { status: 200, body: mySegmentsFacundo });
 
   // Init and run Split client
   const splitio = SplitFactory(config);

--- a/src/__tests__/errorCatching/browser.spec.js
+++ b/src/__tests__/errorCatching/browser.spec.js
@@ -21,7 +21,7 @@ fetchMock.get(settings.url('/splitChanges?since=-1'), function () {
 });
 fetchMock.get(settings.url('/splitChanges?since=1500492097547'), { status: 200, body: splitChangesMock2 });
 fetchMock.get(settings.url('/splitChanges?since=1500492297547'), { status: 200, body: splitChangesMock3 });
-fetchMock.get(settings.url('/mySegments/nico@split.io'), { status: 200, body: mySegmentsMock });
+fetchMock.get(settings.url('/mySegments/nico%40split.io'), { status: 200, body: mySegmentsMock });
 fetchMock.post('*', 200);
 
 const assertionsPlanned = 3;

--- a/src/__tests__/gaIntegration/browser.spec.js
+++ b/src/__tests__/gaIntegration/browser.spec.js
@@ -18,7 +18,7 @@ const settings = SettingsFactory({
 tape('## E2E CI Tests ##', function(assert) {
 
   fetchMock.get(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
-  fetchMock.get(settings.url('/mySegments/facundo@split.io'), { status: 200, body: mySegmentsFacundo });
+  fetchMock.get(settings.url('/mySegments/facundo%40split.io'), { status: 200, body: mySegmentsFacundo });
 
   /* Validate GA integration */
   assert.test('E2E / GA-to-Split', gaToSplitSuite.bind(null, fetchMock));

--- a/src/services/mySegments/get.js
+++ b/src/services/mySegments/get.js
@@ -17,5 +17,11 @@ import base from '../request';
 import { matching } from '../../utils/key/factory';
 
 export default function GET(settings) {
-  return base(settings, `/mySegments/${matching(settings.core.key)}`);
+  /**
+   * URI encoding of user keys in order to:
+   *  - avoid 400 responses (due to URI malformed). E.g.: '/api/mySegments/%'
+   *  - avoid 404 responses. E.g.: '/api/mySegments/foo/bar'
+   *  - match user keys with special characters. E.g.: 'foo%bar', 'foo/bar'
+   */
+  return base(settings, `/mySegments/${encodeURIComponent(matching(settings.core.key))}`);
 }


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

- URI encoding of special characters of user keys in order to:
  - avoid 400 responses (due to URI malformed). E.g.: '/api/mySegments/%'
  - avoid 404 responses. E.g.: '/api/mySegments/foo/bar'
  - match user keys with special characters. E.g.: 'foo%bar', 'foo/bar'

- No need to encode segment names, since both the UI and the Public REST API don’t allow segments with special characters.

## How do we test the changes introduced in this PR?

- Mocked URLs of E2E tests and some user keys were updated to include special characters.
- In a production environment, mySegments requests were tested to assert being executed as expected with encoded characters.

## Extra Notes