### PR TITLE
Update streaming error handling

### DIFF
--- a/src/__tests__/browserSuites/push-fallbacking.spec.js
+++ b/src/__tests__/browserSuites/push-fallbacking.spec.js
@@ -11,8 +11,8 @@ import mySegmentsMarcio from '../mocks/mysegments.marcio@split.io.json';
 
 import occupancy0ControlPriMessage from '../mocks/message.OCCUPANCY.0.control_pri.1586987434550.json';
 import occupancy1ControlPriMessage from '../mocks/message.OCCUPANCY.1.control_pri.1586987434450.json';
-import occupancy1ControlSecMessage from '../mocks/message.OCCUPANCY.1.control_sec.1586987434451.json';
 import occupancy2ControlPriMessage from '../mocks/message.OCCUPANCY.2.control_pri.1586987434650.json';
+import occupancy0ControlSecMessage from '../mocks/message.OCCUPANCY.0.control_sec.1586987434451.json';
 
 import streamingPausedControlPriMessage from '../mocks/message.CONTROL.STREAMING_PAUSED.control_pri.1586987434750.json';
 import streamingResumedControlPriMessage from '../mocks/message.CONTROL.STREAMING_RESUMED.control_pri.1586987434850.json';
@@ -112,7 +112,7 @@ export function testFallbacking(fetchMock, assert) {
     setTimeout(() => {
       eventSourceInstance.emitOpen();
       eventSourceInstance.emitMessage(occupancy1ControlPriMessage);
-      eventSourceInstance.emitMessage(occupancy1ControlSecMessage);
+      eventSourceInstance.emitMessage(occupancy0ControlSecMessage);
     }, MILLIS_SSE_OPEN); // open SSE connection after 0.1 seconds
 
     setTimeout(() => {

--- a/src/__tests__/browserSuites/push-initialization-nopush.spec.js
+++ b/src/__tests__/browserSuites/push-initialization-nopush.spec.js
@@ -22,7 +22,8 @@ const config = {
     featuresRefreshRate: 0.1,
     segmentsRefreshRate: 0.1,
     metricsRefreshRate: 3000,
-    impressionsRefreshRate: 3000
+    impressionsRefreshRate: 3000,
+    pushRetryBackoffBase: 0.01 // small value to assert rapidly that push is not retried
   },
   urls: baseUrls,
   startup: {

--- a/src/__tests__/browserSuites/push-initialization-nopush.spec.js
+++ b/src/__tests__/browserSuites/push-initialization-nopush.spec.js
@@ -4,8 +4,11 @@ import splitChangesMock1 from '../mocks/splitchanges.since.-1.json';
 import splitChangesMock2 from '../mocks/splitchanges.since.1457552620999.json';
 import mySegmentsNicolas from '../mocks/mysegments.nicolas@split.io.json';
 import authPushDisabled from '../mocks/auth.pushDisabled.json';
+import authPushEnabledNicolas from '../mocks/auth.pushEnabled.nicolas@split.io.json';
 import authInvalidCredentials from '../mocks/auth.invalidCredentials.txt';
 import { nearlyEqual } from '../testUtils';
+
+import EventSourceMock, { setMockListener } from '../../sync/__tests__/mocks/eventSourceMock';
 
 const baseUrls = {
   sdk: 'https://sdk.push-initialization-nopush/api',
@@ -109,9 +112,6 @@ export function testNoEventSource(fetchMock, assert) {
 
   const originalEventSource = window.EventSource;
   window.EventSource = undefined;
-  fetchMock.getOnce(settings.url(`/auth?users=${encodeURIComponent(userKey)}`), function () {
-    assert.fail('not authenticate if EventSource is not available');
-  });
 
   testInitializationFail(fetchMock, assert, false);
 
@@ -124,12 +124,31 @@ export function testNoBase64Support(fetchMock, assert) {
 
   const originalAtoB = window.atob;
   window.atob = undefined;
-  fetchMock.getOnce(settings.url(`/auth?users=${encodeURIComponent(userKey)}`), function () {
-    assert.fail('not authenticate if `atob` or `btoa` functions are not available');
-  });
 
   testInitializationFail(fetchMock, assert, false);
 
   window.atob = originalAtoB;
 
+}
+
+export function testSSEWithNonRetryableError(fetchMock, assert) {
+  assert.plan(7);
+
+  // Auth successes
+  fetchMock.getOnce(settings.url(`/auth?users=${encodeURIComponent(userKey)}`), function (url, opts) {
+    if (!opts.headers['Authorization']) assert.fail('`/auth` request must include `Authorization` header');
+    assert.pass('auth successes');
+    return { status: 200, body: authPushEnabledNicolas };
+  });
+  // But SSE fails with a non-recoverable error
+  const originalEventSource = window.EventSource;
+  window.EventSource = EventSourceMock;
+  setMockListener(function (eventSourceInstance) {
+    assert.pass('sse fails');
+    const ably4XXNonRecoverableError = { data: '{"message":"Token expired","code":42910,"statusCode":429}' };
+    eventSourceInstance.emitError(ably4XXNonRecoverableError);
+  });
+
+  testInitializationFail(fetchMock, assert, true);
+  window.EventSource = originalEventSource;
 }

--- a/src/__tests__/browserSuites/push-initialization-retries.spec.js
+++ b/src/__tests__/browserSuites/push-initialization-retries.spec.js
@@ -28,8 +28,7 @@ const config = {
     segmentsRefreshRate: 0.2,
     metricsRefreshRate: 3000,
     impressionsRefreshRate: 3000,
-    authRetryBackoffBase: 0.1,
-    streamingReconnectBackoffBase: 0.1
+    pushRetryBackoffBase: 0.1
   },
   urls: baseUrls,
   startup: {
@@ -44,12 +43,12 @@ const settings = SettingsFactory(config);
  * Sequence of calls:
  *  0.0 secs: initial SyncAll (/splitChanges, /mySegments/*) and first auth attempt (fail due to bad token)
  *  0.0 secs: polling (/splitChanges, /mySegments/*)
- *  0.1 secs: second auth attempt (fail due to network error)
+ *  0.1 secs: second push connect attempt (auth fail due to network error)
  *  0.2 secs: polling (/splitChanges, /mySegments/*)
- *  0.3 secs: third auth attempt (success but push disabled)
+ *  0.3 secs: third push connect attempt (auth success but push disabled)
  *  0.4 secs: polling (/splitChanges, /mySegments/*)
  */
-export function testAuthRetries(fetchMock, assert) {
+export function testPushRetriesDueToAuthErrors(fetchMock, assert) {
 
   let start, splitio, client, ready = false;
 
@@ -62,7 +61,7 @@ export function testAuthRetries(fetchMock, assert) {
   fetchMock.getOnce(settings.url(`/auth?users=${encodeURIComponent(userKey)}`), function (url, opts) {
     if (!opts.headers['Authorization']) assert.fail('`/auth` request must include `Authorization` header');
     const lapse = Date.now() - start;
-    const expected = (settings.scheduler.authRetryBackoffBase * Math.pow(2, 0) + settings.scheduler.authRetryBackoffBase * Math.pow(2, 1));
+    const expected = (settings.scheduler.pushRetryBackoffBase * Math.pow(2, 0) + settings.scheduler.pushRetryBackoffBase * Math.pow(2, 1));
     assert.true(nearlyEqual(lapse, expected), 'third auth attempt (aproximately in 0.3 seconds from first attempt)');
     return { status: 200, body: authPushDisabled };
   });
@@ -105,17 +104,17 @@ export function testAuthRetries(fetchMock, assert) {
 
 /**
  * Sequence of calls:
- *  0.0 secs: initial SyncAll (/splitChanges, /mySegments/*), auth success and sse fail
+ *  0.0 secs: initial SyncAll (/splitChanges, /mySegments/*), auth successes and sse fails
  *  0.0 secs: polling (/splitChanges, /mySegments/*)
- *  0.1 secs: second sse attempt
+ *  0.1 secs: second push connect attempt (auth successes and sse fails again)
  *  0.2 secs: polling (/splitChanges, /mySegments/*)
- *  0.3 secs: third sse attempt (success), syncAll (/splitChanges, /mySegments/*)
+ *  0.3 secs: third push connect attempt (auth and sse success), syncAll (/splitChanges, /mySegments/*)
  */
-export function testSSERetries(fetchMock, assert) {
+export function testPushRetriesDueToSseErrors(fetchMock, assert) {
   window.EventSource = EventSourceMock;
 
   let start, splitio, client, ready = false;
-  const expectedTimeToSSEsuccess = (settings.scheduler.streamingReconnectBackoffBase * Math.pow(2, 0) + settings.scheduler.streamingReconnectBackoffBase * Math.pow(2, 1));
+  const expectedTimeToSSEsuccess = (settings.scheduler.pushRetryBackoffBase * Math.pow(2, 0) + settings.scheduler.pushRetryBackoffBase * Math.pow(2, 1));
 
   const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolas.token}&v=1.1&heartbeats=true`;
   let sseattempts = 0;
@@ -132,7 +131,7 @@ export function testSSERetries(fetchMock, assert) {
     sseattempts++;
   });
 
-  fetchMock.getOnce(settings.url(`/auth?users=${encodeURIComponent(userKey)}`), function (url, opts) {
+  fetchMock.get({ url: settings.url(`/auth?users=${encodeURIComponent(userKey)}`), repeat: 3 }, function (url, opts) {
     if (!opts.headers['Authorization']) assert.fail('`/auth` request must include `Authorization` header');
     assert.pass('auth success');
     return { status: 200, body: authPushEnabledNicolas };

--- a/src/__tests__/browserSuites/push-refresh-token.spec.js
+++ b/src/__tests__/browserSuites/push-refresh-token.spec.js
@@ -3,6 +3,7 @@ import splitChangesMock2 from '../mocks/splitchanges.since.1457552620999.json';
 import mySegmentsNicolasMock1 from '../mocks/mysegments.nicolas@split.io.json';
 
 import authPushEnabledNicolas from '../mocks/auth.pushEnabled.nicolas@split.io.601secs.json';
+import authPushDisabled from '../mocks/auth.pushDisabled.json';
 
 import { nearlyEqual } from '../testUtils';
 
@@ -27,6 +28,9 @@ const config = {
   },
   urls: baseUrls,
   streamingEnabled: true,
+  scheduler: {
+    pushRetryBackoffBase: 0.01 // small value to assert rapidly that push is not retried after auth with push disabled
+  },
   // debug: true,
 };
 const settings = SettingsFactory(config);
@@ -39,7 +43,9 @@ const MILLIS_REFRESH_TOKEN = 1000;
  *  0.0 secs: initial SyncAll (/splitChanges, /segmentChanges/*), auth, SSE connection -> refresh token scheduled in 1 second.
  *  0.1 secs: SSE connection opened -> syncAll (/splitChanges, /segmentChanges/*)
  *  1.0 secs: refresh-token: reauth, SSE connection
- *  1.2 secs: SSE connection reopened -> syncAll (/splitChanges, /segmentChanges/*)
+ *  1.1 secs: SSE connection reopened -> syncAll (/splitChanges, /segmentChanges/*)
+ *  2.0 secs: refresh-token: reauth with pushEnabled false --> SSE connection closed & syncAll
+ *  2.2 secs: destroy the client. NO NEW REQUESTS SHOULD HAVE BEEN PERFORMED (too early for polling and push is disabled)
  */
 export function testRefreshToken(fetchMock, assert) {
   fetchMock.reset();
@@ -47,7 +53,11 @@ export function testRefreshToken(fetchMock, assert) {
   let start, splitio, client;
 
   // mock SSE open and message events
+  let sseCount = 0;
   setMockListener(function (eventSourceInstance) {
+    sseCount++;
+    if (sseCount > 2) assert.fail('expecting only 2 SSE connections');
+
     const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolas.token}&v=1.1&heartbeats=true`;
     assert.equals(eventSourceInstance.url, expectedSSEurl, 'EventSource URL is the expected');
 
@@ -55,6 +65,9 @@ export function testRefreshToken(fetchMock, assert) {
       eventSourceInstance.emitOpen();
     }, MILLIS_SSE_OPEN); // open SSE connection after 0.1 seconds
 
+    setTimeout(() => {
+      assert.equal(eventSourceInstance.readyState, EventSourceMock.CLOSED, 'SSE connection must be closed');
+    }, MILLIS_REFRESH_TOKEN + 50); // after refreshing the token, connections are closed
   });
 
   // initial sync
@@ -88,21 +101,23 @@ export function testRefreshToken(fetchMock, assert) {
   });
   fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 
-  // second re-auth due to refresh token
+  // second re-auth due to refresh token, this time responding with pushEnabled false
   fetchMock.getOnce(settings.url(`/auth?users=${encodeURIComponent(userKey)}`), function (url, opts) {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_REFRESH_TOKEN * 2), 'second reauthentication for token refresh');
     if (!opts.headers['Authorization']) assert.fail('`/auth` request must include `Authorization` header');
-    return { status: 200, body: authPushEnabledNicolas };
+    return { status: 200, body: authPushDisabled };
   });
 
-  // split sync after SSE reopened
+  // split sync after SSE closed due to push disabled
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
     const lapse = Date.now() - start;
-    assert.true(nearlyEqual(lapse, MILLIS_REFRESH_TOKEN * 2 + MILLIS_SSE_OPEN), 'sync after SSE connection is reopened a second time');
-    client.destroy().then(() => {
-      assert.end();
-    });
+    assert.true(nearlyEqual(lapse, MILLIS_REFRESH_TOKEN * 2), 'sync after SSE connection is reopened a second time');
+    setTimeout(() => {
+      client.destroy().then(() => {
+        assert.end();
+      });
+    }, 200); // destroy the client a little bit latter, to assert that there weren't new requests
     return { status: 500, body: 'server error' };
   });
   fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });

--- a/src/__tests__/browserSuites/push-synchronization.spec.js
+++ b/src/__tests__/browserSuites/push-synchronization.spec.js
@@ -8,7 +8,7 @@ import mySegmentsMarcio from '../mocks/mysegments.marcio@split.io.json';
 
 import splitUpdateMessage from '../mocks/message.SPLIT_UPDATE.1457552649999.json';
 import oldSplitUpdateMessage from '../mocks/message.SPLIT_UPDATE.1457552620999.json';
-import mySegmentsUpdateMessage from '../mocks/message.MY_SEGMENTS_UPDATE.nicolas@split.io.1457552640000.json';
+import mySegmentsUpdateMessageNoPayload from '../mocks/message.MY_SEGMENTS_UPDATE.nicolas@split.io.1457552640000.json';
 import mySegmentsUpdateMessageWithPayload from '../mocks/message.MY_SEGMENTS_UPDATE.marcio@split.io.1457552645000.json';
 import mySegmentsUpdateMessageWithEmptyPayload from '../mocks/message.MY_SEGMENTS_UPDATE.marcio@split.io.1457552646000.json';
 import splitKillMessage from '../mocks/message.SPLIT_KILL.1457552650000.json';
@@ -16,7 +16,7 @@ import splitKillMessage from '../mocks/message.SPLIT_KILL.1457552650000.json';
 import authPushEnabledNicolas from '../mocks/auth.pushEnabled.nicolas@split.io.json';
 import authPushEnabledNicolasAndMarcio from '../mocks/auth.pushEnabled.nicolas@split.io.marcio@split.io.json';
 
-import { nearlyEqual } from '../testUtils';
+import { nearlyEqual, hasNoCacheHeader } from '../testUtils';
 import includes from 'lodash/includes';
 
 // Replace original EventSource with mock
@@ -48,7 +48,7 @@ const settings = SettingsFactory(config);
 const MILLIS_SSE_OPEN = 100;
 const MILLIS_FIRST_SPLIT_UPDATE_EVENT = 200;
 const MILLIS_SECOND_SPLIT_UPDATE_EVENT = 300;
-const MILLIS_MYSEGMENT_UPDATE_EVENT = 400;
+const MILLIS_MY_SEGMENTS_UPDATE_EVENT_NO_PAYLOAD = 400;
 const MILLIS_SPLIT_KILL_EVENT = 500;
 const MILLIS_NEW_CLIENT = 600;
 const MILLIS_SECOND_SSE_OPEN = 700;
@@ -102,11 +102,11 @@ export function testSynchronization(fetchMock, assert) {
       assert.equal(client.getTreatment('splitters'), 'off', 'evaluation with initial MySegments list');
       client.once(client.Event.SDK_UPDATE, () => {
         const lapse = Date.now() - start;
-        assert.true(nearlyEqual(lapse, MILLIS_MYSEGMENT_UPDATE_EVENT), 'SDK_UPDATE due to MY_SEGMENTS_UPDATE event');
+        assert.true(nearlyEqual(lapse, MILLIS_MY_SEGMENTS_UPDATE_EVENT_NO_PAYLOAD), 'SDK_UPDATE due to MY_SEGMENTS_UPDATE event');
         assert.equal(client.getTreatment('splitters'), 'on', 'evaluation with updated MySegments list');
       });
-      eventSourceInstance.emitMessage(mySegmentsUpdateMessage);
-    }, MILLIS_MYSEGMENT_UPDATE_EVENT); // send a MY_SEGMENTS_UPDATE event with a new changeNumber after 0.4 seconds
+      eventSourceInstance.emitMessage(mySegmentsUpdateMessageNoPayload);
+    }, MILLIS_MY_SEGMENTS_UPDATE_EVENT_NO_PAYLOAD); // send a MY_SEGMENTS_UPDATE event with a new changeNumber after 0.4 seconds
 
     setTimeout(() => {
       assert.equal(client.getTreatment('whitelist'), 'allowed', 'evaluation with not killed Split');
@@ -196,44 +196,69 @@ export function testSynchronization(fetchMock, assert) {
   });
 
   // initial split and mySegments sync
-  fetchMock.getOnce(settings.url('/splitChanges?since=-1'), function () {
+  fetchMock.getOnce(settings.url('/splitChanges?since=-1'), function (url, opts) {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, 0), 'initial sync');
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
     return { status: 200, body: splitChangesMock1 };
   });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), function (url, opts) {
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
+    return { status: 200, body: mySegmentsNicolasMock1 };
+  });
 
   // split and segment sync after SSE opened
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
+  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function (url, opts) {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_SSE_OPEN), 'sync after SSE connection is opened');
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
     return { status: 200, body: splitChangesMock2 };
   });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), function (url, opts) {
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
+    return { status: 200, body: mySegmentsNicolasMock1 };
+  });
 
   // fetch due to SPLIT_UPDATE event
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock3 });
+  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function (url, opts) {
+    if (!hasNoCacheHeader(opts)) assert.fail('request must include `Cache-Control` header1');
+    return { status: 200, body: splitChangesMock3 };
+  });
 
   // fetch due to first MY_SEGMENTS_UPDATE event
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock2 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), function (url, opts) {
+    if (!hasNoCacheHeader(opts)) assert.fail('request must include `Cache-Control` header2');
+    return { status: 200, body: mySegmentsNicolasMock2 };
+  });
 
   // fetch due to SPLIT_KILL event
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), function () {
+  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), function (url, opts) {
+    if (!hasNoCacheHeader(opts)) assert.fail('request must include `Cache-Control` header3');
     assert.equal(client.getTreatment('whitelist'), 'not_allowed', 'evaluation with split killed immediately, before fetch is done');
     return { status: 200, body: splitChangesMock4 };
   });
 
   // initial fetch of mySegments for new client
-  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), function (url, opts) {
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
+    return { status: 200, body: mySegmentsMarcio };
+  });
 
   // split and mySegment sync after second SSE opened
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552650000'), function () {
+  fetchMock.getOnce(settings.url('/splitChanges?since=1457552650000'), function (url, opts) {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_SECOND_SSE_OPEN), 'sync after second SSE connection is opened');
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
     return { status: 200, body: { splits: [], since: 1457552650000, till: 1457552650000 } };
   });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock2 });
-  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), function (url, opts) {
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
+    return { status: 200, body: mySegmentsNicolasMock2 };
+  });
+  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), function (url, opts) {
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
+    return { status: 200, body: mySegmentsMarcio };
+  });
 
   fetchMock.get(new RegExp('.*'), function (url) {
     assert.fail('unexpected GET request with url: ' + url);

--- a/src/__tests__/mocks/message.OCCUPANCY.0.control_sec.1586987434451.json
+++ b/src/__tests__/mocks/message.OCCUPANCY.0.control_sec.1586987434451.json
@@ -1,0 +1,4 @@
+{
+  "type": "message",
+  "data": "{\"id\":\"JdPcOgIxuH:0:0\",\"timestamp\":1586987434451,\"encoding\":\"json\",\"channel\":\"[?occupancy=metrics.publishers]control_sec\",\"data\":\"{\\\"metrics\\\":{\\\"publishers\\\":0}}\",\"name\":\"[meta]occupancy\"}"
+}

--- a/src/__tests__/mocks/message.OCCUPANCY.1.control_sec.1586987434451.json
+++ b/src/__tests__/mocks/message.OCCUPANCY.1.control_sec.1586987434451.json
@@ -1,4 +1,0 @@
-{
-  "type": "message",
-  "data": "{\"id\":\"JdPcOgIxuH:0:0\",\"timestamp\":1586987434451,\"encoding\":\"json\",\"channel\":\"[?occupancy=metrics.publishers]control_sec\",\"data\":\"{\\\"metrics\\\":{\\\"publishers\\\":1}}\",\"name\":\"[meta]occupancy\"}"
-}

--- a/src/__tests__/mocks/message.SPLIT_UPDATE.1457552650001.json
+++ b/src/__tests__/mocks/message.SPLIT_UPDATE.1457552650001.json
@@ -1,0 +1,4 @@
+{
+  "type": "message",
+  "data": "{\"id\": \"mc4i3NENoA:0:0\",\"clientId\": \"NDEzMTY5Mzg0MA==:MTM2ODE2NDMxNA==\",\"timestamp\": 1457552650001,\"encoding\": \"json\",\"channel\": \"NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw==_splits\",\"data\": \"{\\\"type\\\":\\\"SPLIT_UPDATE\\\",\\\"changeNumber\\\":1457552650001}\"}"
+}

--- a/src/__tests__/mocks/splitchanges.since.1457552650000.till.1457552650001.SPLIT_UPDATE.json
+++ b/src/__tests__/mocks/splitchanges.since.1457552650000.till.1457552650001.SPLIT_UPDATE.json
@@ -1,0 +1,79 @@
+{
+  "splits": [
+    {
+      "orgId": null,
+      "environment": null,
+      "trafficTypeId": null,
+      "trafficTypeName": null,
+      "name": "qc_team",
+      "seed": -1984784937,
+      "status": "ACTIVE",
+      "killed": false,
+      "defaultTreatment": "no",
+      "conditions": [
+        {
+          "matcherGroup": {
+            "combiner": "AND",
+            "matchers": [
+              {
+                "keySelector": null,
+                "matcherType": "WHITELIST",
+                "negate": false,
+                "userDefinedSegmentMatcherData": null,
+                "whitelistMatcherData": {
+                  "whitelist": [
+                    "tia@split.io",
+                    "trevor@split.io"
+                  ]
+                },
+                "unaryNumericMatcherData": null,
+                "betweenMatcherData": null
+              }
+            ]
+          },
+          "partitions": [
+            {
+              "treatment": "yes",
+              "size": 100
+            }
+          ]
+        },
+        {
+          "matcherGroup": {
+            "combiner": "AND",
+            "matchers": [
+              {
+                "keySelector": {
+                  "trafficType": "user",
+                  "attribute": null
+                },
+                "matcherType": "IN_SEGMENT",
+                "negate": false,
+                "userDefinedSegmentMatcherData": {
+                  "segmentName": "new_segment"
+                },
+                "whitelistMatcherData": null,
+                "unaryNumericMatcherData": null,
+                "betweenMatcherData": null,
+                "unaryStringMatcherData": null
+              }
+            ]
+          },
+          "partitions": [
+            {
+              "treatment": "yes",
+              "size": 100
+            },
+            {
+              "treatment": "no",
+              "size": 0
+            }
+          ]
+        }
+      ],
+      "configurations": {}
+    }
+  ],
+  "since": 1457552650000,
+  "till": 1457552650001
+}

--- a/src/__tests__/nodeSuites/push-fallbacking.spec.js
+++ b/src/__tests__/nodeSuites/push-fallbacking.spec.js
@@ -8,8 +8,8 @@ import splitChangesMock3 from '../mocks/splitchanges.real.updateWithoutSegments.
 
 import occupancy0ControlPriMessage from '../mocks/message.OCCUPANCY.0.control_pri.1586987434550.json';
 import occupancy1ControlPriMessage from '../mocks/message.OCCUPANCY.1.control_pri.1586987434450.json';
-import occupancy1ControlSecMessage from '../mocks/message.OCCUPANCY.1.control_sec.1586987434451.json';
 import occupancy2ControlPriMessage from '../mocks/message.OCCUPANCY.2.control_pri.1586987434650.json';
+import occupancy0ControlSecMessage from '../mocks/message.OCCUPANCY.0.control_sec.1586987434451.json';
 
 import streamingPausedControlPriMessage from '../mocks/message.CONTROL.STREAMING_PAUSED.control_pri.1586987434750.json';
 import streamingResumedControlPriMessage from '../mocks/message.CONTROL.STREAMING_RESUMED.control_pri.1586987434850.json';
@@ -104,7 +104,7 @@ export function testFallbacking(fetchMock, assert) {
     setTimeout(() => {
       eventSourceInstance.emitOpen();
       eventSourceInstance.emitMessage(occupancy1ControlPriMessage);
-      eventSourceInstance.emitMessage(occupancy1ControlSecMessage);
+      eventSourceInstance.emitMessage(occupancy0ControlSecMessage);
     }, MILLIS_SSE_OPEN); // open SSE connection after 0.1 seconds
 
     setTimeout(() => {

--- a/src/__tests__/nodeSuites/push-initialization-nopush.spec.js
+++ b/src/__tests__/nodeSuites/push-initialization-nopush.spec.js
@@ -3,11 +3,13 @@ import SettingsFactory from '../../utils/settings';
 import splitChangesMock1 from '../mocks/splitchanges.since.-1.json';
 import splitChangesMock2 from '../mocks/splitchanges.since.1457552620999.json';
 import authPushDisabled from '../mocks/auth.pushDisabled.json';
+import authPushEnabled from '../mocks/auth.pushEnabled.node.json';
 import authInvalidCredentials from '../mocks/auth.invalidCredentials.txt';
 import authNoUserSpecified from '../mocks/auth.noUserSpecified.txt';
 import { nearlyEqual } from '../testUtils';
 
 import { __setEventSource, __restore } from '../../services/getEventSource/node';
+import EventSourceMock, { setMockListener } from '../../sync/__tests__/mocks/eventSourceMock';
 
 const baseUrls = {
   sdk: 'https://sdk.push-initialization-nopush/api',
@@ -123,12 +125,30 @@ export function testNoEventSource(fetchMock, assert) {
   assert.plan(3);
 
   __setEventSource(undefined);
-  fetchMock.getOnce(settings.url('/auth'), function () {
-    assert.fail('not authenticate if EventSource is not available');
-  });
 
   testInitializationFail(fetchMock, assert, false);
 
   __restore();
 
+}
+
+export function testSSEWithNonRetryableError(fetchMock, assert) {
+  assert.plan(7);
+
+  // Auth successes
+  fetchMock.getOnce(settings.url('/auth'), function (url, opts) {
+    if (!opts.headers['Authorization']) assert.fail('`/auth` request must include `Authorization` header');
+    assert.pass('auth successes');
+    return { status: 200, body: authPushEnabled };
+  });
+  // But SSE fails with a non-recoverable error
+  __setEventSource(EventSourceMock);
+  setMockListener(function (eventSourceInstance) {
+    assert.pass('sse fails');
+    const ably4XXNonRecoverableError = { data: '{"message":"Token expired","code":42910,"statusCode":429}' };
+    eventSourceInstance.emitError(ably4XXNonRecoverableError);
+  });
+
+  testInitializationFail(fetchMock, assert, true);
+  __restore();
 }

--- a/src/__tests__/nodeSuites/push-initialization-nopush.spec.js
+++ b/src/__tests__/nodeSuites/push-initialization-nopush.spec.js
@@ -23,7 +23,7 @@ const config = {
     segmentsRefreshRate: 0.1,
     metricsRefreshRate: 3000,
     impressionsRefreshRate: 3000,
-    authRetryBackoffBase: 0.01
+    pushRetryBackoffBase: 0.01 // small value to assert rapidly that push is not retried
   },
   urls: baseUrls,
   startup: {

--- a/src/__tests__/nodeSuites/push-initialization-retries.spec.js
+++ b/src/__tests__/nodeSuites/push-initialization-retries.spec.js
@@ -26,8 +26,7 @@ const config = {
     segmentsRefreshRate: 0.2,
     metricsRefreshRate: 3000,
     impressionsRefreshRate: 3000,
-    authRetryBackoffBase: 0.1,
-    streamingReconnectBackoffBase: 0.1
+    pushRetryBackoffBase: 0.1
   },
   urls: baseUrls,
   startup: {
@@ -42,12 +41,12 @@ const settings = SettingsFactory(config);
  * Sequence of calls:
  *  0.0 secs: initial SyncAll (/splitChanges, /segmentChanges/*) and first auth attempt (fail due to bad token)
  *  0.0 secs: polling (/splitChanges, /segmentChanges/*)
- *  0.1 secs: second auth attempt (fail due to network error)
+ *  0.1 secs: second push connect attempt (auth fail due to network error)
  *  0.2 secs: polling (/splitChanges, /segmentChanges/*)
- *  0.3 secs: third auth attempt (success but push disabled)
+ *  0.3 secs: third push connect attempt (auth success but push disabled)
  *  0.4 secs: polling (/splitChanges, /segmentChanges/*)
  */
-export function testAuthRetries(fetchMock, assert) {
+export function testPushRetriesDueToAuthErrors(fetchMock, assert) {
 
   let start, splitio, client, ready = false;
 
@@ -60,7 +59,7 @@ export function testAuthRetries(fetchMock, assert) {
   fetchMock.getOnce(settings.url('/auth'), function (url, opts) {
     if (!opts.headers['Authorization']) assert.fail('`/auth` request must include `Authorization` header');
     const lapse = Date.now() - start;
-    const expected = (settings.scheduler.authRetryBackoffBase * Math.pow(2, 0) + settings.scheduler.authRetryBackoffBase * Math.pow(2, 1));
+    const expected = (settings.scheduler.pushRetryBackoffBase * Math.pow(2, 0) + settings.scheduler.pushRetryBackoffBase * Math.pow(2, 1));
     assert.true(nearlyEqual(lapse, expected), 'third auth attempt (aproximately in 0.3 seconds from first attempt)');
     return { status: 200, body: authPushDisabled };
   });
@@ -102,16 +101,16 @@ export function testAuthRetries(fetchMock, assert) {
 
 /**
  * Sequence of calls:
- *  0.0 secs: initial SyncAll (/splitChanges, /segmentChanges/*), auth success and sse fail
- *  0.1 secs: second sse attempt
+ *  0.0 secs: initial SyncAll (/splitChanges, /segmentChanges/*), auth successes and sse fails
+ *  0.1 secs: second push connect attempt (auth successes and sse fails again)
  *  0.2 secs: polling (/splitChanges, /segmentChanges/*)
- *  0.3 secs: third sse attempt (success), syncAll (/splitChanges, /segmentChanges/*)
+ *  0.3 secs: third push connect attempt (auth and sse success), syncAll (/splitChanges, /segmentChanges/*)
  */
-export function testSSERetries(fetchMock, assert) {
+export function testPushRetriesDueToSseErrors(fetchMock, assert) {
   __setEventSource(EventSourceMock);
 
   let start, splitio, client, ready = false;
-  const expectedTimeToSSEsuccess = (settings.scheduler.streamingReconnectBackoffBase * Math.pow(2, 0) + settings.scheduler.streamingReconnectBackoffBase * Math.pow(2, 1));
+  const expectedTimeToSSEsuccess = (settings.scheduler.pushRetryBackoffBase * Math.pow(2, 0) + settings.scheduler.pushRetryBackoffBase * Math.pow(2, 1));
 
   const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_segments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabled.token}&v=1.1&heartbeats=true`;
   let sseattempts = 0;
@@ -128,7 +127,7 @@ export function testSSERetries(fetchMock, assert) {
     sseattempts++;
   });
 
-  fetchMock.getOnce(settings.url('/auth'), function (url, opts) {
+  fetchMock.get({ url: settings.url('/auth'), repeat: 3 /* 3 push attempts */ }, function (url, opts) {
     if (!opts.headers['Authorization']) assert.fail('`/auth` request must include `Authorization` header');
     assert.pass('auth success');
     return { status: 200, body: authPushEnabled };

--- a/src/__tests__/nodeSuites/push-refresh-token.spec.js
+++ b/src/__tests__/nodeSuites/push-refresh-token.spec.js
@@ -2,6 +2,7 @@ import splitChangesMock1 from '../mocks/splitchanges.since.-1.json';
 import splitChangesMock2 from '../mocks/splitchanges.since.1457552620999.json';
 
 import authPushEnabled from '../mocks/auth.pushEnabled.node.601secs.json';
+import authPushDisabled from '../mocks/auth.pushDisabled.json';
 
 import { nearlyEqual, mockSegmentChanges } from '../testUtils';
 
@@ -24,6 +25,9 @@ const config = {
   },
   urls: baseUrls,
   streamingEnabled: true,
+  scheduler: {
+    pushRetryBackoffBase: 0.01 // small value to assert rapidly that push is not retried after auth with push disabled
+  },
   // debug: true,
 };
 const settings = SettingsFactory(config);
@@ -36,7 +40,9 @@ const MILLIS_REFRESH_TOKEN = 1000;
  *  0.0 secs: initial SyncAll (/splitChanges, /segmentChanges/*), auth, SSE connection -> refresh token scheduled in 1 second.
  *  0.1 secs: SSE connection opened -> syncAll (/splitChanges, /segmentChanges/*)
  *  1.0 secs: refresh-token: reauth, SSE connection
- *  1.2 secs: SSE connection reopened -> syncAll (/splitChanges, /segmentChanges/*)
+ *  1.1 secs: SSE connection reopened -> syncAll (/splitChanges, /segmentChanges/*)
+ *  2.0 secs: refresh-token: reauth with pushEnabled false --> SSE connection closed & syncAll
+ *  2.2 secs: destroy the client. NO NEW REQUESTS SHOULD HAVE BEEN PERFORMED (too early for polling and push is disabled)
  */
 export function testRefreshToken(fetchMock, assert) {
   fetchMock.reset();
@@ -45,7 +51,11 @@ export function testRefreshToken(fetchMock, assert) {
   let start, splitio, client;
 
   // mock SSE open and message events
+  let sseCount = 0;
   setMockListener(function (eventSourceInstance) {
+    sseCount++;
+    if(sseCount > 2) assert.fail('expecting only 2 SSE connections');
+
     const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_segments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabled.token}&v=1.1&heartbeats=true`;
     assert.equals(eventSourceInstance.url, expectedSSEurl, 'EventSource URL is the expected');
 
@@ -53,6 +63,9 @@ export function testRefreshToken(fetchMock, assert) {
       eventSourceInstance.emitOpen();
     }, MILLIS_SSE_OPEN); // open SSE connection after 0.1 seconds
 
+    setTimeout(() => {
+      assert.equal(eventSourceInstance.readyState, EventSourceMock.CLOSED, 'SSE connection must be closed');
+    }, MILLIS_REFRESH_TOKEN + 50); // after refreshing the token, connections are closed
   });
 
   // initial split sync
@@ -83,21 +96,23 @@ export function testRefreshToken(fetchMock, assert) {
     return { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } };
   });
 
-  // second re-auth due to refresh token
+  // second re-auth due to refresh token, this time responding with pushEnabled false
   fetchMock.getOnce(settings.url('/auth'), function (url, opts) {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_REFRESH_TOKEN * 2), 'second reauthentication for token refresh');
     if (!opts.headers['Authorization']) assert.fail('`/auth` request must include `Authorization` header');
-    return { status: 200, body: authPushEnabled };
+    return { status: 200, body: authPushDisabled };
   });
 
-  // split sync after SSE reopened
+  // split sync after SSE closed due to push disabled
   fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
     const lapse = Date.now() - start;
-    assert.true(nearlyEqual(lapse, MILLIS_REFRESH_TOKEN * 2 + MILLIS_SSE_OPEN), 'sync after SSE connection is reopened a second time');
-    client.destroy().then(() => {
-      assert.end();
-    });
+    assert.true(nearlyEqual(lapse, MILLIS_REFRESH_TOKEN * 2), 'sync after SSE connection is reopened a second time');
+    setTimeout(() => {
+      client.destroy().then(() => {
+        assert.end();
+      });
+    }, 200); // destroy the client a little bit latter, to assert that there weren't new requests
     return { status: 500, body: 'server error' };
   });
 

--- a/src/__tests__/nodeSuites/push-synchronization.spec.js
+++ b/src/__tests__/nodeSuites/push-synchronization.spec.js
@@ -2,15 +2,17 @@ import splitChangesMock1 from '../mocks/splitchanges.since.-1.json';
 import splitChangesMock2 from '../mocks/splitchanges.since.1457552620999.json';
 import splitChangesMock3 from '../mocks/splitchanges.since.1457552620999.till.1457552649999.SPLIT_UPDATE.json';
 import splitChangesMock4 from '../mocks/splitchanges.since.1457552649999.till.1457552650000.SPLIT_KILL.json';
+import splitChangesMock5 from '../mocks/splitchanges.since.1457552650000.till.1457552650001.SPLIT_UPDATE.json';
 
 import splitUpdateMessage from '../mocks/message.SPLIT_UPDATE.1457552649999.json';
 import oldSplitUpdateMessage from '../mocks/message.SPLIT_UPDATE.1457552620999.json';
 import segmentUpdateMessage from '../mocks/message.SEGMENT_UPDATE.1457552640000.json';
 import splitKillMessage from '../mocks/message.SPLIT_KILL.1457552650000.json';
+import splitUpdateWithNewSegmentsMessage from '../mocks/message.SPLIT_UPDATE.1457552650001.json';
 
 import authPushEnabled from '../mocks/auth.pushEnabled.node.json';
 
-import { nearlyEqual, mockSegmentChanges } from '../testUtils';
+import { nearlyEqual, mockSegmentChanges, hasNoCacheHeader } from '../testUtils';
 
 import EventSourceMock, { setMockListener } from '../../sync/__tests__/mocks/eventSourceMock';
 import { __setEventSource } from '../../services/getEventSource/node';
@@ -19,6 +21,7 @@ import { SplitFactory } from '../../';
 import SettingsFactory from '../../utils/settings';
 
 const key = 'nicolas@split.io';
+const otherUserKey = 'marcio@split.io';
 
 const baseUrls = {
   sdk: 'https://sdk.push-synchronization/api',
@@ -40,7 +43,8 @@ const MILLIS_FIRST_SPLIT_UPDATE_EVENT = 200;
 const MILLIS_SECOND_SPLIT_UPDATE_EVENT = 300;
 const MILLIS_SEGMENT_UPDATE_EVENT = 400;
 const MILLIS_SPLIT_KILL_EVENT = 500;
-const MILLIS_DESTROY = 600;
+const MILLIS_SPLIT_UPDATE_EVENT_WITH_NEW_SEGMENTS = 600;
+const MILLIS_DESTROY = 700;
 
 /**
  * Sequence of calls:
@@ -50,13 +54,14 @@ const MILLIS_DESTROY = 600;
  *  0.3 secs: SPLIT_UPDATE event with old changeNumber
  *  0.4 secs: SEGMENT_UPDATE event -> /segmentChanges/
  *  0.5 secs: SPLIT_KILL event -> /splitChanges
+ *  0.6 secs: SPLIT_UPDATE event with new segments -> /splitChanges, /segmentChanges/{newSegments}
  */
 export function testSynchronization(fetchMock, assert) {
-  assert.plan(15);
+  assert.plan(21);
   fetchMock.reset();
   __setEventSource(EventSourceMock);
 
-  let start, splitio, client;
+  let start, splitio, client, sdkUpdateCount = 0;
 
   // mock SSE open and message events
   setMockListener(function (eventSourceInstance) {
@@ -97,8 +102,22 @@ export function testSynchronization(fetchMock, assert) {
       eventSourceInstance.emitMessage(splitKillMessage);
     }, MILLIS_SPLIT_KILL_EVENT); // send a SPLIT_KILL event with a new changeNumber after 0.5 seconds
     setTimeout(() => {
+      assert.equal(client.getTreatment(key, 'qc_team'), 'yes', 'evaluation previous to split update');
+      assert.equal(client.getTreatment(otherUserKey, 'qc_team'), 'no', 'evaluation previous to split update');
+
+      client.once(client.Event.SDK_UPDATE, () => {
+        const lapse = Date.now() - start;
+        assert.true(nearlyEqual(lapse, MILLIS_SPLIT_UPDATE_EVENT_WITH_NEW_SEGMENTS), 'SDK_UPDATE due to SPLIT_UPDATE event with new segments');
+        assert.equal(client.getTreatment(key, 'qc_team'), 'no', 'evaluation of updated Split');
+        assert.equal(client.getTreatment(otherUserKey, 'qc_team'), 'yes', 'evaluation of updated Split');
+      });
+      eventSourceInstance.emitMessage(splitUpdateWithNewSegmentsMessage);
+    }, MILLIS_SPLIT_UPDATE_EVENT_WITH_NEW_SEGMENTS); // send a SPLIT_UPDATE event with new segments after 0.6 seconds
+    setTimeout(() => {
       client.destroy().then(() => {
         assert.equal(client.getTreatment(key, 'whitelist'), 'control', 'evaluation returns control if client is destroyed');
+        // @TODO SDK_UPDATE should be emitted 4 times, but currently it is being emitted twice on SPLIT_KILL
+        assert.equal(sdkUpdateCount, 5, 'SDK_UPDATE should be emitted 5 times');
         assert.end();
       });
     }, MILLIS_DESTROY); // destroy client after 0.6 seconds
@@ -112,48 +131,66 @@ export function testSynchronization(fetchMock, assert) {
   });
 
   // initial split and segment sync
-  fetchMock.getOnce(settings.url('/splitChanges?since=-1'), function () {
+  fetchMock.getOnce(settings.url('/splitChanges?since=-1'), function (url, opts) {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, 0), 'initial sync');
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
     return { status: 200, body: splitChangesMock1 };
   });
-  fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=-1'),
-    { status: 200, body: { since: -1, till: 1457552620999, name: 'splitters', added: [key], removed: [] } }
-  );
+  fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=-1'), function (url, opts) {
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
+    return { status: 200, body: { since: -1, till: 1457552620999, name: 'splitters', added: [key], removed: [] } };
+  });
   // extra retry due to double request (greedy fetch). @TODO: remove once `SplitChangesUpdaterFactory` and `segmentChangesFetcher` are updated
-  fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=1457552620999'),
-    { status: 200, body: { since: 1457552620999, till: 1457552620999, name: 'splitters', added: [], removed: [] } }
-  );
+  fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=1457552620999'), function (url, opts) {
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
+    return { status: 200, body: { since: 1457552620999, till: 1457552620999, name: 'splitters', added: [], removed: [] } };
+  });
 
   // split and segment sync after SSE opened
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
+  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function (url, opts) {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_SSE_OPEN), 'sync after SSE connection is opened');
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
     return { status: 200, body: splitChangesMock2 };
   });
-  fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=1457552620999'),
-    { status: 200, body: { since: 1457552620999, till: 1457552620999, name: 'splitters', added: [], removed: [] } }
-  );
+  fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=1457552620999'), function (url, opts) {
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
+    return { status: 200, body: { since: 1457552620999, till: 1457552620999, name: 'splitters', added: [], removed: [] } };
+  });
 
   // fetch due to SPLIT_UPDATE event
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock3 });
+  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function (url, opts) {
+    if (!hasNoCacheHeader(opts)) assert.fail('request must include `Cache-Control` header');
+    return { status: 200, body: splitChangesMock3 };
+  });
 
   // fetch due to SEGMENT_UPDATE event
-  fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=1457552620999'),
-    { status: 200, body: { since: 1457552620999, till: 1457552640000, name: 'splitters', added: [], removed: [key] } }
-  );
-  // extra retry (fetch until since === till)
-  fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=1457552640000'),
-    { status: 200, body: { since: 1457552640000, till: 1457552640000, name: 'splitters', added: [], removed: [] } }
-  );
+  fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=1457552620999'), function (url, opts) {
+    if (!hasNoCacheHeader(opts)) assert.fail('request must include `Cache-Control` header');
+    return { status: 200, body: { since: 1457552620999, till: 1457552640000, name: 'splitters', added: [], removed: [key] } };
+  });
+  // extra retry (greedyFetch until since === till)
+  fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=1457552640000'), function (url, opts) {
+    if (!hasNoCacheHeader(opts)) assert.fail('request must include `Cache-Control` header');
+    return { status: 200, body: { since: 1457552640000, till: 1457552640000, name: 'splitters', added: [], removed: [] } };
+  });
 
   // fetch due to SPLIT_KILL event
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), function () {
+  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), function (url, opts) {
+    if (!hasNoCacheHeader(opts)) assert.fail('request must include `Cache-Control` header');
     assert.equal(client.getTreatment(key, 'whitelist'), 'not_allowed', 'evaluation with split killed immediately, before fetch is done');
     return { status: 200, body: splitChangesMock4 };
   });
 
+  // fetch due to SPLIT_UPDATE event, with an update that involves a new segment
+  fetchMock.getOnce(settings.url('/splitChanges?since=1457552650000'), function (url, opts) {
+    if (!hasNoCacheHeader(opts)) assert.fail('request must include `Cache-Control` header');
+    return { status: 200, body: splitChangesMock5 };
+  });
+
   mockSegmentChanges(fetchMock, new RegExp(`${settings.url('/segmentChanges')}/(employees|developers)`), [key]);
+  mockSegmentChanges(fetchMock, { url: new RegExp(`${settings.url('/segmentChanges')}/new_segment`), repeat: 2 }, [otherUserKey]);
 
   fetchMock.get(new RegExp('.*'), function (url) {
     assert.fail('unexpected GET request with url: ' + url);
@@ -164,5 +201,6 @@ export function testSynchronization(fetchMock, assert) {
   start = Date.now();
   splitio = SplitFactory(config);
   client = splitio.client();
+  client.on(client.Event.SDK_UPDATE, () => sdkUpdateCount++);
 
 }

--- a/src/__tests__/push/browser.spec.js
+++ b/src/__tests__/push/browser.spec.js
@@ -1,7 +1,7 @@
 import tape from 'tape-catch';
 import fetchMock from '../testUtils/fetchMock';
 import { testAuthWithPushDisabled, testAuthWith401, testNoEventSource, testNoBase64Support } from '../browserSuites/push-initialization-nopush.spec';
-import { testAuthRetries, testSSERetries, testSdkDestroyWhileAuthRetries, testSdkDestroyWhileAuthSuccess } from '../browserSuites/push-initialization-retries.spec';
+import { testPushRetriesDueToAuthErrors, testPushRetriesDueToSseErrors, testSdkDestroyWhileAuthRetries, testSdkDestroyWhileAuthSuccess } from '../browserSuites/push-initialization-retries.spec';
 import { testSynchronization } from '../browserSuites/push-synchronization.spec';
 import { testSynchronizationRetries } from '../browserSuites/push-synchronization-retries.spec';
 import { testFallbacking } from '../browserSuites/push-fallbacking.spec';
@@ -11,14 +11,17 @@ fetchMock.config.overwriteRoutes = false;
 
 tape('## Browser JS - E2E CI Tests for PUSH ##', function (assert) {
 
+  // Non-recoverable issues on inizialization
   assert.test('E2E / PUSH initialization: auth with push disabled', testAuthWithPushDisabled.bind(null, fetchMock));
   assert.test('E2E / PUSH initialization: auth with 401', testAuthWith401.bind(null, fetchMock));
   assert.test('E2E / PUSH initialization: fallback to polling if EventSource is not available', testNoEventSource.bind(null, fetchMock));
   assert.test('E2E / PUSH initialization: fallback to polling if EventSource is not available', testNoBase64Support.bind(null, fetchMock));
 
-  assert.test('E2E / PUSH initialization: auth failures and then success', testAuthRetries.bind(null, fetchMock));
-  assert.test('E2E / PUSH initialization: SSE connection failures and then success', testSSERetries.bind(null, fetchMock));
+  // Recoverable issues on inizialization
+  assert.test('E2E / PUSH initialization: auth failures and then success', testPushRetriesDueToAuthErrors.bind(null, fetchMock));
+  assert.test('E2E / PUSH initialization: SSE connection failures and then success', testPushRetriesDueToSseErrors.bind(null, fetchMock));
 
+  // Graceful shutdown
   assert.test('E2E / PUSH disconnection: SDK destroyed while authenticating', testSdkDestroyWhileAuthSuccess.bind(null, fetchMock));
   assert.test('E2E / PUSH disconnection: SDK destroyed while auth was retrying', testSdkDestroyWhileAuthRetries.bind(null, fetchMock));
 

--- a/src/__tests__/push/browser.spec.js
+++ b/src/__tests__/push/browser.spec.js
@@ -1,6 +1,6 @@
 import tape from 'tape-catch';
 import fetchMock from '../testUtils/fetchMock';
-import { testAuthWithPushDisabled, testAuthWith401, testNoEventSource, testNoBase64Support } from '../browserSuites/push-initialization-nopush.spec';
+import { testAuthWithPushDisabled, testAuthWith401, testNoEventSource, testNoBase64Support, testSSEWithNonRetryableError } from '../browserSuites/push-initialization-nopush.spec';
 import { testPushRetriesDueToAuthErrors, testPushRetriesDueToSseErrors, testSdkDestroyWhileAuthRetries, testSdkDestroyWhileAuthSuccess } from '../browserSuites/push-initialization-retries.spec';
 import { testSynchronization } from '../browserSuites/push-synchronization.spec';
 import { testSynchronizationRetries } from '../browserSuites/push-synchronization-retries.spec';
@@ -16,6 +16,7 @@ tape('## Browser JS - E2E CI Tests for PUSH ##', function (assert) {
   assert.test('E2E / PUSH initialization: auth with 401', testAuthWith401.bind(null, fetchMock));
   assert.test('E2E / PUSH initialization: fallback to polling if EventSource is not available', testNoEventSource.bind(null, fetchMock));
   assert.test('E2E / PUSH initialization: fallback to polling if EventSource is not available', testNoBase64Support.bind(null, fetchMock));
+  assert.test('E2E / PUSH initialization: sse with non-recoverable Ably error', testSSEWithNonRetryableError.bind(null, fetchMock));
 
   // Recoverable issues on inizialization
   assert.test('E2E / PUSH initialization: auth failures and then success', testPushRetriesDueToAuthErrors.bind(null, fetchMock));

--- a/src/__tests__/push/node.spec.js
+++ b/src/__tests__/push/node.spec.js
@@ -1,7 +1,7 @@
 import tape from 'tape-catch';
 import fetchMock from '../testUtils/fetchMock';
 import { testAuthWithPushDisabled, testAuthWith401, testAuthWith400, testNoEventSource } from '../nodeSuites/push-initialization-nopush.spec';
-import { testAuthRetries, testSSERetries, testSdkDestroyWhileAuthRetries, testSdkDestroyWhileAuthSuccess } from '../nodeSuites/push-initialization-retries.spec';
+import { testPushRetriesDueToAuthErrors, testPushRetriesDueToSseErrors, testSdkDestroyWhileAuthRetries, testSdkDestroyWhileAuthSuccess } from '../nodeSuites/push-initialization-retries.spec';
 import { testSynchronization } from '../nodeSuites/push-synchronization.spec';
 import { testSynchronizationRetries } from '../nodeSuites/push-synchronization-retries.spec';
 import { testFallbacking } from '../nodeSuites/push-fallbacking.spec';
@@ -11,14 +11,17 @@ fetchMock.config.overwriteRoutes = false;
 
 tape('## Node JS - E2E CI Tests for PUSH ##', async function (assert) {
 
+  // Non-recoverable issues on inizialization
   assert.test('E2E / PUSH initialization: auth with push disabled', testAuthWithPushDisabled.bind(null, fetchMock));
   assert.test('E2E / PUSH initialization: auth with 401', testAuthWith401.bind(null, fetchMock));
   assert.test('E2E / PUSH initialization: auth with 400', testAuthWith400.bind(null, fetchMock));
   assert.test('E2E / PUSH initialization: fallback to polling if EventSource is not available', testNoEventSource.bind(null, fetchMock));
 
-  assert.test('E2E / PUSH initialization: auth failures and then success', testAuthRetries.bind(null, fetchMock));
-  assert.test('E2E / PUSH initialization: SSE connection failures and then success', testSSERetries.bind(null, fetchMock));
+  // Recoverable issues on inizialization
+  assert.test('E2E / PUSH initialization: auth failures and then success', testPushRetriesDueToAuthErrors.bind(null, fetchMock));
+  assert.test('E2E / PUSH initialization: SSE connection failures and then success', testPushRetriesDueToSseErrors.bind(null, fetchMock));
 
+  // Graceful shutdown
   assert.test('E2E / PUSH disconnection: SDK destroyed while authenticating', testSdkDestroyWhileAuthSuccess.bind(null, fetchMock));
   assert.test('E2E / PUSH disconnection: SDK destroyed while auth was retrying', testSdkDestroyWhileAuthRetries.bind(null, fetchMock));
 

--- a/src/__tests__/push/node.spec.js
+++ b/src/__tests__/push/node.spec.js
@@ -1,6 +1,6 @@
 import tape from 'tape-catch';
 import fetchMock from '../testUtils/fetchMock';
-import { testAuthWithPushDisabled, testAuthWith401, testAuthWith400, testNoEventSource } from '../nodeSuites/push-initialization-nopush.spec';
+import { testAuthWithPushDisabled, testAuthWith401, testAuthWith400, testNoEventSource, testSSEWithNonRetryableError } from '../nodeSuites/push-initialization-nopush.spec';
 import { testPushRetriesDueToAuthErrors, testPushRetriesDueToSseErrors, testSdkDestroyWhileAuthRetries, testSdkDestroyWhileAuthSuccess } from '../nodeSuites/push-initialization-retries.spec';
 import { testSynchronization } from '../nodeSuites/push-synchronization.spec';
 import { testSynchronizationRetries } from '../nodeSuites/push-synchronization-retries.spec';
@@ -16,6 +16,7 @@ tape('## Node JS - E2E CI Tests for PUSH ##', async function (assert) {
   assert.test('E2E / PUSH initialization: auth with 401', testAuthWith401.bind(null, fetchMock));
   assert.test('E2E / PUSH initialization: auth with 400', testAuthWith400.bind(null, fetchMock));
   assert.test('E2E / PUSH initialization: fallback to polling if EventSource is not available', testNoEventSource.bind(null, fetchMock));
+  assert.test('E2E / PUSH initialization: sse with non-recoverable Ably error', testSSEWithNonRetryableError.bind(null, fetchMock));
 
   // Recoverable issues on inizialization
   assert.test('E2E / PUSH initialization: auth failures and then success', testPushRetriesDueToAuthErrors.bind(null, fetchMock));

--- a/src/__tests__/testUtils/index.js
+++ b/src/__tests__/testUtils/index.js
@@ -38,3 +38,7 @@ export function mockSegmentChanges(fetchMock, matcher, keys, changeNumber = 1457
     };
   });
 }
+
+export function hasNoCacheHeader(fetchMockOpts) {
+  return fetchMockOpts.headers['Cache-Control'] === 'no-cache';
+}

--- a/src/producer/browser.js
+++ b/src/producer/browser.js
@@ -35,10 +35,13 @@ const FullBrowserProducer = (context) => {
 
   let isSynchronizingSplits = false;
 
-  function synchronizeSplits() {
+  /**
+   * @param {boolean | undefined} noCache true to revalidate data to fetch
+   */
+  function synchronizeSplits(noCache) {
     isSynchronizingSplits = true;
     // `splitsUpdater` promise always resolves, and with a false value if it fails to fetch or store splits
-    return splitsUpdater().then(function (res) {
+    return splitsUpdater(0, noCache).then(function (res) {
       isSynchronizingSplits = false;
       return res;
     });

--- a/src/producer/browser/Partial.js
+++ b/src/producer/browser/Partial.js
@@ -40,11 +40,12 @@ const PartialBrowserProducer = (context) => {
 
   /**
    * @param {string[] | undefined} segmentList might be undefined
+   * @param {boolean | undefined} noCache true to revalidate data to fetch
    */
-  function synchronizeMySegments(segmentList) {
+  function synchronizeMySegments(segmentList, noCache) {
     isSynchronizingMySegments = true;
     // `mySegmentsUpdater` promise always resolves, and with a false value if it fails to fetch or store mySegments
-    return mySegmentsUpdater(0, segmentList).then(function (res) {
+    return mySegmentsUpdater(0, segmentList, noCache).then(function (res) {
       isSynchronizingMySegments = false;
       return res;
     });

--- a/src/producer/fetcher/MySegments.js
+++ b/src/producer/fetcher/MySegments.js
@@ -20,8 +20,8 @@ import { SplitError } from '../../utils/lang/Errors';
 import mySegmentsService from '../../services/mySegments';
 import mySegmentsRequest from '../../services/mySegments/get';
 
-const mySegmentsFetcher = (settings, startingUp = false, metricCollectors) => {
-  let mySegmentsPromise = mySegmentsService(mySegmentsRequest(settings));
+const mySegmentsFetcher = (settings, startingUp = false, metricCollectors, noCache) => {
+  let mySegmentsPromise = mySegmentsService(mySegmentsRequest(settings, noCache));
 
   mySegmentsPromise = tracker.start(tracker.TaskNames.MY_SEGMENTS_FETCH, startingUp ? metricCollectors : false, mySegmentsPromise);
 

--- a/src/producer/fetcher/SegmentChanges.js
+++ b/src/producer/fetcher/SegmentChanges.js
@@ -18,11 +18,11 @@ import segmentChangesService from '../../services/segmentChanges';
 import segmentChangesRequest from '../../services/segmentChanges/get';
 import tracker from '../../utils/timeTracker';
 
-function greedyFetch(settings, lastSinceValue, segmentName, metricCollectors) {
+function greedyFetch(settings, lastSinceValue, segmentName, metricCollectors, noCache) {
   return tracker.start(tracker.TaskNames.SEGMENTS_FETCH, metricCollectors, segmentChangesService(segmentChangesRequest(settings, {
     since: lastSinceValue,
     segmentName
-  })))
+  }, noCache)))
     // no need to handle json parsing errors as SplitError, since errors are handled differently for segments
     .then(resp => resp.json())
     .then(json => {
@@ -30,7 +30,7 @@ function greedyFetch(settings, lastSinceValue, segmentName, metricCollectors) {
       if (since === till) {
         return [json];
       } else {
-        return Promise.all([json, greedyFetch(settings, till, segmentName)]).then(flatMe => {
+        return Promise.all([json, greedyFetch(settings, till, segmentName, undefined, noCache)]).then(flatMe => {
           return [flatMe[0], ...flatMe[1]];
         });
       }
@@ -45,8 +45,8 @@ function greedyFetch(settings, lastSinceValue, segmentName, metricCollectors) {
 }
 
 // @TODO migrate to a generator function and do the job incrementally
-function segmentChangesFetcher(settings, segmentName, since, metricCollectors) {
-  return greedyFetch(settings, since, segmentName, metricCollectors);
+function segmentChangesFetcher(settings, segmentName, since, metricCollectors, noCache) {
+  return greedyFetch(settings, since, segmentName, metricCollectors, noCache);
 }
 
 export default segmentChangesFetcher;

--- a/src/producer/fetcher/SplitChanges.js
+++ b/src/producer/fetcher/SplitChanges.js
@@ -20,9 +20,9 @@ import { SplitError } from '../../utils/lang/Errors';
 import splitChangesService from '../../services/splitChanges';
 import splitChangesRequest from '../../services/splitChanges/get';
 
-function splitChangesFetcher(settings, since, startingUp = false, metricCollectors, isNode) {
+function splitChangesFetcher(settings, since, startingUp = false, metricCollectors, isNode, noCache) {
   const filterQueryString = settings.sync.__splitFiltersValidation.queryString;
-  let splitsPromise = splitChangesService(splitChangesRequest(settings, since, filterQueryString));
+  let splitsPromise = splitChangesService(splitChangesRequest(settings, since, filterQueryString, noCache));
   const collectMetrics = startingUp || isNode; // If we are on the browser, only collect this metric for first fetch. On node do it always.
 
   splitsPromise = tracker.start(tracker.TaskNames.SPLITS_FETCH, collectMetrics ? metricCollectors : false, splitsPromise);

--- a/src/producer/node.js
+++ b/src/producer/node.js
@@ -35,10 +35,13 @@ const NodeUpdater = (context) => {
   let isSynchronizingSplits = false;
   let isSynchronizingSegments = false;
 
-  function synchronizeSplits() {
+  /**
+   * @param {boolean | undefined} noCache true to revalidate data to fetch
+   */
+  function synchronizeSplits(noCache) {
     isSynchronizingSplits = true;
     // `splitsUpdater` promise always resolves, and with a false value if it fails to fetch or store splits
-    return splitsUpdater().then(function (res) {
+    return splitsUpdater(0, noCache).then(function (res) {
       // Mark splits as ready (track first successfull call to start downloading segments)
       splitFetchCompleted = true;
       isSynchronizingSplits = false;
@@ -48,11 +51,14 @@ const NodeUpdater = (context) => {
 
   /**
    * @param {string[] | undefined} segmentNames list of segment names to fetch. By passing `undefined` it fetches the list of segments registered at the storage
+   * @param {boolean | undefined} fetchOnlyNew if true, only fetch the segments that not exists, i.e., which `changeNumber` is equal to -1.
+   * This param is used by SplitUpdateWorker on server-side SDK, to fetch new registered segments on SPLIT_UPDATE notifications.
+   * @param {boolean | undefined} noCache true to revalidate data to fetch on a SEGMENT_UPDATE notifications.
    */
-  function synchronizeSegment(segmentNames) {
+  function synchronizeSegment(segmentNames, fetchOnlyNew, noCache) {
     isSynchronizingSegments = true;
     // `segmentsUpdater` promise always resolves, and with a false value if it fails to fetch or store some segment
-    return segmentsUpdater(segmentNames).then(function (res) {
+    return segmentsUpdater(segmentNames, fetchOnlyNew, noCache).then(function (res) {
       isSynchronizingSegments = false;
       return res;
     });

--- a/src/producer/updater/MySegments.js
+++ b/src/producer/updater/MySegments.js
@@ -49,8 +49,9 @@ export default function MySegmentsUpdaterFactory(context) {
    *
    * @param {number | undefined} retry current number of retry attemps. this param is only set by SplitChangesUpdater itself.
    * @param {string[] | undefined} segmentList list of mySegment names to sync in the storage. If the list is `undefined`, it fetches them before syncing in the storage.
+   * @param {boolean | undefined} noCache true to revalidate data to fetch
    */
-  return function MySegmentsUpdater(retry = 0, segmentList) {
+  return function MySegmentsUpdater(retry = 0, segmentList, noCache) {
     let updaterPromise;
 
     if (segmentList) {
@@ -58,7 +59,7 @@ export default function MySegmentsUpdaterFactory(context) {
       updaterPromise = new Promise((res) => { updateSegments(segmentList); res();});
     } else {
       // NOTE: We only collect metrics on startup.
-      updaterPromise = mySegmentsFetcher(settings, startingUp, metricCollectors).then(segments => {
+      updaterPromise = mySegmentsFetcher(settings, startingUp, metricCollectors, noCache).then(segments => {
         // Only when we have downloaded segments completely, we should not keep retrying anymore
         startingUp = false;
 

--- a/src/producer/updater/SegmentChanges.js
+++ b/src/producer/updater/SegmentChanges.js
@@ -30,6 +30,7 @@ export default function SegmentChangesUpdaterFactory(context) {
     [context.constants.COLLECTORS]: metricCollectors
   } = context.getAll();
   const segmentsEventEmitter = readiness.segments;
+  const segmentsStorage = storage.segments;
 
   let readyOnAlreadyExistentState = true;
 
@@ -38,8 +39,11 @@ export default function SegmentChangesUpdaterFactory(context) {
    * Thus, a false result doesn't imply that SDK_SEGMENTS_ARRIVED was not emitted.
    *
    * @param {string[] | undefined} segmentNames list of segment names to fetch. By passing `undefined` it fetches the list of segments registered at the storage
+   * @param {boolean | undefined} fetchOnlyNew if true, only fetch the segments that not exists, i.e., which `changeNumber` is equal to -1.
+   * This param is used by SplitUpdateWorker on server-side SDK, to fetch new registered segments on SPLIT_UPDATE notifications.
+   * @param {boolean | undefined} noCache true to revalidate data to fetch on a SEGMENT_UPDATE notifications.
    */
-  return function SegmentChangesUpdater(segmentNames) {
+  return function SegmentChangesUpdater(segmentNames, fetchOnlyNew, noCache) {
     log.debug('Started segments update');
 
     // Async fetchers are collected here.
@@ -54,21 +58,21 @@ export default function SegmentChangesUpdaterFactory(context) {
         const segmentUpdater = function (since) {
           log.debug(`Processing segment ${segmentName}`);
 
-          updaters.push(segmentChangesFetcher(settings, segmentName, since, metricCollectors).then(function (changes) {
+          updaters.push(segmentChangesFetcher(settings, segmentName, since, metricCollectors, noCache).then(function (changes) {
             let changeNumber = -1;
             const changePromises = [];
             changes.forEach(x => {
               let promises = [];
               if (x.added.length > 0) {
-                const result = storage.segments.addToSegment(segmentName, x.added);
+                const result = segmentsStorage.addToSegment(segmentName, x.added);
                 if (thenable(result)) promises.push(result);
               }
               if (x.removed.length > 0) {
-                const result = storage.segments.removeFromSegment(segmentName, x.removed);
+                const result = segmentsStorage.removeFromSegment(segmentName, x.removed);
                 if (thenable(result)) promises.push(result);
               }
               if (x.added.length > 0 || x.removed.length > 0) {
-                const result = storage.segments.setChangeNumber(segmentName, x.till);
+                const result = segmentsStorage.setChangeNumber(segmentName, x.till);
                 if (thenable(result)) promises.push(result);
                 changeNumber = x.till;
               }
@@ -84,7 +88,7 @@ export default function SegmentChangesUpdaterFactory(context) {
           }));
         };
 
-        const since = storage.segments.getChangeNumber(segmentName);
+        const since = segmentsStorage.getChangeNumber(segmentName);
         const sincePromise = thenable(since) ? since.then(segmentUpdater) : segmentUpdater(since);
         sincePromises.push(sincePromise);
       }
@@ -113,7 +117,9 @@ export default function SegmentChangesUpdaterFactory(context) {
     }
 
     // If not a segment name provided, read list of available segments names to be updated.
-    const segments = segmentNames ? segmentNames : storage.segments.getRegisteredSegments();
+    let segments = segmentNames ? segmentNames : segmentsStorage.getRegisteredSegments();
+    if(fetchOnlyNew) segments = segments.filter(segmentName => segmentsStorage.getChangeNumber(segmentName) === -1 );
+
     return thenable(segments) ? segments.then(segmentsUpdater) : segmentsUpdater(segments);
   };
 

--- a/src/producer/updater/SplitChanges.js
+++ b/src/producer/updater/SplitChanges.js
@@ -22,6 +22,11 @@ import { SplitError } from '../../utils/lang/Errors';
 import { _Set, setToArray } from '../../utils/lang/Sets';
 import thenable from '../../utils/promise/thenable';
 
+// For server-side segments storage, returns true if all registered segments have been fetched (changeNumber !== -1)
+function checkAllSegmentsExist(segmentsStorage) {
+  return segmentsStorage.getRegisteredSegments().every(segmentName => segmentsStorage.getChangeNumber(segmentName) !== -1);
+}
+
 function computeSplitsMutation(entries) {
   const computed = entries.reduce((accum, split) => {
     if (split.status === 'ACTIVE') {
@@ -62,13 +67,14 @@ export default function SplitChangesUpdaterFactory(context, isNode = false) {
    * Split updater returns a promise that resolves with a `false` boolean value if it fails to fetch splits or synchronize them with the storage.
    *
    * @param {number | undefined} retry current number of retry attemps. this param is only set by SplitChangesUpdater itself.
+   * @param {boolean | undefined} noCache true to revalidate data to fetch
    */
-  return function SplitChangesUpdater(retry = 0) {
+  return function SplitChangesUpdater(retry = 0, noCache) {
 
     function splitChanges(since) {
       log.debug(`Spin up split update using since = ${since}`);
 
-      const fetcherPromise = splitChangesFetcher(settings, since, startingUp, metricCollectors, isNode)
+      const fetcherPromise = splitChangesFetcher(settings, since, startingUp, metricCollectors, isNode, noCache)
         .then(splitChanges => {
           startingUp = false;
 
@@ -87,7 +93,8 @@ export default function SplitChangesUpdaterFactory(context, isNode = false) {
             storage.splits.removeSplits(mutation.removed),
             storage.segments.registerSegments(mutation.segments)
           ]).then(() => {
-            if (since !== splitChanges.till || readyOnAlreadyExistentState) {
+            // On server-side SDK, we must check that all registered segments have been fetched
+            if (readyOnAlreadyExistentState || (since !== splitChanges.till && (!isNode || checkAllSegmentsExist(storage.segments)))) {
               readyOnAlreadyExistentState = false;
               splitsEventEmitter.emit(splitsEventEmitter.SDK_SPLITS_ARRIVED);
             }
@@ -105,7 +112,7 @@ export default function SplitChangesUpdaterFactory(context, isNode = false) {
           if (startingUp && settings.startup.retriesOnFailureBeforeReady > retry) {
             retry += 1;
             log.info(`Retrying download of splits #${retry}. Reason: ${error}`);
-            return SplitChangesUpdater(retry);
+            return SplitChangesUpdater(retry, noCache);
           } else {
             startingUp = false;
           }

--- a/src/readiness/index.js
+++ b/src/readiness/index.js
@@ -46,6 +46,7 @@ function GateContext() {
     });
 
     splits.on(Events.SDK_SPLITS_ARRIVED, (isSplitKill) => {
+      // `isSplitKill` condition avoids emitting SDK_READY if `/mySegments` fetch and SPLIT_KILL occurs before `/splitChanges` fetch
       if (!isSplitKill) splitsStatus = SPLITS_READY;
       gate.emit(Events.READINESS_GATE_CHECK_STATE);
     });

--- a/src/services/mySegments/get.js
+++ b/src/services/mySegments/get.js
@@ -13,15 +13,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **/
-import base from '../request';
+import base, { noCacheExtraHeader } from '../request';
 import { matching } from '../../utils/key/factory';
 
-export default function GET(settings) {
+export default function GET(settings, noCache) {
   /**
    * URI encoding of user keys in order to:
    *  - avoid 400 responses (due to URI malformed). E.g.: '/api/mySegments/%'
    *  - avoid 404 responses. E.g.: '/api/mySegments/foo/bar'
    *  - match user keys with special characters. E.g.: 'foo%bar', 'foo/bar'
    */
-  return base(settings, `/mySegments/${encodeURIComponent(matching(settings.core.key))}`);
+  return base(settings, `/mySegments/${encodeURIComponent(matching(settings.core.key))}`, undefined, noCache ? noCacheExtraHeader : undefined);
 }

--- a/src/services/request/index.js
+++ b/src/services/request/index.js
@@ -39,3 +39,5 @@ function RequestFactory(settings, relativeUrl, params, extraHeaders) {
 }
 
 export default RequestFactory;
+
+export const noCacheExtraHeader = { 'Cache-Control': 'no-cache' };

--- a/src/services/segmentChanges/get.js
+++ b/src/services/segmentChanges/get.js
@@ -13,8 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **/
-import base from '../request';
+import base, { noCacheExtraHeader } from '../request';
 
-export default function GET(settings, {since, segmentName}) {
-  return base(settings, `/segmentChanges/${segmentName}?since=${since}`);
+export default function GET(settings, {since, segmentName}, noCache) {
+  return base(settings, `/segmentChanges/${segmentName}?since=${since}`, undefined, noCache ? noCacheExtraHeader : undefined);
 }

--- a/src/services/splitChanges/get.js
+++ b/src/services/splitChanges/get.js
@@ -13,8 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **/
-import base from '../request';
+import base, { noCacheExtraHeader } from '../request';
 
-export default function GET(settings, since, filterQueryString) {
-  return base(settings, `/splitChanges?since=${since}${filterQueryString || ''}`);
+export default function GET(settings, since, filterQueryString, noCache) {
+  return base(settings, `/splitChanges?since=${since}${filterQueryString || ''}`, undefined, noCache ? noCacheExtraHeader : undefined);
 }

--- a/src/sync/PushManager/index.js
+++ b/src/sync/PushManager/index.js
@@ -11,7 +11,7 @@ import SSEHandlerFactory from '../SSEHandler';
 import Backoff from '../../utils/backoff';
 import { hashUserKey } from '../../utils/jwt/hashUserKey';
 import logFactory from '../../utils/logger';
-import { SECONDS_BEFORE_EXPIRATION, PUSH_DISCONNECT, PUSH_DISABLED, SSE_ERROR, SPLIT_KILL, SPLIT_UPDATE, SEGMENT_UPDATE, MY_SEGMENTS_UPDATE } from '../constants';
+import { SECONDS_BEFORE_EXPIRATION, PUSH_SUBSYSTEM_DOWN, PUSH_NONRETRYABLE_ERROR, PUSH_RETRYABLE_ERROR, SPLIT_KILL, SPLIT_UPDATE, SEGMENT_UPDATE, MY_SEGMENTS_UPDATE } from '../constants';
 
 const log = logFactory('splitio-sync:push-manager');
 
@@ -45,10 +45,9 @@ export default function PushManagerFactory(context, clientContexts /* undefined 
 
   /** PushManager functions related to initialization */
 
-  const reauthBackoff = new Backoff(connectPush, settings.scheduler.authRetryBackoffBase);
-  const sseReconnectBackoff = new Backoff(sseClient.reopen, settings.scheduler.streamingReconnectBackoffBase);
+  const connectPushRetryBackoff = new Backoff(connectPush, settings.scheduler.pushRetryBackoffBase);
 
-  let timeoutId = 0;
+  let timeoutId;
 
   function scheduleTokenRefresh(issuedAt, expirationTime) {
     // clear scheduled token refresh if exists (needed when resuming PUSH)
@@ -69,16 +68,16 @@ export default function PushManagerFactory(context, clientContexts /* undefined 
     const userKeys = clientContexts ? Object.keys(clientContexts) : undefined;
     authenticate(settings, userKeys).then(
       function (authData) {
-        if (disconnected) return;
+        if (disconnected) return; // the SDK has been destroyed or PUSH_NONRETRYABLE_ERROR emitted (e.g., STREAMING_DISABLED notification)
 
         // restart backoff retry counter for auth and SSE connections, due to HTTP/network errors
-        reauthBackoff.reset();
-        sseReconnectBackoff.reset(); // reset backoff in case SSE conexion has opened after a HTTP or network error.
+        connectPushRetryBackoff.reset();
 
-        // emit PUSH_DISCONNECT if org is not whitelisted
+        // 'pushEnabled: false' is handled as a PUSH_NONRETRYABLE_ERROR instead of PUSH_SUBSYSTEM_DOWN, in order to
+        // close the sseClient in case the org has been bloqued while the instance was connected to streaming
         if (!authData.pushEnabled) {
           log.info('Streaming is not available. Switching to polling mode.');
-          pushEmitter.emit(PUSH_DISCONNECT); // there is no need to close sseClient (it is not open on this scenario)
+          pushEmitter.emit(PUSH_NONRETRYABLE_ERROR);
           return;
         }
 
@@ -92,22 +91,18 @@ export default function PushManagerFactory(context, clientContexts /* undefined 
       }
     ).catch(
       function (error) {
-        if (disconnected) return;
+        if (disconnected) return; // the SDK has been destroyed or PUSH_NONRETRYABLE_ERROR emitted (e.g., STREAMING_DISABLED notification)
 
-        sseClient.close(); // no harm if already closed
-        pushEmitter.emit(PUSH_DISCONNECT); // no harm if `PUSH_DISCONNECT` was already notified
-
-        const errorMessage = `Failed to authenticate for streaming. Error: "${error.message}".`;
+        log.error(`Failed to authenticate for streaming. Error: "${error.message}".`);
 
         // Handle 4XX HTTP errors: 401 (invalid API Key) or 400 (using incorrect API Key, i.e., client-side API Key on server-side)
         if (error.statusCode >= 400 && error.statusCode < 500) {
-          log.error(errorMessage);
+          pushEmitter.emit(PUSH_NONRETRYABLE_ERROR);
           return;
         }
 
-        // Handle other HTTP and network errors
-        const delayInMillis = reauthBackoff.scheduleCall();
-        log.error(`${errorMessage}. Attempting to reauthenticate in ${delayInMillis / 1000} seconds.`);
+        // Handle other HTTP and network errors as recoverable errors
+        pushEmitter.emit(PUSH_RETRYABLE_ERROR);
       }
     );
   }
@@ -119,8 +114,9 @@ export default function PushManagerFactory(context, clientContexts /* undefined 
     sseClient.close();
 
     if (timeoutId) clearTimeout(timeoutId);
-    reauthBackoff.reset();
-    sseReconnectBackoff.reset();
+    connectPushRetryBackoff.reset();
+
+    stopWorkers();
   }
 
   // cancel scheduled fetch retries of Split, Segment, and MySegment Update Workers
@@ -128,33 +124,28 @@ export default function PushManagerFactory(context, clientContexts /* undefined 
     workers.forEach(worker => worker.backoff.reset());
   }
 
-  pushEmitter.on(PUSH_DISCONNECT, stopWorkers);
+  pushEmitter.on(PUSH_SUBSYSTEM_DOWN, stopWorkers);
 
-  /** Fallbacking due to STREAMING_DISABLED control event */
+  /** Fallbacking without retry due to STREAMING_DISABLED control event, 'pushEnabled: false', and non-recoverable SSE and Authentication errors */
 
-  pushEmitter.on(PUSH_DISABLED, function () {
+  pushEmitter.on(PUSH_NONRETRYABLE_ERROR, function handleNonRetryableError() {
+    // Note: `stopWorkers` is been called twice, but it is not harmful
     disconnectPush();
-    pushEmitter.emit(PUSH_DISCONNECT); // no harm if polling already
+    pushEmitter.emit(PUSH_SUBSYSTEM_DOWN); // no harm if polling already
   });
 
-  /** Fallbacking due to SSE errors */
+  /** Fallbacking with retry due to recoverable SSE and Authentication errors */
 
-  pushEmitter.on(SSE_ERROR, function (error) { // HTTP or network error in SSE connection
+  pushEmitter.on(PUSH_RETRYABLE_ERROR, function handleRetryableError() { // HTTP or network error in SSE connection
     // SSE connection is closed to avoid repeated errors due to retries
     sseClient.close();
 
-    // retries are handled via backoff algorithm
-    let delayInMillis;
-    if (error.parsedData && (error.parsedData.statusCode === 400 || error.parsedData.statusCode === 401)) {
-      delayInMillis = reauthBackoff.scheduleCall(); // reauthenticate in case of token invalid or expired (when somehow refresh token was not properly executed)
-    } else {
-      delayInMillis = sseReconnectBackoff.scheduleCall(); // reconnect SSE for any other network or HTTP error
-    }
+    // retry streaming reconnect with backoff algorithm
+    let delayInMillis = connectPushRetryBackoff.scheduleCall();
 
-    const errorMessage = error.parsedData && error.parsedData.message;
-    log.error(`Fail to connect to streaming${errorMessage ? `, with error message: "${errorMessage}"` : ''}. Attempting to reconnect in ${delayInMillis / 1000} seconds.`);
+    log.info(`Attempting to reconnect in ${delayInMillis / 1000} seconds.`);
 
-    pushEmitter.emit(PUSH_DISCONNECT); // no harm if polling already
+    pushEmitter.emit(PUSH_SUBSYSTEM_DOWN); // no harm if polling already
   });
 
   /** Functions related to synchronization (Queues and Workers in the spec) */
@@ -188,10 +179,7 @@ export default function PushManagerFactory(context, clientContexts /* undefined 
     Object.create(pushEmitter),
     {
       // Expose functionality for starting and stoping push mode:
-      stop() {
-        disconnectPush();
-        stopWorkers(); // if we call `stopWorkers` inside `disconnectPush`, it would be called twice on a PUSH_DISABLED event, which anyway is not harmful.
-      },
+      stop: disconnectPush, // `handleNonRetryableError` cannot be used as `stop`, because it emits PUSH_SUBSYSTEM_DOWN event, which start polling.
 
       // used in node
       start: connectPush,

--- a/src/sync/SSEHandler/NotificationKeeper.js
+++ b/src/sync/SSEHandler/NotificationKeeper.js
@@ -1,4 +1,4 @@
-import { PUSH_CONNECT, PUSH_DISCONNECT, PUSH_DISABLED, ControlTypes } from '../constants';
+import { PUSH_SUBSYSTEM_UP, PUSH_SUBSYSTEM_DOWN, PUSH_NONRETRYABLE_ERROR, ControlTypes } from '../constants';
 
 const CONTROL_PRI_CHANNEL_REGEX = /control_pri$/;
 
@@ -11,7 +11,7 @@ export default function notificationKeeperFactory(feedbackLoopEmitter) {
 
   return {
     handleOpen() {
-      feedbackLoopEmitter.emit(PUSH_CONNECT);
+      feedbackLoopEmitter.emit(PUSH_SUBSYSTEM_UP);
     },
 
     isStreamingUp() {
@@ -23,9 +23,9 @@ export default function notificationKeeperFactory(feedbackLoopEmitter) {
         occupancyTimestamp = timestamp;
         if (hasResumed) {
           if (publishers === 0 && hasPublishers) {
-            feedbackLoopEmitter.emit(PUSH_DISCONNECT); // notify(STREAMING_DOWN) in spec
+            feedbackLoopEmitter.emit(PUSH_SUBSYSTEM_DOWN);
           } else if (publishers !== 0 && !hasPublishers) {
-            feedbackLoopEmitter.emit(PUSH_CONNECT); // notify(STREAMING_UP) in spec
+            feedbackLoopEmitter.emit(PUSH_SUBSYSTEM_UP);
           }
           // nothing to do when hasResumed === false:
           // streaming is already down for `publishers === 0`, and cannot be up for `publishers !== 0`
@@ -38,12 +38,12 @@ export default function notificationKeeperFactory(feedbackLoopEmitter) {
       if (CONTROL_PRI_CHANNEL_REGEX.test(channel) && timestamp > controlTimestamp) {
         controlTimestamp = timestamp;
         if (controlType === ControlTypes.STREAMING_DISABLED) {
-          feedbackLoopEmitter.emit(PUSH_DISABLED);
+          feedbackLoopEmitter.emit(PUSH_NONRETRYABLE_ERROR);
         } else if (hasPublishers) {
           if (controlType === ControlTypes.STREAMING_PAUSED && hasResumed) {
-            feedbackLoopEmitter.emit(PUSH_DISCONNECT); // notify(STREAMING_DOWN) in spec
+            feedbackLoopEmitter.emit(PUSH_SUBSYSTEM_DOWN);
           } else if (controlType === ControlTypes.STREAMING_RESUMED && !hasResumed) {
-            feedbackLoopEmitter.emit(PUSH_CONNECT); // notify(STREAMING_UP) in spec
+            feedbackLoopEmitter.emit(PUSH_SUBSYSTEM_UP);
           }
           // nothing to do when hasPublishers === false:
           // streaming is already down for `STREAMING_PAUSED`, and cannot be up for `STREAMING_RESUMED`

--- a/src/sync/SSEHandler/index.js
+++ b/src/sync/SSEHandler/index.js
@@ -1,8 +1,20 @@
 import { errorParser, messageParser } from './NotificationParser';
 import notificationKeeperFactory from './NotificationKeeper';
-import { SSE_ERROR, SPLIT_UPDATE, SEGMENT_UPDATE, MY_SEGMENTS_UPDATE, SPLIT_KILL, OCCUPANCY, CONTROL } from '../constants';
+import { PUSH_RETRYABLE_ERROR, PUSH_NONRETRYABLE_ERROR, SPLIT_UPDATE, SEGMENT_UPDATE, MY_SEGMENTS_UPDATE, SPLIT_KILL, OCCUPANCY, CONTROL } from '../constants';
 import logFactory from '../../utils/logger';
 const log = logFactory('splitio-sync:sse-handler');
+
+function isRetryableError(error) {
+  if (error.parsedData && error.parsedData.code) {
+    const code = error.parsedData.code;
+    // 401 errors due to invalid or expired token (e.g., if refresh token coudn't be executed)
+    if (40140 <= code && code <= 40149) return true;
+    // Others 4XX errors (e.g., bad request from the SDK)
+    if (40000 <= code && code <= 49999) return false;
+  }
+  // network errors or 5XX HTTP errors
+  return true;
+}
 
 /**
  * Factory for SSEHandler
@@ -27,7 +39,14 @@ export default function SSEHandlerFactory(pushEmitter) {
         log.warn(`Error parsing SSE error notification: ${err}`);
       }
 
-      pushEmitter.emit(SSE_ERROR, errorWithParsedData);
+      let errorMessage = errorWithParsedData.parsedData && errorWithParsedData.parsedData.message;
+      log.error(`Fail to connect to streaming${errorMessage ? `, with error message: "${errorMessage}"` : ''}`);
+
+      if (isRetryableError(errorWithParsedData)) {
+        pushEmitter.emit(PUSH_RETRYABLE_ERROR);
+      } else {
+        pushEmitter.emit(PUSH_NONRETRYABLE_ERROR);
+      }
     },
 
     /* NotificationProcessor */

--- a/src/sync/SegmentUpdateWorker/browser.js
+++ b/src/sync/SegmentUpdateWorker/browser.js
@@ -28,7 +28,9 @@ export default class MySegmentUpdateWorker {
     if (this.maxChangeNumber > this.currentChangeNumber) {
       this.handleNewEvent = false;
       const currentMaxChangeNumber = this.maxChangeNumber;
-      this.mySegmentsProducer.synchronizeMySegments(this.segmentList).then((result) => {
+
+      // fetch mySegments revalidating data if cached
+      this.mySegmentsProducer.synchronizeMySegments(this.segmentList, true).then((result) => {
         if (result !== false) // Unlike `Split\SegmentUpdateWorker`, we cannot use `mySegmentsStorage.getChangeNumber` since `/mySegments` endpoint doesn't provide this value.
           this.currentChangeNumber = Math.max(this.currentChangeNumber, currentMaxChangeNumber); // use `currentMaxChangeNumber`, in case that `this.maxChangeNumber` was updated during fetch.
         if (this.handleNewEvent) {

--- a/src/sync/SegmentUpdateWorker/node.js
+++ b/src/sync/SegmentUpdateWorker/node.js
@@ -29,7 +29,8 @@ export default class SegmentUpdateWorker {
       this.handleNewEvent = false;
       const currentMaxChangeNumbers = segmentsToFetch.map(segmentToFetch => this.maxChangeNumbers[segmentToFetch]);
 
-      this.segmentsProducer.synchronizeSegment(segmentsToFetch).then((result) => {
+      // fetch segments revalidating data if cached
+      this.segmentsProducer.synchronizeSegment(segmentsToFetch, false, true).then((result) => {
         // Unlike `SplitUpdateWorker` where changeNumber is consistent between notification and endpoint, if there is no error,
         // we must clean the `maxChangeNumbers` of those segments that didn't receive a new update notification during the fetch.
         if (result !== false) {

--- a/src/sync/SplitUpdateWorker/index.js
+++ b/src/sync/SplitUpdateWorker/index.js
@@ -26,10 +26,14 @@ export default class SplitUpdateWorker {
   __handleSplitUpdateCall() {
     if (this.maxChangeNumber > this.splitStorage.getChangeNumber()) {
       this.handleNewEvent = false;
-      this.splitProducer.synchronizeSplits().then(() => {
+
+      // fetch splits revalidating data if cached
+      this.splitProducer.synchronizeSplits(true).then(() => {
         if (this.handleNewEvent) {
           this.__handleSplitUpdateCall();
         } else {
+          // fetch new registered segments for server-side API. Not retrying on error
+          if(this.splitProducer.synchronizeSegment) this.splitProducer.synchronizeSegment(undefined, true);
           this.backoff.scheduleCall();
         }
       });

--- a/src/sync/__tests__/SSEHandler/index.spec.js
+++ b/src/sync/__tests__/SSEHandler/index.spec.js
@@ -19,7 +19,7 @@ import controlStreamingResumed from '../../../__tests__/mocks/message.CONTROL.ST
 import controlStreamingDisabled from '../../../__tests__/mocks/message.CONTROL.STREAMING_DISABLED.control_pri.1586987434950';
 
 import {
-  PUSH_CONNECT, PUSH_DISCONNECT, PUSH_DISABLED, SSE_ERROR,
+  PUSH_SUBSYSTEM_UP, PUSH_SUBSYSTEM_DOWN, PUSH_DISABLED, SSE_ERROR,
   SPLIT_UPDATE, SEGMENT_UPDATE, MY_SEGMENTS_UPDATE, SPLIT_KILL
 } from '../../constants';
 
@@ -36,7 +36,7 @@ tape('SSEHandler', t => {
     // handleOpen
 
     sseHandler.handleOpen();
-    assert.true(pushEmitter.emit.calledOnceWithExactly(PUSH_CONNECT), 'must emit PUSH_CONNECT');
+    assert.true(pushEmitter.emit.calledOnceWithExactly(PUSH_SUBSYSTEM_UP), 'must emit PUSH_SUBSYSTEM_UP');
 
     sseHandler.handleMessage({ data: '{ "data": "{\\"type\\":\\"SPLIT_UPDATE\\",\\"changeNumber\\":1457552620999 }" }' });
     assert.true(pushEmitter.emit.lastCall.calledWithExactly(SPLIT_UPDATE, 1457552620999), 'must handle update massage if streaming on');
@@ -44,22 +44,22 @@ tape('SSEHandler', t => {
     // OCCUPANCY messages
 
     sseHandler.handleMessage(occupancy1ControlPri);
-    assert.equal(pushEmitter.emit.callCount, 2, 'must not emit PUSH_CONNECT if streaming on');
+    assert.equal(pushEmitter.emit.callCount, 2, 'must not emit PUSH_SUBSYSTEM_UP if streaming on');
 
     sseHandler.handleMessage(occupancy0ControlPri);
-    assert.true(pushEmitter.emit.lastCall.calledWithExactly(PUSH_DISCONNECT), 'must emit PUSH_DISCONNECT if streaming on and OCCUPANCY 0 in control_pri');
+    assert.true(pushEmitter.emit.lastCall.calledWithExactly(PUSH_SUBSYSTEM_DOWN), 'must emit PUSH_SUBSYSTEM_DOWN if streaming on and OCCUPANCY 0 in control_pri');
 
     sseHandler.handleMessage({ data: '{ "data": "{\\"type\\":\\"SPLIT_UPDATE\\",\\"changeNumber\\":1457552620999 }" }' });
     assert.true(pushEmitter.emit.callCount, 3, 'must not handle update massage if streaming off after an OCCUPANCY message');
 
     sseHandler.handleMessage(occupancy0ControlPri);
-    assert.equal(pushEmitter.emit.callCount, 3, 'must not emit PUSH_DISCONNECT if streaming off');
+    assert.equal(pushEmitter.emit.callCount, 3, 'must not emit PUSH_SUBSYSTEM_DOWN if streaming off');
 
     sseHandler.handleMessage(occupancy1ControlPri);
     assert.true(pushEmitter.emit.callCount, 3, 'must ignore OCCUPANCY message if its timestamp is older');
 
     sseHandler.handleMessage(occupancy2ControlPri);
-    assert.true(pushEmitter.emit.lastCall.calledWithExactly(PUSH_CONNECT), 'must emit PUSH_CONNECT if streaming off and OCCUPANCY mayor than 0 in control_pri');
+    assert.true(pushEmitter.emit.lastCall.calledWithExactly(PUSH_SUBSYSTEM_UP), 'must emit PUSH_SUBSYSTEM_UP if streaming off and OCCUPANCY mayor than 0 in control_pri');
 
     sseHandler.handleMessage({ data: '{ "data": "{\\"type\\":\\"SPLIT_UPDATE\\",\\"changeNumber\\":1457552620999 }" }' });
     assert.true(pushEmitter.emit.lastCall.calledWithExactly(SPLIT_UPDATE, 1457552620999), 'must handle update massage if streaming on after an OCCUPANCY event');
@@ -67,19 +67,19 @@ tape('SSEHandler', t => {
     // CONTROL messages
 
     sseHandler.handleMessage(controlStreamingPaused);
-    assert.true(pushEmitter.emit.lastCall.calledWithExactly(PUSH_DISCONNECT), 'must emit PUSH_DISCONNECT if streaming on and received a STREAMING_PAUSED control message');
+    assert.true(pushEmitter.emit.lastCall.calledWithExactly(PUSH_SUBSYSTEM_DOWN), 'must emit PUSH_SUBSYSTEM_DOWN if streaming on and received a STREAMING_PAUSED control message');
 
     sseHandler.handleMessage({ data: '{ "data": "{\\"type\\":\\"SPLIT_UPDATE\\",\\"changeNumber\\":1457552620999 }" }' });
     assert.true(pushEmitter.emit.callCount, 6, 'must not handle update massage if streaming off after a CONTROL message');
 
     sseHandler.handleMessage(controlStreamingPaused);
-    assert.true(pushEmitter.emit.callCount, 6, 'must not emit PUSH_DISCONNECT if streaming off');
+    assert.true(pushEmitter.emit.callCount, 6, 'must not emit PUSH_SUBSYSTEM_DOWN if streaming off');
 
     sseHandler.handleMessage(controlStreamingResumed);
-    assert.true(pushEmitter.emit.lastCall.calledWithExactly(PUSH_CONNECT), 'must emit PUSH_CONNECT if streaming off and received a STREAMING_RESUMED control message');
+    assert.true(pushEmitter.emit.lastCall.calledWithExactly(PUSH_SUBSYSTEM_UP), 'must emit PUSH_SUBSYSTEM_UP if streaming off and received a STREAMING_RESUMED control message');
 
     sseHandler.handleMessage(controlStreamingResumed);
-    assert.equal(pushEmitter.emit.callCount, 7, 'must not emit PUSH_CONNECT if streaming on');
+    assert.equal(pushEmitter.emit.callCount, 7, 'must not emit PUSH_SUBSYSTEM_UP if streaming on');
 
     sseHandler.handleMessage({ data: '{ "data": "{\\"type\\":\\"SPLIT_UPDATE\\",\\"changeNumber\\":1457552620999 }" }' });
     assert.true(pushEmitter.emit.lastCall.calledWithExactly(SPLIT_UPDATE, 1457552620999), 'must handle update massage if streaming on after a CONTROL event');
@@ -91,7 +91,7 @@ tape('SSEHandler', t => {
     sseHandler2.handleOpen();
 
     sseHandler2.handleMessage(controlStreamingPaused);
-    assert.true(pushEmitter.emit.lastCall.calledWithExactly(PUSH_DISCONNECT));
+    assert.true(pushEmitter.emit.lastCall.calledWithExactly(PUSH_SUBSYSTEM_DOWN));
 
     sseHandler2.handleMessage(controlStreamingDisabled);
     assert.true(pushEmitter.emit.lastCall.calledWithExactly(PUSH_DISABLED), 'must emit PUSH_DISABLED if received a STREAMING_RESUMED control message, even if streaming is off');

--- a/src/sync/__tests__/SegmentUpdateWorker/browser.spec.js
+++ b/src/sync/__tests__/SegmentUpdateWorker/browser.spec.js
@@ -95,7 +95,7 @@ tape('MySegmentUpdateWorker', t => {
           producer.__resolveMySegmentsUpdaterCall(3); // fetch success
           setTimeout(() => {
             assert.true(producer.synchronizeMySegments.calledTwice, 'recalls `synchronizeMySegments` once previous event was handled');
-            assert.true(producer.synchronizeMySegments.lastCall.calledWithExactly(['some_segment']), 'calls `synchronizeMySegments` with given segmentList');
+            assert.true(producer.synchronizeMySegments.lastCall.calledWithExactly(['some_segment'], true), 'calls `synchronizeMySegments` with given segmentList');
             producer.__resolveMySegmentsUpdaterCall(4); // fetch success
             setTimeout(() => {
               assert.equal(mySegmentUpdateWorker.currentChangeNumber, 120, 'currentChangeNumber updated');
@@ -110,7 +110,7 @@ tape('MySegmentUpdateWorker', t => {
               producer.__resolveMySegmentsUpdaterCall(5); // fetch success
               setTimeout(() => {
                 assert.true(producer.synchronizeMySegments.calledTwice, 'recalls `synchronizeMySegments` once previous event was handled');
-                assert.true(producer.synchronizeMySegments.lastCall.calledWithExactly(undefined), 'calls `synchronizeMySegments` without segmentList if the event doesn\'t have payload');
+                assert.true(producer.synchronizeMySegments.lastCall.calledWithExactly(undefined, true), 'calls `synchronizeMySegments` without segmentList if the event doesn\'t have payload');
                 producer.__resolveMySegmentsUpdaterCall(6); // fetch success
                 setTimeout(() => {
                   assert.equal(mySegmentUpdateWorker.currentChangeNumber, 140, 'currentChangeNumber updated');

--- a/src/sync/__tests__/SegmentUpdateWorker/node.spec.js
+++ b/src/sync/__tests__/SegmentUpdateWorker/node.spec.js
@@ -61,7 +61,7 @@ tape('SegmentUpdateWorker', t => {
     segmentUpdateWorker.put(100, 'mocked_segment_1');
     assert.deepEqual(segmentUpdateWorker.maxChangeNumbers, { 'mocked_segment_1': 100 }, 'queues events (changeNumbers) if they are mayor than storage changeNumbers and maxChangeNumbers');
     assert.true(producer.synchronizeSegment.calledOnce, 'calls `synchronizeSegment` if `isSynchronizingSegments` is false');
-    assert.true(producer.synchronizeSegment.calledOnceWithExactly(['mocked_segment_1']), 'calls `synchronizeSegment` with segmentName');
+    assert.true(producer.synchronizeSegment.calledOnceWithExactly(['mocked_segment_1'], false, true), 'calls `synchronizeSegment` with segmentName');
 
     // assert queueing items if `isSynchronizingSegments` is true
     assert.equal(producer.isSynchronizingSegments(), true);
@@ -79,7 +79,7 @@ tape('SegmentUpdateWorker', t => {
     setTimeout(() => {
       assert.equal(cache.getChangeNumber('mocked_segment_1'), 100, '100');
       assert.true(producer.synchronizeSegment.calledTwice, 'recalls `synchronizeSegment` if `isSynchronizingSegments` is false and queue is not empty');
-      assert.true(producer.synchronizeSegment.lastCall.calledWithExactly(['mocked_segment_1', 'mocked_segment_2', 'mocked_segment_3']), 'calls `synchronizeSegment` with segmentName');
+      assert.true(producer.synchronizeSegment.lastCall.calledWithExactly(['mocked_segment_1', 'mocked_segment_2', 'mocked_segment_3'], false, true), 'calls `synchronizeSegment` with segmentName');
       assert.equal(segmentUpdateWorker.backoff.attempts, 0, 'no retry scheduled if synchronization success (changeNumbers are the expected)');
 
       // assert not rescheduling synchronization if some changeNumber is not updated as expected,
@@ -88,7 +88,7 @@ tape('SegmentUpdateWorker', t => {
       producer.__resolveSegmentsUpdaterCall(1, { 'mocked_segment_1': 100, 'mocked_segment_2': 100, 'mocked_segment_3': 94 });
       setTimeout(() => {
         assert.equal(producer.synchronizeSegment.callCount, 3, 'recalls `synchronizeSegment` if a new item was queued with a greater changeNumber while the fetch was pending');
-        assert.true(producer.synchronizeSegment.lastCall.calledWithExactly(['mocked_segment_1']), 'calls `synchronizeSegment` with the segmentName that was queued with a greater changeNumber while the fetch was pending');
+        assert.true(producer.synchronizeSegment.lastCall.calledWithExactly(['mocked_segment_1'], false, true), 'calls `synchronizeSegment` with the segmentName that was queued with a greater changeNumber while the fetch was pending');
         assert.equal(segmentUpdateWorker.backoff.attempts, 0, 'doesn\'t retry backoff schedule since a new item was queued');
 
         // assert dequeueing remaining events

--- a/src/sync/browser.js
+++ b/src/sync/browser.js
@@ -4,7 +4,7 @@ import PartialProducerFactory from '../producer/browser/Partial';
 import { matching } from '../utils/key/factory';
 import { forOwn, toString } from '../utils/lang';
 import logFactory from '../utils/logger';
-import { PUSH_DISCONNECT, PUSH_CONNECT } from './constants';
+import { PUSH_SUBSYSTEM_DOWN, PUSH_SUBSYSTEM_UP } from './constants';
 const log = logFactory('splitio-sync:sync-manager');
 
 /**
@@ -80,8 +80,8 @@ export default function BrowserSyncManagerFactory(mainContext) {
         if (pushManager) {
           if (!isSharedClient) {
             syncAll(); // initial syncAll (only when main client is created)
-            pushManager.on(PUSH_CONNECT, stopPollingAndSyncAll);
-            pushManager.on(PUSH_DISCONNECT, startPolling);
+            pushManager.on(PUSH_SUBSYSTEM_UP, stopPollingAndSyncAll);
+            pushManager.on(PUSH_SUBSYSTEM_DOWN, startPolling);
           } else {
             if (mainProducer.isRunning()) {
               // if doing polling, we must start the producer periodic fetch of data

--- a/src/sync/constants.js
+++ b/src/sync/constants.js
@@ -2,10 +2,27 @@
 export const SECONDS_BEFORE_EXPIRATION = 600;
 
 // Internal SDK events, subscribed by SyncManager and PushManager
-export const PUSH_CONNECT = 'PUSH_CONNECT';
-export const PUSH_DISABLED = 'PUSH_DISABLED';
-export const PUSH_DISCONNECT = 'PUSH_DISCONNECT';
-export const SSE_ERROR = 'SSE_ERROR';
+/**
+ * emitted on SSE and Authenticate non-recoverable errors, STREAMING_DISABLED control notification and authentication with pushEnabled false
+ * triggers `handleNonRetryableError` call
+ */
+export const PUSH_NONRETRYABLE_ERROR = 'PUSH_NONRETRYABLE_ERROR';
+/**
+ * emitted on SSE and Authenticate recoverable errors
+ * triggers `handleRetryableError` call
+ */
+export const PUSH_RETRYABLE_ERROR = 'PUSH_RETRYABLE_ERROR';
+/**
+ * emitted on STREAMING_RESUMED control notification, OCCUPANCY different than 0, and SSE onopen event
+ * triggers `stopPollingAndSyncAll` call
+ */
+export const PUSH_SUBSYSTEM_UP = 'PUSH_SUBSYSTEM_UP';
+
+/**
+ * emitted on STREAMING_PAUSED control notification, OCCUPANCY equal to 0, PUSH_NONRETRYABLE_ERROR and PUSH_RETRYABLE_ERROR events.
+ * triggers `startPolling` and `stopWorkers` calls
+ */
+export const PUSH_SUBSYSTEM_DOWN = 'PUSH_SUBSYSTEM_DOWN';
 
 // Update-type push notifications, handled by NotificationProcessor
 export const MY_SEGMENTS_UPDATE = 'MY_SEGMENTS_UPDATE';

--- a/src/sync/node.js
+++ b/src/sync/node.js
@@ -1,7 +1,7 @@
 import PushManagerFactory from './PushManager';
 import FullProducerFactory from '../producer';
 import logFactory from '../utils/logger';
-import { PUSH_DISCONNECT, PUSH_CONNECT } from './constants';
+import { PUSH_SUBSYSTEM_DOWN, PUSH_SUBSYSTEM_UP } from './constants';
 const log = logFactory('splitio-sync:sync-manager');
 
 /**
@@ -47,8 +47,8 @@ export default function NodeSyncManagerFactory(context) {
       // start syncing
       if (pushManager) {
         syncAll();
-        pushManager.on(PUSH_CONNECT, stopPollingAndSyncAll);
-        pushManager.on(PUSH_DISCONNECT, startPolling);
+        pushManager.on(PUSH_SUBSYSTEM_UP, stopPollingAndSyncAll);
+        pushManager.on(PUSH_SUBSYSTEM_DOWN, startPolling);
         setTimeout(pushManager.start); // Run in next event-loop cycle as in browser
       } else {
         producer.start();

--- a/src/utils/settings/index.js
+++ b/src/utils/settings/index.js
@@ -64,10 +64,8 @@ const base = {
     eventsPushRate: 60,
     // how many events will be queued before flushing
     eventsQueueSize: 500,
-    // backoff base seconds to wait before re attempting to authenticate for push notifications
-    authRetryBackoffBase: 1,
-    // backoff base seconds to wait before re attempting to connect to streaming
-    streamingReconnectBackoffBase: 1
+    // backoff base seconds to wait before re attempting to connect to push notifications
+    pushRetryBackoffBase: 1,
   },
 
   urls: {
@@ -160,8 +158,7 @@ function defaults(custom) {
     withDefaults.streamingEnabled = true;
     // Backoff bases.
     // We are not checking if bases are positive numbers. Thus, we might be reauthenticating immediately (`setTimeout` with NaN or negative number)
-    withDefaults.scheduler.authRetryBackoffBase = fromSecondsToMillis(withDefaults.scheduler.authRetryBackoffBase);
-    withDefaults.scheduler.streamingReconnectBackoffBase = fromSecondsToMillis(withDefaults.scheduler.streamingReconnectBackoffBase);
+    withDefaults.scheduler.pushRetryBackoffBase = fromSecondsToMillis(withDefaults.scheduler.pushRetryBackoffBase);
   }
 
   // validate the `splitFilters` settings and parse splits query

--- a/ts-tests/index.ts
+++ b/ts-tests/index.ts
@@ -434,8 +434,7 @@ let fullBrowserSettings: SplitIO.IBrowserSettings = {
     offlineRefreshRate: 1,
     eventsPushRate: 1,
     eventsQueueSize: 1,
-    authRetryBackoffBase: 1,
-    streamingReconnectBackoffBase: 1
+    pushRetryBackoffBase: 1
   },
   startup: {
     readyTimeout: 1,
@@ -480,8 +479,7 @@ let fullNodeSettings: SplitIO.INodeSettings = {
     offlineRefreshRate: 1,
     eventsPushRate: 1,
     eventsQueueSize: 1,
-    authRetryBackoffBase: 1,
-    streamingReconnectBackoffBase: 1
+    pushRetryBackoffBase: 1
   },
   startup: {
     readyTimeout: 1,

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -74,8 +74,7 @@ interface ISettings {
     offlineRefreshRate: number,
     eventsPushRate: number,
     eventsQueueSize: number,
-    authRetryBackoffBase: number,
-    streamingReconnectBackoffBase: number
+    pushRetryBackoffBase: number
   },
   readonly startup: {
     readyTimeout: number,
@@ -282,19 +281,12 @@ interface INodeBasicSettings extends ISharedSettings {
      */
     offlineRefreshRate?: number
     /**
-     * When using streaming mode, seconds to wait before re attempting to authenticate for push notifications.
+     * When using streaming mode, seconds to wait before re attempting to connect for push notifications.
      * Next attempts follow intervals in power of two: base seconds, base x 2 seconds, base x 4 seconds, ...
-     * @property {number} authRetryBackoffBase
+     * @property {number} pushRetryBackoffBase
      * @default 1
      */
-    authRetryBackoffBase?: number,
-    /**
-     * When using streaming mode, seconds to wait before re attempting to connect to streaming.
-     * Next attempts follow intervals in power of two: base seconds, base x 2 seconds, base x 4 seconds, ...
-     * @property {number} streamingReconnectBackoffBase
-     * @default 1
-     */
-    streamingReconnectBackoffBase?: number,
+    pushRetryBackoffBase?: number,
   },
   /**
    * SDK Core settings for NodeJS.
@@ -906,21 +898,14 @@ declare namespace SplitIO {
        * @property {number} offlineRefreshRate
        * @default 15
        */
-      offlineRefreshRate?: number
+      offlineRefreshRate?: number,
       /**
-       * When using streaming mode, seconds to wait before re attempting to authenticate for push notifications.
+       * When using streaming mode, seconds to wait before re attempting to connect for push notifications.
        * Next attempts follow intervals in power of two: base seconds, base x 2 seconds, base x 4 seconds, ...
-       * @property {number} authRetryBackoffBase
+       * @property {number} pushRetryBackoffBase
        * @default 1
        */
-      authRetryBackoffBase?: number,
-      /**
-       * When using streaming mode, seconds to wait before re attempting to connect to streaming.
-       * Next attempts follow intervals in power of two: base seconds, base x 2 seconds, base x 4 seconds, ...
-       * @property {number} streamingReconnectBackoffBase
-       * @default 1
-       */
-      streamingReconnectBackoffBase?: number,
+      pushRetryBackoffBase?: number,
     },
     /**
      * SDK Core settings for the browser.


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

- Updated type declarations: added `pushRetryBackoffBase` config param 
- Updated error handling logic for streaming:
  - There is a single backoff to schedule push connect retries.
  - Updated SSE error handling to consider recoverable vs non-recoverable errors (already done for authentication).
  - Fixed a corner-case issue: close the SSE connection if push is disabled for the org on a re-authentication (refresh token). 
- Renamed internal push event names to follow the spec.

## How do we test the changes introduced in this PR?

- Updated `testPushRetriesDueToSseErrors` E2E test: push connect attempt starts from authentication even if only the SSE connection fails.
- Added new tests:
  - UT for SSEHandler
  - E2E test for no push retry attempt on initialization with a SSE non-recoverable error (`testSSEWithNonRetryableError`)
  - E2E test for no push retry attempt on a refresh token with pushEnabled false (extended `testRefreshToken`)

## Extra Notes