### PR TITLE
Type definitions update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ deploy:
     acl: public_read
     cache_control: "max-age=31536000, public"
     on:
-      branch: development
+      branch: type_definitions_update
   - provider: s3
     access_key_id: ${AWS_ACCESS_KEY_ID_PROD}
     secret_access_key: ${AWS_SECRET_ACCESS_PROD}

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ deploy:
     acl: public_read
     cache_control: "max-age=31536000, public"
     on:
-      branch: type_definitions_update
+      branch: development
   - provider: s3
     access_key_id: ${AWS_ACCESS_KEY_ID_PROD}
     secret_access_key: ${AWS_SECRET_ACCESS_PROD}

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 10.15.3 (Feb XX, 2020)
- - Updated type definitions to remove `@types/node` dependency and avoid conflicts between Node and DOM types.
+ - Updated type definitions to remove `@types/node` dependency and avoid conflicts between Node and DOM type definitions.
  - Bugfixing - Handle issue importing node-fetch library (issue #505).
 
 10.15.2 (Dec 3, 2020)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 10.15.3 (Feb XX, 2020)
+ - Updated type definitions to remove `@types/node` dependency and avoid conflicts between Node and DOM types.
  - Bugfixing - Handle issue importing node-fetch library (issue #505).
 
 10.15.2 (Dec 3, 2020)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.15.3-canary.0",
+  "version": "10.15.3-canary.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1180,7 +1180,9 @@
     "@types/node": {
       "version": "13.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
-      "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
+      "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ==",
+      "dev": true,
+      "optional": true
     },
     "@types/yauzl": {
       "version": "2.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.15.3-canary.0",
+  "version": "10.15.3-canary.1",
   "description": "Split SDK",
   "files": [
     "README.md",
@@ -34,7 +34,6 @@
   "dependencies": {
     "@babel/runtime": "^7.10.2",
     "@types/google.analytics": "0.0.40",
-    "@types/node": "^13.9.1",
     "events": "3.1.0",
     "ioredis": "4.18.0",
     "ip": "1.1.5",

--- a/scripts/ts-tests.sh
+++ b/scripts/ts-tests.sh
@@ -3,6 +3,14 @@
 cd ts-tests ## Go to typescript tests folder
 echo "Installing dependencies for TypeScript declarations testing..."
 npm install ## Install dependencies
+npm install @types/node@6.0.31 ## Install type definitions for Node.js v6.x (the oldest supported version)
+echo "Dependencies installed, linking the package."
+npm link @splitsoftware/splitio ## Link to the cloned code
+echo "Running tsc compiler."
+./node_modules/.bin/tsc ## Run typescript compiler. No need for flags as we have a tsconfig.json file
+
+echo "Testing again with the latest @types/node version..."
+npm install @types/node@14 ## Install latest type definitions for Node.js
 echo "Dependencies installed, linking the package."
 npm link @splitsoftware/splitio ## Link to the cloned code
 echo "Running tsc compiler."

--- a/ts-tests/index.ts
+++ b/ts-tests/index.ts
@@ -226,6 +226,7 @@ const a: boolean = client.emit(splitEvent);
 client = client.removeAllListeners(splitEvent);
 client = client.removeAllListeners();
 const b: number = client.listenerCount(splitEvent);
+let nodeEventEmitter: NodeJS.EventEmitter = client;
 
 // Ready and destroy
 const readyPromise: Promise<void> = client.ready();
@@ -287,6 +288,7 @@ const a1: boolean = client.emit(splitEvent);
 client = client.removeAllListeners(splitEvent);
 client = client.removeAllListeners();
 const b1: number = client.listenerCount(splitEvent);
+nodeEventEmitter = client;
 
 // Ready and destroy (same as for sync client, just for interface checking)
 const readyPromise1: Promise<void> = client.ready();
@@ -334,6 +336,7 @@ const aa: boolean = manager.emit(splitEvent);
 manager = manager.removeAllListeners(splitEvent);
 manager = manager.removeAllListeners();
 const bb: number = manager.listenerCount(splitEvent);
+nodeEventEmitter = manager;
 
 // manager exposes Event constants too
 const managerEventConsts: {[key: string]: SplitIO.Event} = manager.Event;
@@ -357,6 +360,7 @@ const aaa: boolean = asyncManager.emit(splitEvent);
 asyncManager = asyncManager.removeAllListeners(splitEvent);
 asyncManager = asyncManager.removeAllListeners();
 const bbb: number = asyncManager.listenerCount(splitEvent);
+nodeEventEmitter = asyncManager;
 
 // asyncManager exposes Event constants too
 const asyncManagerEventConsts: {[key: string]: SplitIO.Event} = asyncManager.Event;

--- a/ts-tests/package.json
+++ b/ts-tests/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "repository": "splitio/javascript-client",
   "dependencies": {
+    "@types/node": "^14.14.25",
     "typescript": "^3.7.4"
   }
 }

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -2,12 +2,33 @@
 // Project: http://www.split.io/
 // Definitions by: Nico Zelaya <https://github.com/NicoZelaya/>
 
-/// <reference types="node" />
 /// <reference types="google.analytics" />
 
 export as namespace SplitIO;
 export = SplitIO;
 
+/**
+ * NodeJS.EventEmitter interface
+ * @see {@link https://nodejs.org/api/events.html}
+ */
+interface EventEmitter {
+  addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+  on(event: string | symbol, listener: (...args: any[]) => void): this;
+  once(event: string | symbol, listener: (...args: any[]) => void): this;
+  removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+  off(event: string | symbol, listener: (...args: any[]) => void): this;
+  removeAllListeners(event?: string | symbol): this;
+  setMaxListeners(n: number): this;
+  getMaxListeners(): number;
+  listeners(event: string | symbol): Function[];
+  rawListeners(event: string | symbol): Function[];
+  emit(event: string | symbol, ...args: any[]): boolean;
+  listenerCount(type: string | symbol): number;
+  // Added in Node 6...
+  prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
+  prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
+  eventNames(): Array<string | symbol>;
+}
 /**
  * @typedef {Object} EventConsts
  * @property {string} SDK_READY The ready event.
@@ -338,9 +359,9 @@ interface INodeBasicSettings extends ISharedSettings {
 /**
  * Common API for entities that expose status handlers.
  * @interface IStatusInterface
- * @extends NodeJS.EventEmitter
+ * @extends EventEmitter
  */
-interface IStatusInterface extends NodeJS.EventEmitter {
+interface IStatusInterface extends EventEmitter {
   /**
    * Constant object containing the SDK events for you to use.
    * @property {EventConsts} Event
@@ -744,13 +765,13 @@ declare namespace SplitIO {
    */
   type UrlSettings = {
     /**
-     * String property to override the base URL where the SDK will get feature flagging related data like a Split rollout plan or segments information. 
+     * String property to override the base URL where the SDK will get feature flagging related data like a Split rollout plan or segments information.
      * @property {string} sdk
      * @default 'https://sdk.split.io/api'
      */
     sdk?: string,
     /**
-     * String property to override the base URL where the SDK will post event-related information like impressions. 
+     * String property to override the base URL where the SDK will post event-related information like impressions.
      * @property {string} events
      * @default 'https://events.split.io/api'
      */


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

Updated EventEmitter type definition to not require @types/node, in order to avoid possible conflicts with the "dom" type definitions of build-in APIs such as setTimeout or console.

## How do we test the changes introduced in this PR?

Declaration type tests were extended to assert that the EventEmitter interface is type compatible with the NodeJS.EventEmitter interface on different versions of @types/node.

## Extra Notes