### PR TITLE
Fetch new segments after SPLIT_UPDATE

### DIFF
--- a/src/__tests__/browserSuites/push-synchronization.spec.js
+++ b/src/__tests__/browserSuites/push-synchronization.spec.js
@@ -8,7 +8,7 @@ import mySegmentsMarcio from '../mocks/mysegments.marcio@split.io.json';
 
 import splitUpdateMessage from '../mocks/message.SPLIT_UPDATE.1457552649999.json';
 import oldSplitUpdateMessage from '../mocks/message.SPLIT_UPDATE.1457552620999.json';
-import mySegmentsUpdateMessage from '../mocks/message.MY_SEGMENTS_UPDATE.nicolas@split.io.1457552640000.json';
+import mySegmentsUpdateMessageNoPayload from '../mocks/message.MY_SEGMENTS_UPDATE.nicolas@split.io.1457552640000.json';
 import mySegmentsUpdateMessageWithPayload from '../mocks/message.MY_SEGMENTS_UPDATE.marcio@split.io.1457552645000.json';
 import mySegmentsUpdateMessageWithEmptyPayload from '../mocks/message.MY_SEGMENTS_UPDATE.marcio@split.io.1457552646000.json';
 import splitKillMessage from '../mocks/message.SPLIT_KILL.1457552650000.json';
@@ -16,7 +16,7 @@ import splitKillMessage from '../mocks/message.SPLIT_KILL.1457552650000.json';
 import authPushEnabledNicolas from '../mocks/auth.pushEnabled.nicolas@split.io.json';
 import authPushEnabledNicolasAndMarcio from '../mocks/auth.pushEnabled.nicolas@split.io.marcio@split.io.json';
 
-import { nearlyEqual } from '../testUtils';
+import { nearlyEqual, hasNoCacheHeader } from '../testUtils';
 import includes from 'lodash/includes';
 
 // Replace original EventSource with mock
@@ -48,7 +48,7 @@ const settings = SettingsFactory(config);
 const MILLIS_SSE_OPEN = 100;
 const MILLIS_FIRST_SPLIT_UPDATE_EVENT = 200;
 const MILLIS_SECOND_SPLIT_UPDATE_EVENT = 300;
-const MILLIS_MYSEGMENT_UPDATE_EVENT = 400;
+const MILLIS_MY_SEGMENTS_UPDATE_EVENT_NO_PAYLOAD = 400;
 const MILLIS_SPLIT_KILL_EVENT = 500;
 const MILLIS_NEW_CLIENT = 600;
 const MILLIS_SECOND_SSE_OPEN = 700;
@@ -102,11 +102,11 @@ export function testSynchronization(fetchMock, assert) {
       assert.equal(client.getTreatment('splitters'), 'off', 'evaluation with initial MySegments list');
       client.once(client.Event.SDK_UPDATE, () => {
         const lapse = Date.now() - start;
-        assert.true(nearlyEqual(lapse, MILLIS_MYSEGMENT_UPDATE_EVENT), 'SDK_UPDATE due to MY_SEGMENTS_UPDATE event');
+        assert.true(nearlyEqual(lapse, MILLIS_MY_SEGMENTS_UPDATE_EVENT_NO_PAYLOAD), 'SDK_UPDATE due to MY_SEGMENTS_UPDATE event');
         assert.equal(client.getTreatment('splitters'), 'on', 'evaluation with updated MySegments list');
       });
-      eventSourceInstance.emitMessage(mySegmentsUpdateMessage);
-    }, MILLIS_MYSEGMENT_UPDATE_EVENT); // send a MY_SEGMENTS_UPDATE event with a new changeNumber after 0.4 seconds
+      eventSourceInstance.emitMessage(mySegmentsUpdateMessageNoPayload);
+    }, MILLIS_MY_SEGMENTS_UPDATE_EVENT_NO_PAYLOAD); // send a MY_SEGMENTS_UPDATE event with a new changeNumber after 0.4 seconds
 
     setTimeout(() => {
       assert.equal(client.getTreatment('whitelist'), 'allowed', 'evaluation with not killed Split');
@@ -196,44 +196,69 @@ export function testSynchronization(fetchMock, assert) {
   });
 
   // initial split and mySegments sync
-  fetchMock.getOnce(settings.url('/splitChanges?since=-1'), function () {
+  fetchMock.getOnce(settings.url('/splitChanges?since=-1'), function (url, opts) {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, 0), 'initial sync');
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
     return { status: 200, body: splitChangesMock1 };
   });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), function (url, opts) {
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
+    return { status: 200, body: mySegmentsNicolasMock1 };
+  });
 
   // split and segment sync after SSE opened
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
+  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function (url, opts) {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_SSE_OPEN), 'sync after SSE connection is opened');
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
     return { status: 200, body: splitChangesMock2 };
   });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), function (url, opts) {
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
+    return { status: 200, body: mySegmentsNicolasMock1 };
+  });
 
   // fetch due to SPLIT_UPDATE event
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock3 });
+  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function (url, opts) {
+    if (!hasNoCacheHeader(opts)) assert.fail('request must include `Cache-Control` header1');
+    return { status: 200, body: splitChangesMock3 };
+  });
 
   // fetch due to first MY_SEGMENTS_UPDATE event
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock2 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), function (url, opts) {
+    if (!hasNoCacheHeader(opts)) assert.fail('request must include `Cache-Control` header2');
+    return { status: 200, body: mySegmentsNicolasMock2 };
+  });
 
   // fetch due to SPLIT_KILL event
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), function () {
+  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), function (url, opts) {
+    if (!hasNoCacheHeader(opts)) assert.fail('request must include `Cache-Control` header3');
     assert.equal(client.getTreatment('whitelist'), 'not_allowed', 'evaluation with split killed immediately, before fetch is done');
     return { status: 200, body: splitChangesMock4 };
   });
 
   // initial fetch of mySegments for new client
-  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), function (url, opts) {
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
+    return { status: 200, body: mySegmentsMarcio };
+  });
 
   // split and mySegment sync after second SSE opened
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552650000'), function () {
+  fetchMock.getOnce(settings.url('/splitChanges?since=1457552650000'), function (url, opts) {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_SECOND_SSE_OPEN), 'sync after second SSE connection is opened');
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
     return { status: 200, body: { splits: [], since: 1457552650000, till: 1457552650000 } };
   });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock2 });
-  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), function (url, opts) {
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
+    return { status: 200, body: mySegmentsNicolasMock2 };
+  });
+  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), function (url, opts) {
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
+    return { status: 200, body: mySegmentsMarcio };
+  });
 
   fetchMock.get(new RegExp('.*'), function (url) {
     assert.fail('unexpected GET request with url: ' + url);

--- a/src/__tests__/mocks/message.SPLIT_UPDATE.1457552650001.json
+++ b/src/__tests__/mocks/message.SPLIT_UPDATE.1457552650001.json
@@ -1,0 +1,4 @@
+{
+  "type": "message",
+  "data": "{\"id\": \"mc4i3NENoA:0:0\",\"clientId\": \"NDEzMTY5Mzg0MA==:MTM2ODE2NDMxNA==\",\"timestamp\": 1457552650001,\"encoding\": \"json\",\"channel\": \"NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw==_splits\",\"data\": \"{\\\"type\\\":\\\"SPLIT_UPDATE\\\",\\\"changeNumber\\\":1457552650001}\"}"
+}

--- a/src/__tests__/mocks/splitchanges.since.1457552650000.till.1457552650001.SPLIT_UPDATE.json
+++ b/src/__tests__/mocks/splitchanges.since.1457552650000.till.1457552650001.SPLIT_UPDATE.json
@@ -1,0 +1,79 @@
+{
+  "splits": [
+    {
+      "orgId": null,
+      "environment": null,
+      "trafficTypeId": null,
+      "trafficTypeName": null,
+      "name": "qc_team",
+      "seed": -1984784937,
+      "status": "ACTIVE",
+      "killed": false,
+      "defaultTreatment": "no",
+      "conditions": [
+        {
+          "matcherGroup": {
+            "combiner": "AND",
+            "matchers": [
+              {
+                "keySelector": null,
+                "matcherType": "WHITELIST",
+                "negate": false,
+                "userDefinedSegmentMatcherData": null,
+                "whitelistMatcherData": {
+                  "whitelist": [
+                    "tia@split.io",
+                    "trevor@split.io"
+                  ]
+                },
+                "unaryNumericMatcherData": null,
+                "betweenMatcherData": null
+              }
+            ]
+          },
+          "partitions": [
+            {
+              "treatment": "yes",
+              "size": 100
+            }
+          ]
+        },
+        {
+          "matcherGroup": {
+            "combiner": "AND",
+            "matchers": [
+              {
+                "keySelector": {
+                  "trafficType": "user",
+                  "attribute": null
+                },
+                "matcherType": "IN_SEGMENT",
+                "negate": false,
+                "userDefinedSegmentMatcherData": {
+                  "segmentName": "new_segment"
+                },
+                "whitelistMatcherData": null,
+                "unaryNumericMatcherData": null,
+                "betweenMatcherData": null,
+                "unaryStringMatcherData": null
+              }
+            ]
+          },
+          "partitions": [
+            {
+              "treatment": "yes",
+              "size": 100
+            },
+            {
+              "treatment": "no",
+              "size": 0
+            }
+          ]
+        }
+      ],
+      "configurations": {}
+    }
+  ],
+  "since": 1457552650000,
+  "till": 1457552650001
+}

--- a/src/__tests__/nodeSuites/push-synchronization.spec.js
+++ b/src/__tests__/nodeSuites/push-synchronization.spec.js
@@ -2,11 +2,13 @@ import splitChangesMock1 from '../mocks/splitchanges.since.-1.json';
 import splitChangesMock2 from '../mocks/splitchanges.since.1457552620999.json';
 import splitChangesMock3 from '../mocks/splitchanges.since.1457552620999.till.1457552649999.SPLIT_UPDATE.json';
 import splitChangesMock4 from '../mocks/splitchanges.since.1457552649999.till.1457552650000.SPLIT_KILL.json';
+import splitChangesMock5 from '../mocks/splitchanges.since.1457552650000.till.1457552650001.SPLIT_UPDATE.json';
 
 import splitUpdateMessage from '../mocks/message.SPLIT_UPDATE.1457552649999.json';
 import oldSplitUpdateMessage from '../mocks/message.SPLIT_UPDATE.1457552620999.json';
 import segmentUpdateMessage from '../mocks/message.SEGMENT_UPDATE.1457552640000.json';
 import splitKillMessage from '../mocks/message.SPLIT_KILL.1457552650000.json';
+import splitUpdateWithNewSegmentsMessage from '../mocks/message.SPLIT_UPDATE.1457552650001.json';
 
 import authPushEnabled from '../mocks/auth.pushEnabled.node.json';
 
@@ -19,6 +21,7 @@ import { SplitFactory } from '../../';
 import SettingsFactory from '../../utils/settings';
 
 const key = 'nicolas@split.io';
+const otherUserKey = 'marcio@split.io';
 
 const baseUrls = {
   sdk: 'https://sdk.push-synchronization/api',
@@ -40,7 +43,8 @@ const MILLIS_FIRST_SPLIT_UPDATE_EVENT = 200;
 const MILLIS_SECOND_SPLIT_UPDATE_EVENT = 300;
 const MILLIS_SEGMENT_UPDATE_EVENT = 400;
 const MILLIS_SPLIT_KILL_EVENT = 500;
-const MILLIS_DESTROY = 600;
+const MILLIS_SPLIT_UPDATE_EVENT_WITH_NEW_SEGMENTS = 600;
+const MILLIS_DESTROY = 700;
 
 /**
  * Sequence of calls:
@@ -50,13 +54,14 @@ const MILLIS_DESTROY = 600;
  *  0.3 secs: SPLIT_UPDATE event with old changeNumber
  *  0.4 secs: SEGMENT_UPDATE event -> /segmentChanges/
  *  0.5 secs: SPLIT_KILL event -> /splitChanges
+ *  0.6 secs: SPLIT_UPDATE event with new segments -> /splitChanges, /segmentChanges/{newSegments}
  */
 export function testSynchronization(fetchMock, assert) {
-  assert.plan(15);
+  assert.plan(21);
   fetchMock.reset();
   __setEventSource(EventSourceMock);
 
-  let start, splitio, client;
+  let start, splitio, client, sdkUpdateCount = 0;
 
   // mock SSE open and message events
   setMockListener(function (eventSourceInstance) {
@@ -97,8 +102,24 @@ export function testSynchronization(fetchMock, assert) {
       eventSourceInstance.emitMessage(splitKillMessage);
     }, MILLIS_SPLIT_KILL_EVENT); // send a SPLIT_KILL event with a new changeNumber after 0.5 seconds
     setTimeout(() => {
+      assert.equal(client.getTreatment(key, 'qc_team'), 'yes', 'evaluation previous to split update');
+      assert.equal(client.getTreatment(otherUserKey, 'qc_team'), 'no', 'evaluation previous to split update');
+      // @TODO avoid duplicated SDK_UPDATE event
+      client.once(client.Event.SDK_UPDATE, () => {
+        client.once(client.Event.SDK_UPDATE, () => {
+          const lapse = Date.now() - start;
+          assert.true(nearlyEqual(lapse, MILLIS_SPLIT_UPDATE_EVENT_WITH_NEW_SEGMENTS), 'SDK_UPDATE due to SPLIT_UPDATE event with new segments');
+          assert.equal(client.getTreatment(key, 'qc_team'), 'no', 'evaluation of updated Split');
+          assert.equal(client.getTreatment(otherUserKey, 'qc_team'), 'yes', 'evaluation of updated Split');
+        });
+      });
+      eventSourceInstance.emitMessage(splitUpdateWithNewSegmentsMessage);
+    }, MILLIS_SPLIT_UPDATE_EVENT_WITH_NEW_SEGMENTS); // send a SPLIT_UPDATE event with new segments after 0.6 seconds
+    setTimeout(() => {
       client.destroy().then(() => {
         assert.equal(client.getTreatment(key, 'whitelist'), 'control', 'evaluation returns control if client is destroyed');
+        // @TODO ideally SDK_UPDATE should be emitted 4 times
+        assert.equal(sdkUpdateCount, 6, 'SDK_UPDATE should be emitted 6 times');
         assert.end();
       });
     }, MILLIS_DESTROY); // destroy client after 0.6 seconds
@@ -153,7 +174,11 @@ export function testSynchronization(fetchMock, assert) {
     return { status: 200, body: splitChangesMock4 };
   });
 
+  // fetch due to SPLIT_UPDATE event, with an update that involves a new segment
+  fetchMock.getOnce(settings.url('/splitChanges?since=1457552650000'), { status: 200, body: splitChangesMock5 });
+
   mockSegmentChanges(fetchMock, new RegExp(`${settings.url('/segmentChanges')}/(employees|developers)`), [key]);
+  mockSegmentChanges(fetchMock, { url: new RegExp(`${settings.url('/segmentChanges')}/new_segment`), repeat: 2 }, [otherUserKey]);
 
   fetchMock.get(new RegExp('.*'), function (url) {
     assert.fail('unexpected GET request with url: ' + url);
@@ -164,5 +189,6 @@ export function testSynchronization(fetchMock, assert) {
   start = Date.now();
   splitio = SplitFactory(config);
   client = splitio.client();
+  client.on(client.Event.SDK_UPDATE, () => sdkUpdateCount++);
 
 }

--- a/src/__tests__/testUtils/index.js
+++ b/src/__tests__/testUtils/index.js
@@ -38,3 +38,7 @@ export function mockSegmentChanges(fetchMock, matcher, keys, changeNumber = 1457
     };
   });
 }
+
+export function hasNoCacheHeader(fetchMockOpts) {
+  return fetchMockOpts.headers['Cache-Control'] === 'no-cache';
+}

--- a/src/producer/browser.js
+++ b/src/producer/browser.js
@@ -35,10 +35,13 @@ const FullBrowserProducer = (context) => {
 
   let isSynchronizingSplits = false;
 
-  function synchronizeSplits() {
+  /**
+   * @param {boolean | undefined} noCache true to revalidate data to fetch
+   */
+  function synchronizeSplits(noCache) {
     isSynchronizingSplits = true;
     // `splitsUpdater` promise always resolves, and with a false value if it fails to fetch or store splits
-    return splitsUpdater().then(function (res) {
+    return splitsUpdater(0, noCache).then(function (res) {
       isSynchronizingSplits = false;
       return res;
     });

--- a/src/producer/browser/Partial.js
+++ b/src/producer/browser/Partial.js
@@ -40,11 +40,12 @@ const PartialBrowserProducer = (context) => {
 
   /**
    * @param {string[] | undefined} segmentList might be undefined
+   * @param {boolean | undefined} noCache true to revalidate data to fetch
    */
-  function synchronizeMySegments(segmentList) {
+  function synchronizeMySegments(segmentList, noCache) {
     isSynchronizingMySegments = true;
     // `mySegmentsUpdater` promise always resolves, and with a false value if it fails to fetch or store mySegments
-    return mySegmentsUpdater(0, segmentList).then(function (res) {
+    return mySegmentsUpdater(0, segmentList, noCache).then(function (res) {
       isSynchronizingMySegments = false;
       return res;
     });

--- a/src/producer/fetcher/MySegments.js
+++ b/src/producer/fetcher/MySegments.js
@@ -20,8 +20,8 @@ import { SplitError } from '../../utils/lang/Errors';
 import mySegmentsService from '../../services/mySegments';
 import mySegmentsRequest from '../../services/mySegments/get';
 
-const mySegmentsFetcher = (settings, startingUp = false, metricCollectors) => {
-  let mySegmentsPromise = mySegmentsService(mySegmentsRequest(settings));
+const mySegmentsFetcher = (settings, startingUp = false, metricCollectors, noCache) => {
+  let mySegmentsPromise = mySegmentsService(mySegmentsRequest(settings, noCache));
 
   mySegmentsPromise = tracker.start(tracker.TaskNames.MY_SEGMENTS_FETCH, startingUp ? metricCollectors : false, mySegmentsPromise);
 

--- a/src/producer/fetcher/SegmentChanges.js
+++ b/src/producer/fetcher/SegmentChanges.js
@@ -18,11 +18,11 @@ import segmentChangesService from '../../services/segmentChanges';
 import segmentChangesRequest from '../../services/segmentChanges/get';
 import tracker from '../../utils/timeTracker';
 
-function greedyFetch(settings, lastSinceValue, segmentName, metricCollectors) {
+function greedyFetch(settings, lastSinceValue, segmentName, metricCollectors, noCache) {
   return tracker.start(tracker.TaskNames.SEGMENTS_FETCH, metricCollectors, segmentChangesService(segmentChangesRequest(settings, {
     since: lastSinceValue,
     segmentName
-  })))
+  }, noCache)))
     // no need to handle json parsing errors as SplitError, since errors are handled differently for segments
     .then(resp => resp.json())
     .then(json => {
@@ -30,7 +30,7 @@ function greedyFetch(settings, lastSinceValue, segmentName, metricCollectors) {
       if (since === till) {
         return [json];
       } else {
-        return Promise.all([json, greedyFetch(settings, till, segmentName)]).then(flatMe => {
+        return Promise.all([json, greedyFetch(settings, till, segmentName, undefined, noCache)]).then(flatMe => {
           return [flatMe[0], ...flatMe[1]];
         });
       }
@@ -45,8 +45,8 @@ function greedyFetch(settings, lastSinceValue, segmentName, metricCollectors) {
 }
 
 // @TODO migrate to a generator function and do the job incrementally
-function segmentChangesFetcher(settings, segmentName, since, metricCollectors) {
-  return greedyFetch(settings, since, segmentName, metricCollectors);
+function segmentChangesFetcher(settings, segmentName, since, metricCollectors, noCache) {
+  return greedyFetch(settings, since, segmentName, metricCollectors, noCache);
 }
 
 export default segmentChangesFetcher;

--- a/src/producer/fetcher/SplitChanges.js
+++ b/src/producer/fetcher/SplitChanges.js
@@ -20,9 +20,9 @@ import { SplitError } from '../../utils/lang/Errors';
 import splitChangesService from '../../services/splitChanges';
 import splitChangesRequest from '../../services/splitChanges/get';
 
-function splitChangesFetcher(settings, since, startingUp = false, metricCollectors, isNode) {
+function splitChangesFetcher(settings, since, startingUp = false, metricCollectors, isNode, noCache) {
   const filterQueryString = settings.sync.__splitFiltersValidation.queryString;
-  let splitsPromise = splitChangesService(splitChangesRequest(settings, since, filterQueryString));
+  let splitsPromise = splitChangesService(splitChangesRequest(settings, since, filterQueryString, noCache));
   const collectMetrics = startingUp || isNode; // If we are on the browser, only collect this metric for first fetch. On node do it always.
 
   splitsPromise = tracker.start(tracker.TaskNames.SPLITS_FETCH, collectMetrics ? metricCollectors : false, splitsPromise);

--- a/src/producer/node.js
+++ b/src/producer/node.js
@@ -35,10 +35,13 @@ const NodeUpdater = (context) => {
   let isSynchronizingSplits = false;
   let isSynchronizingSegments = false;
 
-  function synchronizeSplits() {
+  /**
+   * @param {boolean | undefined} noCache true to revalidate data to fetch
+   */
+  function synchronizeSplits(noCache) {
     isSynchronizingSplits = true;
     // `splitsUpdater` promise always resolves, and with a false value if it fails to fetch or store splits
-    return splitsUpdater().then(function (res) {
+    return splitsUpdater(0, noCache).then(function (res) {
       // Mark splits as ready (track first successfull call to start downloading segments)
       splitFetchCompleted = true;
       isSynchronizingSplits = false;
@@ -48,13 +51,14 @@ const NodeUpdater = (context) => {
 
   /**
    * @param {string[] | undefined} segmentNames list of segment names to fetch. By passing `undefined` it fetches the list of segments registered at the storage
-   * @param {boolean} fetchOnlyNew if true, only fetch the segments that not exists, i.e., which `changeNumber` is equal to -1.
-   * This param is used by SplitUpdateWorker to fetch new registered segments on SPLIT_UPDATE notifications.
+   * @param {boolean | undefined} fetchOnlyNew if true, only fetch the segments that not exists, i.e., which `changeNumber` is equal to -1.
+   * This param is used by SplitUpdateWorker on server-side SDK, to fetch new registered segments on SPLIT_UPDATE notifications.
+   * @param {boolean | undefined} noCache true to revalidate data to fetch on a SEGMENT_UPDATE notifications.
    */
-  function synchronizeSegment(segmentNames, fetchOnlyNew) {
+  function synchronizeSegment(segmentNames, fetchOnlyNew, noCache) {
     isSynchronizingSegments = true;
     // `segmentsUpdater` promise always resolves, and with a false value if it fails to fetch or store some segment
-    return segmentsUpdater(segmentNames, fetchOnlyNew).then(function (res) {
+    return segmentsUpdater(segmentNames, fetchOnlyNew, noCache).then(function (res) {
       isSynchronizingSegments = false;
       return res;
     });

--- a/src/producer/node.js
+++ b/src/producer/node.js
@@ -48,11 +48,13 @@ const NodeUpdater = (context) => {
 
   /**
    * @param {string[] | undefined} segmentNames list of segment names to fetch. By passing `undefined` it fetches the list of segments registered at the storage
+   * @param {boolean} fetchOnlyNew if true, only fetch the segments that not exists, i.e., which `changeNumber` is equal to -1.
+   * This param is used by SplitUpdateWorker to fetch new registered segments on SPLIT_UPDATE notifications.
    */
-  function synchronizeSegment(segmentNames) {
+  function synchronizeSegment(segmentNames, fetchOnlyNew) {
     isSynchronizingSegments = true;
     // `segmentsUpdater` promise always resolves, and with a false value if it fails to fetch or store some segment
-    return segmentsUpdater(segmentNames).then(function (res) {
+    return segmentsUpdater(segmentNames, fetchOnlyNew).then(function (res) {
       isSynchronizingSegments = false;
       return res;
     });

--- a/src/producer/updater/MySegments.js
+++ b/src/producer/updater/MySegments.js
@@ -49,8 +49,9 @@ export default function MySegmentsUpdaterFactory(context) {
    *
    * @param {number | undefined} retry current number of retry attemps. this param is only set by SplitChangesUpdater itself.
    * @param {string[] | undefined} segmentList list of mySegment names to sync in the storage. If the list is `undefined`, it fetches them before syncing in the storage.
+   * @param {boolean | undefined} noCache true to revalidate data to fetch
    */
-  return function MySegmentsUpdater(retry = 0, segmentList) {
+  return function MySegmentsUpdater(retry = 0, segmentList, noCache) {
     let updaterPromise;
 
     if (segmentList) {
@@ -58,7 +59,7 @@ export default function MySegmentsUpdaterFactory(context) {
       updaterPromise = new Promise((res) => { updateSegments(segmentList); res();});
     } else {
       // NOTE: We only collect metrics on startup.
-      updaterPromise = mySegmentsFetcher(settings, startingUp, metricCollectors).then(segments => {
+      updaterPromise = mySegmentsFetcher(settings, startingUp, metricCollectors, noCache).then(segments => {
         // Only when we have downloaded segments completely, we should not keep retrying anymore
         startingUp = false;
 

--- a/src/producer/updater/SegmentChanges.js
+++ b/src/producer/updater/SegmentChanges.js
@@ -39,10 +39,11 @@ export default function SegmentChangesUpdaterFactory(context) {
    * Thus, a false result doesn't imply that SDK_SEGMENTS_ARRIVED was not emitted.
    *
    * @param {string[] | undefined} segmentNames list of segment names to fetch. By passing `undefined` it fetches the list of segments registered at the storage
-   * @param {boolean} fetchOnlyNew if set, only fetch the segments that not exists, i.e., which `changeNumber` is equal to -1.
+   * @param {boolean | undefined} fetchOnlyNew if true, only fetch the segments that not exists, i.e., which `changeNumber` is equal to -1.
    * This param is used by SplitUpdateWorker on server-side SDK, to fetch new registered segments on SPLIT_UPDATE notifications.
+   * @param {boolean | undefined} noCache true to revalidate data to fetch on a SEGMENT_UPDATE notifications.
    */
-  return function SegmentChangesUpdater(segmentNames, fetchOnlyNew) {
+  return function SegmentChangesUpdater(segmentNames, fetchOnlyNew, noCache) {
     log.debug('Started segments update');
 
     // Async fetchers are collected here.
@@ -57,7 +58,7 @@ export default function SegmentChangesUpdaterFactory(context) {
         const segmentUpdater = function (since) {
           log.debug(`Processing segment ${segmentName}`);
 
-          updaters.push(segmentChangesFetcher(settings, segmentName, since, metricCollectors).then(function (changes) {
+          updaters.push(segmentChangesFetcher(settings, segmentName, since, metricCollectors, noCache).then(function (changes) {
             let changeNumber = -1;
             const changePromises = [];
             changes.forEach(x => {

--- a/src/producer/updater/SegmentChanges.js
+++ b/src/producer/updater/SegmentChanges.js
@@ -116,7 +116,7 @@ export default function SegmentChangesUpdaterFactory(context) {
     }
 
     // If not a segment name provided, read list of available segments names to be updated.
-    let segments = segmentNames ? segmentNames : storage.segments.getRegisteredSegments();
+    let segments = segmentNames ? segmentNames : segmentsStorage.getRegisteredSegments();
     if(fetchOnlyNew) segments = segments.filter(segmentName => segmentsStorage.getChangeNumber(segmentName) === -1 );
 
     return thenable(segments) ? segments.then(segmentsUpdater) : segmentsUpdater(segments);

--- a/src/producer/updater/SegmentChanges.js
+++ b/src/producer/updater/SegmentChanges.js
@@ -39,7 +39,7 @@ export default function SegmentChangesUpdaterFactory(context) {
    * Thus, a false result doesn't imply that SDK_SEGMENTS_ARRIVED was not emitted.
    *
    * @param {string[] | undefined} segmentNames list of segment names to fetch. By passing `undefined` it fetches the list of segments registered at the storage
-   * @param {boolean | undefined} fetchOnlyNew if set, only fetch the segments that not exists, i.e., which `changeNumber` is equal to -1.
+   * @param {boolean} fetchOnlyNew if set, only fetch the segments that not exists, i.e., which `changeNumber` is equal to -1.
    * This param is used by SplitUpdateWorker on server-side SDK, to fetch new registered segments on SPLIT_UPDATE notifications.
    */
   return function SegmentChangesUpdater(segmentNames, fetchOnlyNew) {

--- a/src/producer/updater/SplitChanges.js
+++ b/src/producer/updater/SplitChanges.js
@@ -67,13 +67,14 @@ export default function SplitChangesUpdaterFactory(context, isNode = false) {
    * Split updater returns a promise that resolves with a `false` boolean value if it fails to fetch splits or synchronize them with the storage.
    *
    * @param {number | undefined} retry current number of retry attemps. this param is only set by SplitChangesUpdater itself.
+   * @param {boolean | undefined} noCache true to revalidate data to fetch
    */
-  return function SplitChangesUpdater(retry = 0) {
+  return function SplitChangesUpdater(retry = 0, noCache) {
 
     function splitChanges(since) {
       log.debug(`Spin up split update using since = ${since}`);
 
-      const fetcherPromise = splitChangesFetcher(settings, since, startingUp, metricCollectors, isNode)
+      const fetcherPromise = splitChangesFetcher(settings, since, startingUp, metricCollectors, isNode, noCache)
         .then(splitChanges => {
           startingUp = false;
 
@@ -111,7 +112,7 @@ export default function SplitChangesUpdaterFactory(context, isNode = false) {
           if (startingUp && settings.startup.retriesOnFailureBeforeReady > retry) {
             retry += 1;
             log.info(`Retrying download of splits #${retry}. Reason: ${error}`);
-            return SplitChangesUpdater(retry);
+            return SplitChangesUpdater(retry, noCache);
           } else {
             startingUp = false;
           }

--- a/src/producer/updater/SplitChanges.js
+++ b/src/producer/updater/SplitChanges.js
@@ -22,6 +22,11 @@ import { SplitError } from '../../utils/lang/Errors';
 import { _Set, setToArray } from '../../utils/lang/Sets';
 import thenable from '../../utils/promise/thenable';
 
+// For server-side segments storage, returns true if all registered segments have been fetched (changeNumber !== -1)
+function checkAllSegmentsExist(segmentsStorage) {
+  return segmentsStorage.getRegisteredSegments().every(segmentName => segmentsStorage.getChangeNumber(segmentName) !== -1);
+}
+
 function computeSplitsMutation(entries) {
   const computed = entries.reduce((accum, split) => {
     if (split.status === 'ACTIVE') {
@@ -87,7 +92,8 @@ export default function SplitChangesUpdaterFactory(context, isNode = false) {
             storage.splits.removeSplits(mutation.removed),
             storage.segments.registerSegments(mutation.segments)
           ]).then(() => {
-            if (since !== splitChanges.till || readyOnAlreadyExistentState) {
+            // On server-side SDK, we must check that all registered segments have been fetched
+            if (readyOnAlreadyExistentState || (since !== splitChanges.till && (!isNode || checkAllSegmentsExist(storage.segments)))) {
               readyOnAlreadyExistentState = false;
               splitsEventEmitter.emit(splitsEventEmitter.SDK_SPLITS_ARRIVED);
             }

--- a/src/readiness/index.js
+++ b/src/readiness/index.js
@@ -46,6 +46,7 @@ function GateContext() {
     });
 
     splits.on(Events.SDK_SPLITS_ARRIVED, (isSplitKill) => {
+      // `isSplitKill` condition is for avoiding emitting SDK_READY when `/mySegments` fetch and SPLIT_KILL ocurs before `/splitChanges` fetch
       if (!isSplitKill) splitsStatus = SPLITS_READY;
       gate.emit(Events.READINESS_GATE_CHECK_STATE);
     });

--- a/src/readiness/index.js
+++ b/src/readiness/index.js
@@ -46,7 +46,7 @@ function GateContext() {
     });
 
     splits.on(Events.SDK_SPLITS_ARRIVED, (isSplitKill) => {
-      // `isSplitKill` condition is for avoiding emitting SDK_READY when `/mySegments` fetch and SPLIT_KILL ocurs before `/splitChanges` fetch
+      // `isSplitKill` condition avoids emitting SDK_READY if `/mySegments` fetch and SPLIT_KILL occurs before `/splitChanges` fetch
       if (!isSplitKill) splitsStatus = SPLITS_READY;
       gate.emit(Events.READINESS_GATE_CHECK_STATE);
     });

--- a/src/services/mySegments/get.js
+++ b/src/services/mySegments/get.js
@@ -13,15 +13,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **/
-import base from '../request';
+import base, { noCacheExtraHeader } from '../request';
 import { matching } from '../../utils/key/factory';
 
-export default function GET(settings) {
+export default function GET(settings, noCache) {
   /**
    * URI encoding of user keys in order to:
    *  - avoid 400 responses (due to URI malformed). E.g.: '/api/mySegments/%'
    *  - avoid 404 responses. E.g.: '/api/mySegments/foo/bar'
    *  - match user keys with special characters. E.g.: 'foo%bar', 'foo/bar'
    */
-  return base(settings, `/mySegments/${encodeURIComponent(matching(settings.core.key))}`);
+  return base(settings, `/mySegments/${encodeURIComponent(matching(settings.core.key))}`, undefined, noCache ? noCacheExtraHeader : undefined);
 }

--- a/src/services/request/index.js
+++ b/src/services/request/index.js
@@ -39,3 +39,5 @@ function RequestFactory(settings, relativeUrl, params, extraHeaders) {
 }
 
 export default RequestFactory;
+
+export const noCacheExtraHeader = { 'Cache-Control': 'no-cache' };

--- a/src/services/segmentChanges/get.js
+++ b/src/services/segmentChanges/get.js
@@ -13,8 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **/
-import base from '../request';
+import base, { noCacheExtraHeader } from '../request';
 
-export default function GET(settings, {since, segmentName}) {
-  return base(settings, `/segmentChanges/${segmentName}?since=${since}`);
+export default function GET(settings, {since, segmentName}, noCache) {
+  return base(settings, `/segmentChanges/${segmentName}?since=${since}`, undefined, noCache ? noCacheExtraHeader : undefined);
 }

--- a/src/services/splitChanges/get.js
+++ b/src/services/splitChanges/get.js
@@ -13,8 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **/
-import base from '../request';
+import base, { noCacheExtraHeader } from '../request';
 
-export default function GET(settings, since, filterQueryString) {
-  return base(settings, `/splitChanges?since=${since}${filterQueryString || ''}`);
+export default function GET(settings, since, filterQueryString, noCache) {
+  return base(settings, `/splitChanges?since=${since}${filterQueryString || ''}`, undefined, noCache ? noCacheExtraHeader : undefined);
 }

--- a/src/sync/SegmentUpdateWorker/browser.js
+++ b/src/sync/SegmentUpdateWorker/browser.js
@@ -28,7 +28,9 @@ export default class MySegmentUpdateWorker {
     if (this.maxChangeNumber > this.currentChangeNumber) {
       this.handleNewEvent = false;
       const currentMaxChangeNumber = this.maxChangeNumber;
-      this.mySegmentsProducer.synchronizeMySegments(this.segmentList).then((result) => {
+
+      // fetch mySegments revalidating data if cached
+      this.mySegmentsProducer.synchronizeMySegments(this.segmentList, true).then((result) => {
         if (result !== false) // Unlike `Split\SegmentUpdateWorker`, we cannot use `mySegmentsStorage.getChangeNumber` since `/mySegments` endpoint doesn't provide this value.
           this.currentChangeNumber = Math.max(this.currentChangeNumber, currentMaxChangeNumber); // use `currentMaxChangeNumber`, in case that `this.maxChangeNumber` was updated during fetch.
         if (this.handleNewEvent) {

--- a/src/sync/SegmentUpdateWorker/node.js
+++ b/src/sync/SegmentUpdateWorker/node.js
@@ -29,7 +29,8 @@ export default class SegmentUpdateWorker {
       this.handleNewEvent = false;
       const currentMaxChangeNumbers = segmentsToFetch.map(segmentToFetch => this.maxChangeNumbers[segmentToFetch]);
 
-      this.segmentsProducer.synchronizeSegment(segmentsToFetch).then((result) => {
+      // fetch segments revalidating data if cached
+      this.segmentsProducer.synchronizeSegment(segmentsToFetch, false, true).then((result) => {
         // Unlike `SplitUpdateWorker` where changeNumber is consistent between notification and endpoint, if there is no error,
         // we must clean the `maxChangeNumbers` of those segments that didn't receive a new update notification during the fetch.
         if (result !== false) {

--- a/src/sync/SplitUpdateWorker/index.js
+++ b/src/sync/SplitUpdateWorker/index.js
@@ -26,7 +26,9 @@ export default class SplitUpdateWorker {
   __handleSplitUpdateCall() {
     if (this.maxChangeNumber > this.splitStorage.getChangeNumber()) {
       this.handleNewEvent = false;
-      this.splitProducer.synchronizeSplits().then(() => {
+
+      // fetch splits revalidating data if cached
+      this.splitProducer.synchronizeSplits(true).then(() => {
         if (this.handleNewEvent) {
           this.__handleSplitUpdateCall();
         } else {

--- a/src/sync/SplitUpdateWorker/index.js
+++ b/src/sync/SplitUpdateWorker/index.js
@@ -30,6 +30,8 @@ export default class SplitUpdateWorker {
         if (this.handleNewEvent) {
           this.__handleSplitUpdateCall();
         } else {
+          // fetch new registered segments for server-side API. Not retrying on error
+          if(this.splitProducer.synchronizeSegment) this.splitProducer.synchronizeSegment(undefined, true);
           this.backoff.scheduleCall();
         }
       });

--- a/src/sync/__tests__/SegmentUpdateWorker/browser.spec.js
+++ b/src/sync/__tests__/SegmentUpdateWorker/browser.spec.js
@@ -95,7 +95,7 @@ tape('MySegmentUpdateWorker', t => {
           producer.__resolveMySegmentsUpdaterCall(3); // fetch success
           setTimeout(() => {
             assert.true(producer.synchronizeMySegments.calledTwice, 'recalls `synchronizeMySegments` once previous event was handled');
-            assert.true(producer.synchronizeMySegments.lastCall.calledWithExactly(['some_segment']), 'calls `synchronizeMySegments` with given segmentList');
+            assert.true(producer.synchronizeMySegments.lastCall.calledWithExactly(['some_segment'], true), 'calls `synchronizeMySegments` with given segmentList');
             producer.__resolveMySegmentsUpdaterCall(4); // fetch success
             setTimeout(() => {
               assert.equal(mySegmentUpdateWorker.currentChangeNumber, 120, 'currentChangeNumber updated');
@@ -110,7 +110,7 @@ tape('MySegmentUpdateWorker', t => {
               producer.__resolveMySegmentsUpdaterCall(5); // fetch success
               setTimeout(() => {
                 assert.true(producer.synchronizeMySegments.calledTwice, 'recalls `synchronizeMySegments` once previous event was handled');
-                assert.true(producer.synchronizeMySegments.lastCall.calledWithExactly(undefined), 'calls `synchronizeMySegments` without segmentList if the event doesn\'t have payload');
+                assert.true(producer.synchronizeMySegments.lastCall.calledWithExactly(undefined, true), 'calls `synchronizeMySegments` without segmentList if the event doesn\'t have payload');
                 producer.__resolveMySegmentsUpdaterCall(6); // fetch success
                 setTimeout(() => {
                   assert.equal(mySegmentUpdateWorker.currentChangeNumber, 140, 'currentChangeNumber updated');

--- a/src/sync/__tests__/SegmentUpdateWorker/node.spec.js
+++ b/src/sync/__tests__/SegmentUpdateWorker/node.spec.js
@@ -61,7 +61,7 @@ tape('SegmentUpdateWorker', t => {
     segmentUpdateWorker.put(100, 'mocked_segment_1');
     assert.deepEqual(segmentUpdateWorker.maxChangeNumbers, { 'mocked_segment_1': 100 }, 'queues events (changeNumbers) if they are mayor than storage changeNumbers and maxChangeNumbers');
     assert.true(producer.synchronizeSegment.calledOnce, 'calls `synchronizeSegment` if `isSynchronizingSegments` is false');
-    assert.true(producer.synchronizeSegment.calledOnceWithExactly(['mocked_segment_1']), 'calls `synchronizeSegment` with segmentName');
+    assert.true(producer.synchronizeSegment.calledOnceWithExactly(['mocked_segment_1'], false, true), 'calls `synchronizeSegment` with segmentName');
 
     // assert queueing items if `isSynchronizingSegments` is true
     assert.equal(producer.isSynchronizingSegments(), true);
@@ -79,7 +79,7 @@ tape('SegmentUpdateWorker', t => {
     setTimeout(() => {
       assert.equal(cache.getChangeNumber('mocked_segment_1'), 100, '100');
       assert.true(producer.synchronizeSegment.calledTwice, 'recalls `synchronizeSegment` if `isSynchronizingSegments` is false and queue is not empty');
-      assert.true(producer.synchronizeSegment.lastCall.calledWithExactly(['mocked_segment_1', 'mocked_segment_2', 'mocked_segment_3']), 'calls `synchronizeSegment` with segmentName');
+      assert.true(producer.synchronizeSegment.lastCall.calledWithExactly(['mocked_segment_1', 'mocked_segment_2', 'mocked_segment_3'], false, true), 'calls `synchronizeSegment` with segmentName');
       assert.equal(segmentUpdateWorker.backoff.attempts, 0, 'no retry scheduled if synchronization success (changeNumbers are the expected)');
 
       // assert not rescheduling synchronization if some changeNumber is not updated as expected,
@@ -88,7 +88,7 @@ tape('SegmentUpdateWorker', t => {
       producer.__resolveSegmentsUpdaterCall(1, { 'mocked_segment_1': 100, 'mocked_segment_2': 100, 'mocked_segment_3': 94 });
       setTimeout(() => {
         assert.equal(producer.synchronizeSegment.callCount, 3, 'recalls `synchronizeSegment` if a new item was queued with a greater changeNumber while the fetch was pending');
-        assert.true(producer.synchronizeSegment.lastCall.calledWithExactly(['mocked_segment_1']), 'calls `synchronizeSegment` with the segmentName that was queued with a greater changeNumber while the fetch was pending');
+        assert.true(producer.synchronizeSegment.lastCall.calledWithExactly(['mocked_segment_1'], false, true), 'calls `synchronizeSegment` with the segmentName that was queued with a greater changeNumber while the fetch was pending');
         assert.equal(segmentUpdateWorker.backoff.attempts, 0, 'doesn\'t retry backoff schedule since a new item was queued');
 
         // assert dequeueing remaining events


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

On server-side SDK (node), if SPLIT_UPDATE notifications involve splits changes with new segments (not registered yet), perform the fetch of those segments.
Only emit SDK_UPDATE when segments are fetched. Otherwise, the SDK might evaluate some split with an "empty" segment returning then an invalid treatment.

## How do we test the changes introduced in this PR?

Added E2E tests for the new use cases.

## Extra Notes

- In SplitUpdateWorker, fetching segments doesn't retry on failure. Thus, if the segments fetch fails on a SPLIT_UPDATE message, SDK_UPDATE is not emitted.
- Behaviour change: on polling mode in serder-side SDK, if splits changes uses new segments, it doesn't emit SDK_UPDATE until they are fetched in the periodic segments fetch task.

- **Discuss possible refactor**: remove `fetchOnlyNew` param from SegmentsUpdater and process the list in SplitUpdateWorker, but this requires SplitUpdateWorker having the segments storage as a dependency.
