### PR TITLE
Impr beacon mode

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+10.15.2 (Dec 2, 2020)
+ - Updated requests for `/testImpressions/beacon` to include the impressions mode.
+
 10.15.1 (Nov 12, 2020)
  - Updated the version for ioredis in the package.json to be fixed to 4.18.0 given after 4.19.0 it requires Node 10, in case this SDK is installed without considering our package-lock.json file on an old Node.
  - Updated TypeScript declarations to include the `urls` settings object (to connect to Split Synchronizer in proxy mode) for the non-async settings where it would be applicable.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.15.1",
+  "version": "10.15.2-canary.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.15.1",
+  "version": "10.15.2-canary.0",
   "description": "Split SDK",
   "files": [
     "README.md",

--- a/src/__tests__/browserSuites/use-beacon-api.debug.spec.js
+++ b/src/__tests__/browserSuites/use-beacon-api.debug.spec.js
@@ -55,6 +55,7 @@ const assertCallsToBeaconAPI = (assert) => {
   let parsedPayload = JSON.parse(impressionsCallArgs[1]);
   assert.equal(parsedPayload.token, '...', 'assert correct payload token');
   assert.equal(parsedPayload.sdk, settings.version, 'assert correct sdk version');
+  assert.equal(parsedPayload.sim, DEBUG, 'assert correct impressions mode');
   assertImpressionSent(assert, parsedPayload.entries[0]);
 
   // The second call is for flushing events

--- a/src/__tests__/browserSuites/use-beacon-api.spec.js
+++ b/src/__tests__/browserSuites/use-beacon-api.spec.js
@@ -3,6 +3,7 @@ import { SplitFactory } from '../../';
 import SettingsFactory from '../../utils/settings';
 import splitChangesMock1 from '../mocks/splitchanges.since.-1.json';
 import mySegmentsFacundo from '../mocks/mysegments.facundo@split.io.json';
+import { OPTIMIZED } from '../../utils/constants';
 
 const config = {
   core: {
@@ -58,6 +59,7 @@ const assertCallsToBeaconAPI = (assert) => {
   let parsedPayload = JSON.parse(impressionsCallArgs[1]);
   assert.equal(parsedPayload.token, '...', 'assert correct payload token');
   assert.equal(parsedPayload.sdk, settings.version, 'assert correct sdk version');
+  assert.equal(parsedPayload.sim, OPTIMIZED, 'assert correct impressions mode');
   assertImpressionSent(assert, parsedPayload.entries[0]);
 
   // The second call is for flushing events

--- a/src/producer/updater/SplitChanges.js
+++ b/src/producer/updater/SplitChanges.js
@@ -121,7 +121,7 @@ export default function SplitChangesUpdaterFactory(context, isNode = false) {
 
     // @TODO check why e2e tests take so much time when sync storage result is not handled in a promise
     const since = storage.splits.getChangeNumber();
-    const sincePromise = thenable(since) ? since.then(splitChanges) : Promise.resolve(since);
+    const sincePromise = thenable(since) ? since : Promise.resolve(since);
     return sincePromise.then(splitChanges);
   };
 }


### PR DESCRIPTION
# JS SDK

## What did you accomplish?
Added the new "sim" (Split/Sync Impressions Mode) field to impressions payload sent via beacon API.

## How do we test the changes introduced in this PR?
Run the tests, check the network traffic of the beacon request to include the new field.

## Extra Notes