### PR TITLE
SegmentUpdateWorker patch

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+10.14.1 (Aug XX, 2020)
+ - Updated push streaming support for Node to optimize segment requests.
+
 10.14.0 (Jul 31, 2020)
  - Added `sync.splitFilters` property to SDK configuration to pass a list of filters for the splits that will be downloaded. Read more in our docs.
  - Added expiration policy to split cache for browsers using localStorage: cache is cleared after 10 days of the last successful update.

--- a/src/__tests__/nodeSuites/metrics.spec.js
+++ b/src/__tests__/nodeSuites/metrics.spec.js
@@ -41,6 +41,7 @@ export default async function(key, fetchMock, assert) {
   fetchMock.getOnce(segmentChangesUrlRegex, { status: 200, body: { since:10, till:10, name: 'segmentName', added: [], removed: [] } });
   fetchMock.getOnce(segmentChangesUrlRegex, 401);
   fetchMock.getOnce(segmentChangesUrlRegex, 500);
+  fetchMock.getOnce(segmentChangesUrlRegex, { status: 200, body: '{ INVALID JSON' });
   fetchMock.get(segmentChangesUrlRegex, { status: 200, body: {since:10, till:10, name: 'segmentName' + Date.now(), added: [], removed: []} });
   // Should not execute but adding just in case.
   fetchMock.get(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock2 });

--- a/src/__tests__/nodeSuites/push-synchronization-retries.spec.js
+++ b/src/__tests__/nodeSuites/push-synchronization-retries.spec.js
@@ -58,7 +58,7 @@ const MILLIS_THIRD_RETRY_FOR_SPLIT_KILL_EVENT = 2000;
  *
  *  0.4 secs: SPLIT_UPDATE event with old changeNumber -> SDK_UPDATE not triggered
  *
- *  0.5 secs: SEGMENT_UPDATE event -> /segmentChanges/*: outdated response
+ *  0.5 secs: SEGMENT_UPDATE event -> /segmentChanges/*: server error (cannot test outdated response, since it is not supported)
  *  0.6 secs: SEGMENT_UPDATE event -> /segmentChanges/* retry: network error
  *  0.8 secs: SEGMENT_UPDATE event -> /segmentChanges/* retry: invalid JSON response
  *  1.2 secs: SEGMENT_UPDATE event -> /segmentChanges/* retry: success -> SDK_UPDATE triggered
@@ -166,7 +166,8 @@ export function testSynchronizationRetries(fetchMock, assert) {
   fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=1457552620999'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_SEGMENT_UPDATE_EVENT), 'sync due to SEGMENT_UPDATE event');
-    return { status: 200, body: { since: 1457552620999, till: 1457552620999, name: 'splitters', added: [], removed: [] } }; // outdated response
+    return { status: 500, body: 'server error' }; // server error
+    // return { status: 200, body: { since: 1457552620999, till: 1457552620999, name: 'splitters', added: [], removed: [] } }; // outdated response is not handled currently
   });
   // first fetch retry for SEGMENT_UPDATE event, due to previous unexpected response (response till minor than SEGMENT_UPDATE changeNumber)
   fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=1457552620999'), { throws: new TypeError('Network error') });

--- a/src/producer/fetcher/SegmentChanges.js
+++ b/src/producer/fetcher/SegmentChanges.js
@@ -17,15 +17,14 @@ limitations under the License.
 import segmentChangesService from '../../services/segmentChanges';
 import segmentChangesRequest from '../../services/segmentChanges/get';
 import tracker from '../../utils/timeTracker';
-import { SplitError } from '../../utils/lang/Errors';
 
 function greedyFetch(settings, lastSinceValue, segmentName, metricCollectors) {
   return tracker.start(tracker.TaskNames.SEGMENTS_FETCH, metricCollectors, segmentChangesService(segmentChangesRequest(settings, {
     since: lastSinceValue,
     segmentName
   })))
-    // JSON parsing errors are handled as SplitErrors, to distinguish from user callback errors
-    .then(resp => resp.json().catch(error => { throw new SplitError(error.message); }))
+    // no need to handle json parsing errors as SplitError, since errors are handled differently for segments
+    .then(resp => resp.json())
     .then(json => {
       let { since, till } = json;
       if (since === till) {

--- a/src/sync/AuthClient/index.js
+++ b/src/sync/AuthClient/index.js
@@ -14,6 +14,7 @@ import { decodeJWTtoken } from '../../utils/jwt';
 export default function authenticate(settings, userKeys) {
   let authPromise = authService(authRequest(settings, userKeys)); // errors handled by authService
   return authPromise
+    // no need to handle json parsing errors as SplitError, since no user callbacks are executed after this promise is resolved
     .then(resp => resp.json())
     .then(json => {
       if (json.token) { // empty token when `"pushEnabled": false`

--- a/src/sync/SegmentUpdateWorker/SegmentUpdateWorker.js
+++ b/src/sync/SegmentUpdateWorker/SegmentUpdateWorker.js
@@ -20,7 +20,7 @@ export default class SegmentUpdateWorker {
 
   // Private method
   // Preconditions: this.segmentsProducer.isSynchronizingSegments === false
-  // Approach similar than MySegmentUpdateWorker due to difference on Segments notification and endpoint changeNumber
+  // Approach similar to MySegmentUpdateWorker due to differences on Segments notifications and endpoint changeNumbers
   __handleSegmentUpdateCall() {
     const segmentsToFetch = Object.keys(this.maxChangeNumbers).filter((segmentName) => {
       return this.maxChangeNumbers[segmentName] > this.segmentsStorage.getChangeNumber(segmentName);
@@ -29,7 +29,7 @@ export default class SegmentUpdateWorker {
       this.handleNewEvent = false;
       const currentMaxChangeNumbers = segmentsToFetch.map(segmentToFetch => this.maxChangeNumbers[segmentToFetch]);
       this.segmentsProducer.synchronizeSegment(segmentsToFetch).then((result) => {
-        if (result !== false) // Unlike `SplitUpdateWorker` where changeNumber is consistent between notification and endpoint, we must reset the `maxChangeNumbers` of those segments that were fetched and not updated by a new notification.
+        if (result !== false) // Unlike `SplitUpdateWorker` where changeNumber is consistent between notification and endpoint, we must reset the `maxChangeNumbers` of those segments that were properly fetched and not updated by a new notification.
           segmentsToFetch.forEach((fetchedSegment, index) => {
             if (this.maxChangeNumbers[fetchedSegment] === currentMaxChangeNumbers[index])
               this.maxChangeNumbers[fetchedSegment] = this.segmentsStorage.getChangeNumber(fetchedSegment);

--- a/src/sync/SegmentUpdateWorker/SegmentUpdateWorker.js
+++ b/src/sync/SegmentUpdateWorker/SegmentUpdateWorker.js
@@ -28,16 +28,22 @@ export default class SegmentUpdateWorker {
     if (segmentsToFetch.length > 0) {
       this.handleNewEvent = false;
       const currentMaxChangeNumbers = segmentsToFetch.map(segmentToFetch => this.maxChangeNumbers[segmentToFetch]);
+
       this.segmentsProducer.synchronizeSegment(segmentsToFetch).then((result) => {
-        if (result !== false) // Unlike `SplitUpdateWorker` where changeNumber is consistent between notification and endpoint, we must reset the `maxChangeNumbers` of those segments that were properly fetched and not updated by a new notification.
+        // Unlike `SplitUpdateWorker` where changeNumber is consistent between notification and endpoint, if there is no error,
+        // we must clean the `maxChangeNumbers` of those segments that didn't receive a new update notification during the fetch.
+        if (result !== false) {
           segmentsToFetch.forEach((fetchedSegment, index) => {
-            if (this.maxChangeNumbers[fetchedSegment] === currentMaxChangeNumbers[index])
-              this.maxChangeNumbers[fetchedSegment] = this.segmentsStorage.getChangeNumber(fetchedSegment);
+            if (this.maxChangeNumbers[fetchedSegment] === currentMaxChangeNumbers[index]) this.maxChangeNumbers[fetchedSegment] = -1;
           });
+        } else {
+          // recursive invocation with backoff if there was some error
+          this.backoff.scheduleCall();
+        }
+
+        // immediate recursive invocation if a new notification was queued during fetch
         if (this.handleNewEvent) {
           this.__handleSegmentUpdateCall();
-        } else {
-          this.backoff.scheduleCall();
         }
       });
     }

--- a/src/sync/__tests__/SegmentUpdateWorker/node.spec.js
+++ b/src/sync/__tests__/SegmentUpdateWorker/node.spec.js
@@ -95,7 +95,7 @@ tape('SegmentUpdateWorker', t => {
         producer.__resolveSegmentsUpdaterCall(2, { 'mocked_segment_1': 105 }); // resolve third call to `synchronizeSegment`
         setTimeout(() => {
           assert.equal(producer.synchronizeSegment.callCount, 3, 'doesn\'t recall `synchronizeSegment` if fetched changeNumbers are not the expected (i.e., are different from the queued items)');
-          assert.deepEqual(segmentUpdateWorker.maxChangeNumbers, { 'mocked_segment_1': 105, 'mocked_segment_2': 100, 'mocked_segment_3': 94 }, 'maxChangeNumbers');
+          assert.deepEqual(segmentUpdateWorker.maxChangeNumbers, { 'mocked_segment_1': -1, 'mocked_segment_2': -1, 'mocked_segment_3': -1 }, 'maxChangeNumbers were cleaned');
 
           // assert restarting retries, when a newer event is queued
           segmentUpdateWorker.put(110, 'mocked_segment_1'); // queued

--- a/src/sync/__tests__/SegmentUpdateWorker/node.spec.js
+++ b/src/sync/__tests__/SegmentUpdateWorker/node.spec.js
@@ -82,17 +82,19 @@ tape('SegmentUpdateWorker', t => {
       assert.true(producer.synchronizeSegment.lastCall.calledWithExactly(['mocked_segment_1', 'mocked_segment_2', 'mocked_segment_3']), 'calls `synchronizeSegment` with segmentName');
       assert.equal(segmentUpdateWorker.backoff.attempts, 0, 'no retry scheduled if synchronization success (changeNumbers are the expected)');
 
-      // assert reschedule synchronization if some changeNumber is not updated as expected
+      // assert not rescheduling synchronization if some changeNumber is not updated as expected,
+      // but rescheduling if a new item was queued with a greater changeNumber while the fetch was pending.
+      segmentUpdateWorker.put(110, 'mocked_segment_1');
       producer.__resolveSegmentsUpdaterCall(1, { 'mocked_segment_1': 100, 'mocked_segment_2': 100, 'mocked_segment_3': 94 });
       setTimeout(() => {
-        assert.equal(producer.synchronizeSegment.callCount, 3, 'recalls `synchronizeSegment` if synchronization fail (one changeNumber is not the expected)');
-        assert.true(producer.synchronizeSegment.lastCall.calledWithExactly(['mocked_segment_1']), 'calls `synchronizeSegment` with the segmentName that failed to fetch');
-        assert.equal(segmentUpdateWorker.backoff.attempts, 1, 'retry scheduled since synchronization failed (one changeNumber is not the expected)');
+        assert.equal(producer.synchronizeSegment.callCount, 3, 'recalls `synchronizeSegment` if a new item was queued with a greater changeNumber while the fetch was pending');
+        assert.true(producer.synchronizeSegment.lastCall.calledWithExactly(['mocked_segment_1']), 'calls `synchronizeSegment` with the segmentName that was queued with a greater changeNumber while the fetch was pending');
+        assert.equal(segmentUpdateWorker.backoff.attempts, 0, 'doesn\'t retry backoff schedule since a new item was queued');
 
         // assert dequeueing remaining events
-        producer.__resolveSegmentsUpdaterCall(1, { 'mocked_segment_1': 105 }); // resolve third call to `synchronizeSegment`
+        producer.__resolveSegmentsUpdaterCall(2, { 'mocked_segment_1': 105 }); // resolve third call to `synchronizeSegment`
         setTimeout(() => {
-          assert.equal(producer.synchronizeSegment.callCount, 3, 'doesn\'t call `synchronizeSegment` again');
+          assert.equal(producer.synchronizeSegment.callCount, 3, 'doesn\'t recall `synchronizeSegment` if fetched changeNumbers are not the expected (i.e., are different from the queued items)');
           assert.deepEqual(segmentUpdateWorker.maxChangeNumbers, { 'mocked_segment_1': 105, 'mocked_segment_2': 100, 'mocked_segment_3': 94 }, 'maxChangeNumbers');
 
           // assert restarting retries, when a newer event is queued


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

- Updated SegmentUpdateWorker to surpass difference on changeNumber of segment notification and endpoint.
- Handling JSON parsing errors on `/segmentChanges` requests.

## How do we test the changes introduced in this PR?

- Updated E2E and Unit tests

## Extra Notes