### PR TITLE
NotificationKeeper update

### DIFF
--- a/src/__tests__/browserSuites/push-fallbacking.spec.js
+++ b/src/__tests__/browserSuites/push-fallbacking.spec.js
@@ -11,8 +11,8 @@ import mySegmentsMarcio from '../mocks/mysegments.marcio@split.io.json';
 
 import occupancy0ControlPriMessage from '../mocks/message.OCCUPANCY.0.control_pri.1586987434550.json';
 import occupancy1ControlPriMessage from '../mocks/message.OCCUPANCY.1.control_pri.1586987434450.json';
-import occupancy1ControlSecMessage from '../mocks/message.OCCUPANCY.1.control_sec.1586987434451.json';
 import occupancy2ControlPriMessage from '../mocks/message.OCCUPANCY.2.control_pri.1586987434650.json';
+import occupancy0ControlSecMessage from '../mocks/message.OCCUPANCY.0.control_sec.1586987434451.json';
 
 import streamingPausedControlPriMessage from '../mocks/message.CONTROL.STREAMING_PAUSED.control_pri.1586987434750.json';
 import streamingResumedControlPriMessage from '../mocks/message.CONTROL.STREAMING_RESUMED.control_pri.1586987434850.json';
@@ -112,7 +112,7 @@ export function testFallbacking(fetchMock, assert) {
     setTimeout(() => {
       eventSourceInstance.emitOpen();
       eventSourceInstance.emitMessage(occupancy1ControlPriMessage);
-      eventSourceInstance.emitMessage(occupancy1ControlSecMessage);
+      eventSourceInstance.emitMessage(occupancy0ControlSecMessage);
     }, MILLIS_SSE_OPEN); // open SSE connection after 0.1 seconds
 
     setTimeout(() => {

--- a/src/__tests__/mocks/message.OCCUPANCY.0.control_sec.1586987434451.json
+++ b/src/__tests__/mocks/message.OCCUPANCY.0.control_sec.1586987434451.json
@@ -1,0 +1,4 @@
+{
+  "type": "message",
+  "data": "{\"id\":\"JdPcOgIxuH:0:0\",\"timestamp\":1586987434451,\"encoding\":\"json\",\"channel\":\"[?occupancy=metrics.publishers]control_sec\",\"data\":\"{\\\"metrics\\\":{\\\"publishers\\\":0}}\",\"name\":\"[meta]occupancy\"}"
+}

--- a/src/__tests__/mocks/message.OCCUPANCY.1.control_sec.1586987434451.json
+++ b/src/__tests__/mocks/message.OCCUPANCY.1.control_sec.1586987434451.json
@@ -1,4 +1,0 @@
-{
-  "type": "message",
-  "data": "{\"id\":\"JdPcOgIxuH:0:0\",\"timestamp\":1586987434451,\"encoding\":\"json\",\"channel\":\"[?occupancy=metrics.publishers]control_sec\",\"data\":\"{\\\"metrics\\\":{\\\"publishers\\\":1}}\",\"name\":\"[meta]occupancy\"}"
-}

--- a/src/__tests__/nodeSuites/push-fallbacking.spec.js
+++ b/src/__tests__/nodeSuites/push-fallbacking.spec.js
@@ -8,8 +8,8 @@ import splitChangesMock3 from '../mocks/splitchanges.real.updateWithoutSegments.
 
 import occupancy0ControlPriMessage from '../mocks/message.OCCUPANCY.0.control_pri.1586987434550.json';
 import occupancy1ControlPriMessage from '../mocks/message.OCCUPANCY.1.control_pri.1586987434450.json';
-import occupancy1ControlSecMessage from '../mocks/message.OCCUPANCY.1.control_sec.1586987434451.json';
 import occupancy2ControlPriMessage from '../mocks/message.OCCUPANCY.2.control_pri.1586987434650.json';
+import occupancy0ControlSecMessage from '../mocks/message.OCCUPANCY.0.control_sec.1586987434451.json';
 
 import streamingPausedControlPriMessage from '../mocks/message.CONTROL.STREAMING_PAUSED.control_pri.1586987434750.json';
 import streamingResumedControlPriMessage from '../mocks/message.CONTROL.STREAMING_RESUMED.control_pri.1586987434850.json';
@@ -104,7 +104,7 @@ export function testFallbacking(fetchMock, assert) {
     setTimeout(() => {
       eventSourceInstance.emitOpen();
       eventSourceInstance.emitMessage(occupancy1ControlPriMessage);
-      eventSourceInstance.emitMessage(occupancy1ControlSecMessage);
+      eventSourceInstance.emitMessage(occupancy0ControlSecMessage);
     }, MILLIS_SSE_OPEN); // open SSE connection after 0.1 seconds
 
     setTimeout(() => {

--- a/src/sync/SSEHandler/NotificationKeeper.js
+++ b/src/sync/SSEHandler/NotificationKeeper.js
@@ -1,6 +1,5 @@
 import { PUSH_SUBSYSTEM_UP, PUSH_SUBSYSTEM_DOWN, PUSH_NONRETRYABLE_ERROR, ControlTypes } from '../constants';
 
-
 const CONTROL_CHANNEL_REGEXS = [/control_pri$/, /control_sec$/];
 
 export default function notificationKeeperFactory(feedbackLoopEmitter) {

--- a/src/sync/SSEHandler/NotificationKeeper.js
+++ b/src/sync/SSEHandler/NotificationKeeper.js
@@ -1,13 +1,19 @@
 import { PUSH_SUBSYSTEM_UP, PUSH_SUBSYSTEM_DOWN, PUSH_NONRETRYABLE_ERROR, ControlTypes } from '../constants';
 
-const CONTROL_PRI_CHANNEL_REGEX = /control_pri$/;
+
+const CONTROL_CHANNEL_REGEXS = [/control_pri$/, /control_sec$/];
 
 export default function notificationKeeperFactory(feedbackLoopEmitter) {
 
-  let occupancyTimestamp = -1;
+  let occupancyTimestamps = [-1, -1]; // keep track of most recent occupancy notification timestamp per channel
+  let occupancyPublishers = [true, true]; // keep track of publishers presence per channel, in order to compute `hasPublishers`
   let hasPublishers = true; // false if the number of publishers is equal to 0 in the last OCCUPANCY notification from CHANNEL_PRI
-  let controlTimestamp = -1;
+  let controlTimestamps = [-1, -1]; // keep track of most recent control notification timestamp per channel
   let hasResumed = true; // false if last CONTROL event was STREAMING_PAUSED or STREAMING_DISABLED
+
+  function getHasPublishers() { // computes the value of `hasPublishers`
+    return occupancyPublishers.some(hasPublishers => hasPublishers);
+  }
 
   return {
     handleOpen() {
@@ -19,37 +25,43 @@ export default function notificationKeeperFactory(feedbackLoopEmitter) {
     },
 
     handleOccupancyEvent(publishers, channel, timestamp) {
-      if (CONTROL_PRI_CHANNEL_REGEX.test(channel) && timestamp > occupancyTimestamp) {
-        occupancyTimestamp = timestamp;
-        if (hasResumed) {
-          if (publishers === 0 && hasPublishers) {
-            feedbackLoopEmitter.emit(PUSH_SUBSYSTEM_DOWN);
-          } else if (publishers !== 0 && !hasPublishers) {
-            feedbackLoopEmitter.emit(PUSH_SUBSYSTEM_UP);
+      CONTROL_CHANNEL_REGEXS.some((regex, index) => {
+        if (regex.test(channel) && timestamp > occupancyTimestamps[index]) {
+          occupancyTimestamps[index] = timestamp;
+          occupancyPublishers[index] = publishers !== 0;
+          const newHasPublishers = getHasPublishers();
+          if (hasResumed) {
+            if (!newHasPublishers && hasPublishers) {
+              feedbackLoopEmitter.emit(PUSH_SUBSYSTEM_DOWN);
+            } else if (newHasPublishers && !hasPublishers) {
+              feedbackLoopEmitter.emit(PUSH_SUBSYSTEM_UP);
+            }
+            // nothing to do when hasResumed === false:
+            // streaming is already down for `!newHasPublishers`, and cannot be up for `newHasPublishers`
           }
-          // nothing to do when hasResumed === false:
-          // streaming is already down for `publishers === 0`, and cannot be up for `publishers !== 0`
+          hasPublishers = newHasPublishers;
         }
-        hasPublishers = publishers !== 0;
-      }
+      });
     },
 
     handleControlEvent(controlType, channel, timestamp) {
-      if (CONTROL_PRI_CHANNEL_REGEX.test(channel) && timestamp > controlTimestamp) {
-        controlTimestamp = timestamp;
-        if (controlType === ControlTypes.STREAMING_DISABLED) {
-          feedbackLoopEmitter.emit(PUSH_NONRETRYABLE_ERROR);
-        } else if (hasPublishers) {
-          if (controlType === ControlTypes.STREAMING_PAUSED && hasResumed) {
-            feedbackLoopEmitter.emit(PUSH_SUBSYSTEM_DOWN);
-          } else if (controlType === ControlTypes.STREAMING_RESUMED && !hasResumed) {
-            feedbackLoopEmitter.emit(PUSH_SUBSYSTEM_UP);
+      CONTROL_CHANNEL_REGEXS.some((regex, index) => {
+        if (regex.test(channel) && timestamp > controlTimestamps[index]) {
+          controlTimestamps[index] = timestamp;
+          if (controlType === ControlTypes.STREAMING_DISABLED) {
+            feedbackLoopEmitter.emit(PUSH_NONRETRYABLE_ERROR);
+          } else if (hasPublishers) {
+            if (controlType === ControlTypes.STREAMING_PAUSED && hasResumed) {
+              feedbackLoopEmitter.emit(PUSH_SUBSYSTEM_DOWN);
+            } else if (controlType === ControlTypes.STREAMING_RESUMED && !hasResumed) {
+              feedbackLoopEmitter.emit(PUSH_SUBSYSTEM_UP);
+            }
+            // nothing to do when hasPublishers === false:
+            // streaming is already down for `STREAMING_PAUSED`, and cannot be up for `STREAMING_RESUMED`
           }
-          // nothing to do when hasPublishers === false:
-          // streaming is already down for `STREAMING_PAUSED`, and cannot be up for `STREAMING_RESUMED`
+          hasResumed = controlType === ControlTypes.STREAMING_RESUMED;
         }
-        hasResumed = controlType === ControlTypes.STREAMING_RESUMED;
-      }
+      });
     },
 
   };

--- a/src/sync/SSEHandler/NotificationKeeper.js
+++ b/src/sync/SSEHandler/NotificationKeeper.js
@@ -4,11 +4,21 @@ const CONTROL_CHANNEL_REGEXS = [/control_pri$/, /control_sec$/];
 
 export default function notificationKeeperFactory(feedbackLoopEmitter) {
 
-  let occupancyTimestamps = [-1, -1]; // keep track of most recent occupancy notification timestamp per channel
-  let occupancyPublishers = [true, true]; // keep track of publishers presence per channel, in order to compute `hasPublishers`
-  let hasPublishers = true; // false if the number of publishers is equal to 0 in the last OCCUPANCY notification from CHANNEL_PRI
-  let controlTimestamps = [-1, -1]; // keep track of most recent control notification timestamp per channel
-  let hasResumed = true; // false if last CONTROL event was STREAMING_PAUSED or STREAMING_DISABLED
+  // keep track of most recent occupancy notification timestamp per channel
+  let occupancyTimestamps = [-1, -1];
+
+  // keep track of publishers presence per channel, in order to compute `hasPublishers`
+  // Init with true, to emit PUSH_SUBSYSTEM_UP if initial OCCUPANCY notifications have 0 publishers
+  let occupancyPublishers = [true, true];
+
+  // false if the number of publishers is equal to 0 in all regions
+  let hasPublishers = true;
+
+  // keep track of most recent control notification timestamp per channel
+  let controlTimestamps = [-1, -1];
+
+  // false if last CONTROL event was STREAMING_PAUSED or STREAMING_DISABLED
+  let hasResumed = true;
 
   function getHasPublishers() { // computes the value of `hasPublishers`
     return occupancyPublishers.some(hasPublishers => hasPublishers);


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

Updated NotificationKeeper to handle CONTROL and OCCUPANCY messages from control_sec channel. 
As before, since Occupancy messages are sent as soon as streaming connects, the NotificationKeeper initiates assuming that there are publishers in both regions, in order to emit PUSH_SUBSYSTEM_DOWN in case all initial notification messages have 0 publishers.

## How do we test the changes introduced in this PR?

Added tests to consider control and occupancy messages from control_sec.

## Extra Notes