### PR TITLE
Added no-cache header for streaming updates

### DIFF
--- a/src/__tests__/browserSuites/push-synchronization.spec.js
+++ b/src/__tests__/browserSuites/push-synchronization.spec.js
@@ -8,7 +8,7 @@ import mySegmentsMarcio from '../mocks/mysegments.marcio@split.io.json';
 
 import splitUpdateMessage from '../mocks/message.SPLIT_UPDATE.1457552649999.json';
 import oldSplitUpdateMessage from '../mocks/message.SPLIT_UPDATE.1457552620999.json';
-import mySegmentsUpdateMessage from '../mocks/message.MY_SEGMENTS_UPDATE.nicolas@split.io.1457552640000.json';
+import mySegmentsUpdateMessageNoPayload from '../mocks/message.MY_SEGMENTS_UPDATE.nicolas@split.io.1457552640000.json';
 import mySegmentsUpdateMessageWithPayload from '../mocks/message.MY_SEGMENTS_UPDATE.marcio@split.io.1457552645000.json';
 import mySegmentsUpdateMessageWithEmptyPayload from '../mocks/message.MY_SEGMENTS_UPDATE.marcio@split.io.1457552646000.json';
 import splitKillMessage from '../mocks/message.SPLIT_KILL.1457552650000.json';
@@ -16,7 +16,7 @@ import splitKillMessage from '../mocks/message.SPLIT_KILL.1457552650000.json';
 import authPushEnabledNicolas from '../mocks/auth.pushEnabled.nicolas@split.io.json';
 import authPushEnabledNicolasAndMarcio from '../mocks/auth.pushEnabled.nicolas@split.io.marcio@split.io.json';
 
-import { nearlyEqual } from '../testUtils';
+import { nearlyEqual, hasNoCacheHeader } from '../testUtils';
 import includes from 'lodash/includes';
 
 // Replace original EventSource with mock
@@ -48,7 +48,7 @@ const settings = SettingsFactory(config);
 const MILLIS_SSE_OPEN = 100;
 const MILLIS_FIRST_SPLIT_UPDATE_EVENT = 200;
 const MILLIS_SECOND_SPLIT_UPDATE_EVENT = 300;
-const MILLIS_MYSEGMENT_UPDATE_EVENT = 400;
+const MILLIS_MY_SEGMENTS_UPDATE_EVENT_NO_PAYLOAD = 400;
 const MILLIS_SPLIT_KILL_EVENT = 500;
 const MILLIS_NEW_CLIENT = 600;
 const MILLIS_SECOND_SSE_OPEN = 700;
@@ -102,11 +102,11 @@ export function testSynchronization(fetchMock, assert) {
       assert.equal(client.getTreatment('splitters'), 'off', 'evaluation with initial MySegments list');
       client.once(client.Event.SDK_UPDATE, () => {
         const lapse = Date.now() - start;
-        assert.true(nearlyEqual(lapse, MILLIS_MYSEGMENT_UPDATE_EVENT), 'SDK_UPDATE due to MY_SEGMENTS_UPDATE event');
+        assert.true(nearlyEqual(lapse, MILLIS_MY_SEGMENTS_UPDATE_EVENT_NO_PAYLOAD), 'SDK_UPDATE due to MY_SEGMENTS_UPDATE event');
         assert.equal(client.getTreatment('splitters'), 'on', 'evaluation with updated MySegments list');
       });
-      eventSourceInstance.emitMessage(mySegmentsUpdateMessage);
-    }, MILLIS_MYSEGMENT_UPDATE_EVENT); // send a MY_SEGMENTS_UPDATE event with a new changeNumber after 0.4 seconds
+      eventSourceInstance.emitMessage(mySegmentsUpdateMessageNoPayload);
+    }, MILLIS_MY_SEGMENTS_UPDATE_EVENT_NO_PAYLOAD); // send a MY_SEGMENTS_UPDATE event with a new changeNumber after 0.4 seconds
 
     setTimeout(() => {
       assert.equal(client.getTreatment('whitelist'), 'allowed', 'evaluation with not killed Split');
@@ -196,44 +196,69 @@ export function testSynchronization(fetchMock, assert) {
   });
 
   // initial split and mySegments sync
-  fetchMock.getOnce(settings.url('/splitChanges?since=-1'), function () {
+  fetchMock.getOnce(settings.url('/splitChanges?since=-1'), function (url, opts) {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, 0), 'initial sync');
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
     return { status: 200, body: splitChangesMock1 };
   });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), function (url, opts) {
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
+    return { status: 200, body: mySegmentsNicolasMock1 };
+  });
 
   // split and segment sync after SSE opened
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
+  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function (url, opts) {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_SSE_OPEN), 'sync after SSE connection is opened');
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
     return { status: 200, body: splitChangesMock2 };
   });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), function (url, opts) {
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
+    return { status: 200, body: mySegmentsNicolasMock1 };
+  });
 
   // fetch due to SPLIT_UPDATE event
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock3 });
+  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function (url, opts) {
+    if (!hasNoCacheHeader(opts)) assert.fail('request must include `Cache-Control` header1');
+    return { status: 200, body: splitChangesMock3 };
+  });
 
   // fetch due to first MY_SEGMENTS_UPDATE event
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock2 });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), function (url, opts) {
+    if (!hasNoCacheHeader(opts)) assert.fail('request must include `Cache-Control` header2');
+    return { status: 200, body: mySegmentsNicolasMock2 };
+  });
 
   // fetch due to SPLIT_KILL event
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), function () {
+  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), function (url, opts) {
+    if (!hasNoCacheHeader(opts)) assert.fail('request must include `Cache-Control` header3');
     assert.equal(client.getTreatment('whitelist'), 'not_allowed', 'evaluation with split killed immediately, before fetch is done');
     return { status: 200, body: splitChangesMock4 };
   });
 
   // initial fetch of mySegments for new client
-  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), function (url, opts) {
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
+    return { status: 200, body: mySegmentsMarcio };
+  });
 
   // split and mySegment sync after second SSE opened
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552650000'), function () {
+  fetchMock.getOnce(settings.url('/splitChanges?since=1457552650000'), function (url, opts) {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_SECOND_SSE_OPEN), 'sync after second SSE connection is opened');
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
     return { status: 200, body: { splits: [], since: 1457552650000, till: 1457552650000 } };
   });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock2 });
-  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), function (url, opts) {
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
+    return { status: 200, body: mySegmentsNicolasMock2 };
+  });
+  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), function (url, opts) {
+    if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
+    return { status: 200, body: mySegmentsMarcio };
+  });
 
   fetchMock.get(new RegExp('.*'), function (url) {
     assert.fail('unexpected GET request with url: ' + url);

--- a/src/__tests__/testUtils/index.js
+++ b/src/__tests__/testUtils/index.js
@@ -38,3 +38,7 @@ export function mockSegmentChanges(fetchMock, matcher, keys, changeNumber = 1457
     };
   });
 }
+
+export function hasNoCacheHeader(fetchMockOpts) {
+  return fetchMockOpts.headers['Cache-Control'] === 'no-cache';
+}

--- a/src/producer/browser.js
+++ b/src/producer/browser.js
@@ -35,10 +35,13 @@ const FullBrowserProducer = (context) => {
 
   let isSynchronizingSplits = false;
 
-  function synchronizeSplits() {
+  /**
+   * @param {boolean | undefined} noCache true to revalidate data to fetch
+   */
+  function synchronizeSplits(noCache) {
     isSynchronizingSplits = true;
     // `splitsUpdater` promise always resolves, and with a false value if it fails to fetch or store splits
-    return splitsUpdater().then(function (res) {
+    return splitsUpdater(0, noCache).then(function (res) {
       isSynchronizingSplits = false;
       return res;
     });

--- a/src/producer/browser/Partial.js
+++ b/src/producer/browser/Partial.js
@@ -40,11 +40,12 @@ const PartialBrowserProducer = (context) => {
 
   /**
    * @param {string[] | undefined} segmentList might be undefined
+   * @param {boolean | undefined} noCache true to revalidate data to fetch
    */
-  function synchronizeMySegments(segmentList) {
+  function synchronizeMySegments(segmentList, noCache) {
     isSynchronizingMySegments = true;
     // `mySegmentsUpdater` promise always resolves, and with a false value if it fails to fetch or store mySegments
-    return mySegmentsUpdater(0, segmentList).then(function (res) {
+    return mySegmentsUpdater(0, segmentList, noCache).then(function (res) {
       isSynchronizingMySegments = false;
       return res;
     });

--- a/src/producer/fetcher/MySegments.js
+++ b/src/producer/fetcher/MySegments.js
@@ -20,8 +20,8 @@ import { SplitError } from '../../utils/lang/Errors';
 import mySegmentsService from '../../services/mySegments';
 import mySegmentsRequest from '../../services/mySegments/get';
 
-const mySegmentsFetcher = (settings, startingUp = false, metricCollectors) => {
-  let mySegmentsPromise = mySegmentsService(mySegmentsRequest(settings));
+const mySegmentsFetcher = (settings, startingUp = false, metricCollectors, noCache) => {
+  let mySegmentsPromise = mySegmentsService(mySegmentsRequest(settings, noCache));
 
   mySegmentsPromise = tracker.start(tracker.TaskNames.MY_SEGMENTS_FETCH, startingUp ? metricCollectors : false, mySegmentsPromise);
 

--- a/src/producer/fetcher/SegmentChanges.js
+++ b/src/producer/fetcher/SegmentChanges.js
@@ -30,7 +30,7 @@ function greedyFetch(settings, lastSinceValue, segmentName, metricCollectors, no
       if (since === till) {
         return [json];
       } else {
-        return Promise.all([json, greedyFetch(settings, till, segmentName)]).then(flatMe => {
+        return Promise.all([json, greedyFetch(settings, till, segmentName, undefined, noCache)]).then(flatMe => {
           return [flatMe[0], ...flatMe[1]];
         });
       }

--- a/src/producer/fetcher/SegmentChanges.js
+++ b/src/producer/fetcher/SegmentChanges.js
@@ -18,11 +18,11 @@ import segmentChangesService from '../../services/segmentChanges';
 import segmentChangesRequest from '../../services/segmentChanges/get';
 import tracker from '../../utils/timeTracker';
 
-function greedyFetch(settings, lastSinceValue, segmentName, metricCollectors) {
+function greedyFetch(settings, lastSinceValue, segmentName, metricCollectors, noCache) {
   return tracker.start(tracker.TaskNames.SEGMENTS_FETCH, metricCollectors, segmentChangesService(segmentChangesRequest(settings, {
     since: lastSinceValue,
     segmentName
-  })))
+  }, noCache)))
     // no need to handle json parsing errors as SplitError, since errors are handled differently for segments
     .then(resp => resp.json())
     .then(json => {
@@ -45,8 +45,8 @@ function greedyFetch(settings, lastSinceValue, segmentName, metricCollectors) {
 }
 
 // @TODO migrate to a generator function and do the job incrementally
-function segmentChangesFetcher(settings, segmentName, since, metricCollectors) {
-  return greedyFetch(settings, since, segmentName, metricCollectors);
+function segmentChangesFetcher(settings, segmentName, since, metricCollectors, noCache) {
+  return greedyFetch(settings, since, segmentName, metricCollectors, noCache);
 }
 
 export default segmentChangesFetcher;

--- a/src/producer/fetcher/SplitChanges.js
+++ b/src/producer/fetcher/SplitChanges.js
@@ -20,9 +20,9 @@ import { SplitError } from '../../utils/lang/Errors';
 import splitChangesService from '../../services/splitChanges';
 import splitChangesRequest from '../../services/splitChanges/get';
 
-function splitChangesFetcher(settings, since, startingUp = false, metricCollectors, isNode) {
+function splitChangesFetcher(settings, since, startingUp = false, metricCollectors, isNode, noCache) {
   const filterQueryString = settings.sync.__splitFiltersValidation.queryString;
-  let splitsPromise = splitChangesService(splitChangesRequest(settings, since, filterQueryString));
+  let splitsPromise = splitChangesService(splitChangesRequest(settings, since, filterQueryString, noCache));
   const collectMetrics = startingUp || isNode; // If we are on the browser, only collect this metric for first fetch. On node do it always.
 
   splitsPromise = tracker.start(tracker.TaskNames.SPLITS_FETCH, collectMetrics ? metricCollectors : false, splitsPromise);

--- a/src/producer/node.js
+++ b/src/producer/node.js
@@ -35,10 +35,13 @@ const NodeUpdater = (context) => {
   let isSynchronizingSplits = false;
   let isSynchronizingSegments = false;
 
-  function synchronizeSplits() {
+  /**
+   * @param {boolean | undefined} noCache true to revalidate data to fetch
+   */
+  function synchronizeSplits(noCache) {
     isSynchronizingSplits = true;
     // `splitsUpdater` promise always resolves, and with a false value if it fails to fetch or store splits
-    return splitsUpdater().then(function (res) {
+    return splitsUpdater(0, noCache).then(function (res) {
       // Mark splits as ready (track first successfull call to start downloading segments)
       splitFetchCompleted = true;
       isSynchronizingSplits = false;
@@ -48,11 +51,12 @@ const NodeUpdater = (context) => {
 
   /**
    * @param {string[] | undefined} segmentNames list of segment names to fetch. By passing `undefined` it fetches the list of segments registered at the storage
+   * @param {boolean | undefined} noCache true to revalidate data to fetch
    */
-  function synchronizeSegment(segmentNames) {
+  function synchronizeSegment(segmentNames, noCache) {
     isSynchronizingSegments = true;
     // `segmentsUpdater` promise always resolves, and with a false value if it fails to fetch or store some segment
-    return segmentsUpdater(segmentNames).then(function (res) {
+    return segmentsUpdater(segmentNames, noCache).then(function (res) {
       isSynchronizingSegments = false;
       return res;
     });

--- a/src/producer/updater/MySegments.js
+++ b/src/producer/updater/MySegments.js
@@ -49,8 +49,9 @@ export default function MySegmentsUpdaterFactory(context) {
    *
    * @param {number | undefined} retry current number of retry attemps. this param is only set by SplitChangesUpdater itself.
    * @param {string[] | undefined} segmentList list of mySegment names to sync in the storage. If the list is `undefined`, it fetches them before syncing in the storage.
+   * @param {boolean | undefined} noCache true to revalidate data to fetch
    */
-  return function MySegmentsUpdater(retry = 0, segmentList) {
+  return function MySegmentsUpdater(retry = 0, segmentList, noCache) {
     let updaterPromise;
 
     if (segmentList) {
@@ -58,7 +59,7 @@ export default function MySegmentsUpdaterFactory(context) {
       updaterPromise = new Promise((res) => { updateSegments(segmentList); res();});
     } else {
       // NOTE: We only collect metrics on startup.
-      updaterPromise = mySegmentsFetcher(settings, startingUp, metricCollectors).then(segments => {
+      updaterPromise = mySegmentsFetcher(settings, startingUp, metricCollectors, noCache).then(segments => {
         // Only when we have downloaded segments completely, we should not keep retrying anymore
         startingUp = false;
 

--- a/src/producer/updater/SegmentChanges.js
+++ b/src/producer/updater/SegmentChanges.js
@@ -38,8 +38,9 @@ export default function SegmentChangesUpdaterFactory(context) {
    * Thus, a false result doesn't imply that SDK_SEGMENTS_ARRIVED was not emitted.
    *
    * @param {string[] | undefined} segmentNames list of segment names to fetch. By passing `undefined` it fetches the list of segments registered at the storage
+   * @param {boolean | undefined} noCache true to revalidate data to fetch
    */
-  return function SegmentChangesUpdater(segmentNames) {
+  return function SegmentChangesUpdater(segmentNames, noCache) {
     log.debug('Started segments update');
 
     // Async fetchers are collected here.
@@ -54,7 +55,7 @@ export default function SegmentChangesUpdaterFactory(context) {
         const segmentUpdater = function (since) {
           log.debug(`Processing segment ${segmentName}`);
 
-          updaters.push(segmentChangesFetcher(settings, segmentName, since, metricCollectors).then(function (changes) {
+          updaters.push(segmentChangesFetcher(settings, segmentName, since, metricCollectors, noCache).then(function (changes) {
             let changeNumber = -1;
             const changePromises = [];
             changes.forEach(x => {

--- a/src/producer/updater/SplitChanges.js
+++ b/src/producer/updater/SplitChanges.js
@@ -62,13 +62,14 @@ export default function SplitChangesUpdaterFactory(context, isNode = false) {
    * Split updater returns a promise that resolves with a `false` boolean value if it fails to fetch splits or synchronize them with the storage.
    *
    * @param {number | undefined} retry current number of retry attemps. this param is only set by SplitChangesUpdater itself.
+   * @param {boolean | undefined} noCache true to revalidate data to fetch
    */
-  return function SplitChangesUpdater(retry = 0) {
+  return function SplitChangesUpdater(retry = 0, noCache) {
 
     function splitChanges(since) {
       log.debug(`Spin up split update using since = ${since}`);
 
-      const fetcherPromise = splitChangesFetcher(settings, since, startingUp, metricCollectors, isNode)
+      const fetcherPromise = splitChangesFetcher(settings, since, startingUp, metricCollectors, isNode, noCache)
         .then(splitChanges => {
           startingUp = false;
 
@@ -105,7 +106,7 @@ export default function SplitChangesUpdaterFactory(context, isNode = false) {
           if (startingUp && settings.startup.retriesOnFailureBeforeReady > retry) {
             retry += 1;
             log.info(`Retrying download of splits #${retry}. Reason: ${error}`);
-            return SplitChangesUpdater(retry);
+            return SplitChangesUpdater(retry, noCache);
           } else {
             startingUp = false;
           }

--- a/src/services/mySegments/get.js
+++ b/src/services/mySegments/get.js
@@ -13,15 +13,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **/
-import base from '../request';
+import base, { noCacheExtraHeader } from '../request';
 import { matching } from '../../utils/key/factory';
 
-export default function GET(settings) {
+export default function GET(settings, noCache) {
   /**
    * URI encoding of user keys in order to:
    *  - avoid 400 responses (due to URI malformed). E.g.: '/api/mySegments/%'
    *  - avoid 404 responses. E.g.: '/api/mySegments/foo/bar'
    *  - match user keys with special characters. E.g.: 'foo%bar', 'foo/bar'
    */
-  return base(settings, `/mySegments/${encodeURIComponent(matching(settings.core.key))}`);
+  return base(settings, `/mySegments/${encodeURIComponent(matching(settings.core.key))}`, undefined, noCache ? noCacheExtraHeader : undefined);
 }

--- a/src/services/request/index.js
+++ b/src/services/request/index.js
@@ -39,3 +39,5 @@ function RequestFactory(settings, relativeUrl, params, extraHeaders) {
 }
 
 export default RequestFactory;
+
+export const noCacheExtraHeader = { 'Cache-Control': 'no-cache' };

--- a/src/services/segmentChanges/get.js
+++ b/src/services/segmentChanges/get.js
@@ -13,8 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **/
-import base from '../request';
+import base, { noCacheExtraHeader } from '../request';
 
-export default function GET(settings, {since, segmentName}) {
-  return base(settings, `/segmentChanges/${segmentName}?since=${since}`);
+export default function GET(settings, {since, segmentName}, noCache) {
+  return base(settings, `/segmentChanges/${segmentName}?since=${since}`, undefined, noCache ? noCacheExtraHeader : undefined);
 }

--- a/src/services/splitChanges/get.js
+++ b/src/services/splitChanges/get.js
@@ -13,8 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **/
-import base from '../request';
+import base, { noCacheExtraHeader } from '../request';
 
-export default function GET(settings, since, filterQueryString) {
-  return base(settings, `/splitChanges?since=${since}${filterQueryString || ''}`);
+export default function GET(settings, since, filterQueryString, noCache) {
+  return base(settings, `/splitChanges?since=${since}${filterQueryString || ''}`, undefined, noCache ? noCacheExtraHeader : undefined);
 }

--- a/src/sync/SegmentUpdateWorker/browser.js
+++ b/src/sync/SegmentUpdateWorker/browser.js
@@ -28,7 +28,9 @@ export default class MySegmentUpdateWorker {
     if (this.maxChangeNumber > this.currentChangeNumber) {
       this.handleNewEvent = false;
       const currentMaxChangeNumber = this.maxChangeNumber;
-      this.mySegmentsProducer.synchronizeMySegments(this.segmentList).then((result) => {
+
+      // fetch mySegments revalidating data if cached
+      this.mySegmentsProducer.synchronizeMySegments(this.segmentList, true).then((result) => {
         if (result !== false) // Unlike `Split\SegmentUpdateWorker`, we cannot use `mySegmentsStorage.getChangeNumber` since `/mySegments` endpoint doesn't provide this value.
           this.currentChangeNumber = Math.max(this.currentChangeNumber, currentMaxChangeNumber); // use `currentMaxChangeNumber`, in case that `this.maxChangeNumber` was updated during fetch.
         if (this.handleNewEvent) {

--- a/src/sync/SegmentUpdateWorker/node.js
+++ b/src/sync/SegmentUpdateWorker/node.js
@@ -29,7 +29,8 @@ export default class SegmentUpdateWorker {
       this.handleNewEvent = false;
       const currentMaxChangeNumbers = segmentsToFetch.map(segmentToFetch => this.maxChangeNumbers[segmentToFetch]);
 
-      this.segmentsProducer.synchronizeSegment(segmentsToFetch).then((result) => {
+      // fetch segments revalidating data if cached
+      this.segmentsProducer.synchronizeSegment(segmentsToFetch, true).then((result) => {
         // Unlike `SplitUpdateWorker` where changeNumber is consistent between notification and endpoint, if there is no error,
         // we must clean the `maxChangeNumbers` of those segments that didn't receive a new update notification during the fetch.
         if (result !== false) {

--- a/src/sync/SplitUpdateWorker/index.js
+++ b/src/sync/SplitUpdateWorker/index.js
@@ -26,7 +26,9 @@ export default class SplitUpdateWorker {
   __handleSplitUpdateCall() {
     if (this.maxChangeNumber > this.splitStorage.getChangeNumber()) {
       this.handleNewEvent = false;
-      this.splitProducer.synchronizeSplits().then(() => {
+
+      // fetch splits revalidating data if cached
+      this.splitProducer.synchronizeSplits(true).then(() => {
         if (this.handleNewEvent) {
           this.__handleSplitUpdateCall();
         } else {

--- a/src/sync/__tests__/SegmentUpdateWorker/browser.spec.js
+++ b/src/sync/__tests__/SegmentUpdateWorker/browser.spec.js
@@ -95,7 +95,7 @@ tape('MySegmentUpdateWorker', t => {
           producer.__resolveMySegmentsUpdaterCall(3); // fetch success
           setTimeout(() => {
             assert.true(producer.synchronizeMySegments.calledTwice, 'recalls `synchronizeMySegments` once previous event was handled');
-            assert.true(producer.synchronizeMySegments.lastCall.calledWithExactly(['some_segment']), 'calls `synchronizeMySegments` with given segmentList');
+            assert.true(producer.synchronizeMySegments.lastCall.calledWithExactly(['some_segment'], true), 'calls `synchronizeMySegments` with given segmentList');
             producer.__resolveMySegmentsUpdaterCall(4); // fetch success
             setTimeout(() => {
               assert.equal(mySegmentUpdateWorker.currentChangeNumber, 120, 'currentChangeNumber updated');
@@ -110,7 +110,7 @@ tape('MySegmentUpdateWorker', t => {
               producer.__resolveMySegmentsUpdaterCall(5); // fetch success
               setTimeout(() => {
                 assert.true(producer.synchronizeMySegments.calledTwice, 'recalls `synchronizeMySegments` once previous event was handled');
-                assert.true(producer.synchronizeMySegments.lastCall.calledWithExactly(undefined), 'calls `synchronizeMySegments` without segmentList if the event doesn\'t have payload');
+                assert.true(producer.synchronizeMySegments.lastCall.calledWithExactly(undefined, true), 'calls `synchronizeMySegments` without segmentList if the event doesn\'t have payload');
                 producer.__resolveMySegmentsUpdaterCall(6); // fetch success
                 setTimeout(() => {
                   assert.equal(mySegmentUpdateWorker.currentChangeNumber, 140, 'currentChangeNumber updated');

--- a/src/sync/__tests__/SegmentUpdateWorker/node.spec.js
+++ b/src/sync/__tests__/SegmentUpdateWorker/node.spec.js
@@ -61,7 +61,7 @@ tape('SegmentUpdateWorker', t => {
     segmentUpdateWorker.put(100, 'mocked_segment_1');
     assert.deepEqual(segmentUpdateWorker.maxChangeNumbers, { 'mocked_segment_1': 100 }, 'queues events (changeNumbers) if they are mayor than storage changeNumbers and maxChangeNumbers');
     assert.true(producer.synchronizeSegment.calledOnce, 'calls `synchronizeSegment` if `isSynchronizingSegments` is false');
-    assert.true(producer.synchronizeSegment.calledOnceWithExactly(['mocked_segment_1']), 'calls `synchronizeSegment` with segmentName');
+    assert.true(producer.synchronizeSegment.calledOnceWithExactly(['mocked_segment_1'], false, true), 'calls `synchronizeSegment` with segmentName');
 
     // assert queueing items if `isSynchronizingSegments` is true
     assert.equal(producer.isSynchronizingSegments(), true);
@@ -79,7 +79,7 @@ tape('SegmentUpdateWorker', t => {
     setTimeout(() => {
       assert.equal(cache.getChangeNumber('mocked_segment_1'), 100, '100');
       assert.true(producer.synchronizeSegment.calledTwice, 'recalls `synchronizeSegment` if `isSynchronizingSegments` is false and queue is not empty');
-      assert.true(producer.synchronizeSegment.lastCall.calledWithExactly(['mocked_segment_1', 'mocked_segment_2', 'mocked_segment_3']), 'calls `synchronizeSegment` with segmentName');
+      assert.true(producer.synchronizeSegment.lastCall.calledWithExactly(['mocked_segment_1', 'mocked_segment_2', 'mocked_segment_3'], false, true), 'calls `synchronizeSegment` with segmentName');
       assert.equal(segmentUpdateWorker.backoff.attempts, 0, 'no retry scheduled if synchronization success (changeNumbers are the expected)');
 
       // assert not rescheduling synchronization if some changeNumber is not updated as expected,
@@ -88,7 +88,7 @@ tape('SegmentUpdateWorker', t => {
       producer.__resolveSegmentsUpdaterCall(1, { 'mocked_segment_1': 100, 'mocked_segment_2': 100, 'mocked_segment_3': 94 });
       setTimeout(() => {
         assert.equal(producer.synchronizeSegment.callCount, 3, 'recalls `synchronizeSegment` if a new item was queued with a greater changeNumber while the fetch was pending');
-        assert.true(producer.synchronizeSegment.lastCall.calledWithExactly(['mocked_segment_1']), 'calls `synchronizeSegment` with the segmentName that was queued with a greater changeNumber while the fetch was pending');
+        assert.true(producer.synchronizeSegment.lastCall.calledWithExactly(['mocked_segment_1'], false, true), 'calls `synchronizeSegment` with the segmentName that was queued with a greater changeNumber while the fetch was pending');
         assert.equal(segmentUpdateWorker.backoff.attempts, 0, 'doesn\'t retry backoff schedule since a new item was queued');
 
         // assert dequeueing remaining events


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

- Added Cache-control header for `/splitChanges`, `/segmentChanges` and `/mySegments` requests associated to streaming update notifications.

## How do we test the changes introduced in this PR?

- Added asserts to E2E push tests
- Updated UTs

## Extra Notes