### PR TITLE
Fixed the issue getFetch(...) is not a function

### DIFF
--- a/src/services/getFetch/node.js
+++ b/src/services/getFetch/node.js
@@ -1,4 +1,4 @@
-let nodeFetch = require('node-fetch');
+let nodeFetch = require('node-fetch').default;
 
 // This function is only exposed for testing purposes.
 export function __setFetch(fetch) {


### PR DESCRIPTION
# Node.js SDK

## What did you accomplish?
Fixed the issue getFetch in node.js is not a function when building via webpack

## How do we test the changes introduced in this PR?
Test run builds as normal.
