### PR TITLE
Fix: tweak how Array.from function exists

### DIFF
--- a/src/utils/lang/Sets.js
+++ b/src/utils/lang/Sets.js
@@ -85,7 +85,7 @@ export function setToArray(set) {
  */
 function getSetConstructor() {
   // eslint-disable-next-line compat/compat
-  if (Array.from && typeof Set === 'function' && Set.prototype && Set.prototype.values) {
+  if (typeof Array.from === 'function' && typeof Set === 'function' && Set.prototype && Set.prototype.values) {
     return Set;
   }
   return SetPoly;


### PR DESCRIPTION
# JS SDK

## What did you accomplish?
I'm updating how we are checking if the `Array.from` function exists in the current environment.

## How do we test the changes introduced in this PR?
1 - Checkout this branch
2 - Build the SDK
3 - Test locally, or run the tests suites.

## Extra Notes