### PR TITLE
Fix import issue for webpack 5

### DIFF
--- a/src/utils/settings/index.js
+++ b/src/utils/settings/index.js
@@ -25,9 +25,10 @@ import mode from './mode';
 import validateSplitFilters from '../inputValidation/splitFilters';
 import { API } from '../../utils/logger';
 import { STANDALONE_MODE, STORAGE_MEMORY, CONSUMER_MODE, OPTIMIZED } from '../../utils/constants';
-import { version } from '../../../package.json';
+import packageJSON from '../../../package.json';
 import validImpressionsMode from './impressionsMode';
 
+const { version } = packageJSON
 const eventsEndpointMatcher = /^\/(testImpressions|metrics|events)/;
 const authEndpointMatcher = /^\/auth/;
 const streamingEndpointMatcher = /^\/(sse|event-stream)/;

--- a/src/utils/settings/index.js
+++ b/src/utils/settings/index.js
@@ -28,7 +28,7 @@ import { STANDALONE_MODE, STORAGE_MEMORY, CONSUMER_MODE, OPTIMIZED } from '../..
 import packageJSON from '../../../package.json';
 import validImpressionsMode from './impressionsMode';
 
-const { version } = packageJSON
+const { version } = packageJSON;
 const eventsEndpointMatcher = /^\/(testImpressions|metrics|events)/;
 const authEndpointMatcher = /^\/auth/;
 const streamingEndpointMatcher = /^\/(sse|event-stream)/;


### PR DESCRIPTION
# JS SDK

## What did you accomplish?
resolve issue that blocks webpack 5 from being able to complete a build.
```Should not import the named export 'version' (imported as 'version') from default-exporting module (only default export is available soon)```
## How do we test the changes introduced in this PR?
Nonbreaking change, all existing tests should be passing.
## Extra Notes