### PR TITLE
Removing @deprecated from ready() method on splitio.d.ts

### DIFF
--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -370,7 +370,6 @@ interface IStatusInterface extends EventEmitter {
   /**
    * Returns a promise that will be resolved once the SDK has finished loading.
    * @function ready
-   * @deprecated Use on(sdk.Event.SDK_READY, callback: () => void) instead.
    * @returns {Promise<void>}
    */
   ready(): Promise<void>


### PR DESCRIPTION
# JS SDK

## What did you accomplish?
Removed a deprecation mark from the ready() method of the status manager interface in our TypeScript declarations. We've ended up supporting the feature properly and it's not going anywhere for the time being.

## How do we test the changes introduced in this PR?
Run our ts-tests. It's only metadata so no worth running any functionality tests.

## Extra Notes