### PR TITLE
throw error instead of string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import keyParser from './utils/key/parser';
 import logFactory, { API } from './utils/logger';
 const log = logFactory('splitio');
 import tracker from './utils/timeTracker';
+import { SplitError } from './utils/lang/Errors';
 import SplitFactoryOnline from './factory/online';
 import SplitFactoryOffline from './factory/offline';
 import sdkStatusManager from './readiness/statusManager';
@@ -83,20 +84,20 @@ export function SplitFactory(config) {
       }
 
       if (typeof storage.shared != 'function') {
-        throw 'Shared Client not supported by the storage mechanism. Create isolated instances instead.';
+        throw new SplitError('Shared Client not supported by the storage mechanism. Create isolated instances instead.');
       }
 
       // Validate the key value
       const validKey = validateKey(key, 'Shared Client instantiation');
       if (validKey === false) {
-        throw 'Shared Client needs a valid key.';
+        throw new SplitError('Shared Client needs a valid key.');
       }
 
       let validTrafficType;
       if (trafficType !== undefined) {
         validTrafficType = validateTrafficType(trafficType, 'Shared Client instantiation');
         if (validTrafficType === false) {
-          throw 'Shared Client needs a valid traffic type or no traffic type at all.';
+          throw new SplitError('Shared Client needs a valid traffic type or no traffic type at all.');
         }
       }
       const instanceId = buildInstanceId(validKey, validTrafficType);

--- a/src/services/splitChanges/offline/node.js
+++ b/src/services/splitChanges/offline/node.js
@@ -20,7 +20,9 @@ import yaml from 'js-yaml';
 import logFactory from '../../../utils/logger';
 import { isString, endsWith, find, forOwn, uniq, } from '../../../utils/lang';
 import parseCondition from './parseCondition';
+import { SplitError } from '../../../utils/lang/Errors';
 const log = logFactory('splitio-offline:splits-fetcher');
+
 
 const DEFAULT_FILENAME = '.split';
 
@@ -34,7 +36,7 @@ function configFilesPath(config = {}) {
 
     if (process.env.SPLIT_CONFIG_ROOT) root = process.env.SPLIT_CONFIG_ROOT;
 
-    if (!root) throw 'Missing split mock configuration root.';
+    if (!root) throw new SplitError('Missing split mock configuration root.');
 
     configFilePath = path.join(root, DEFAULT_FILENAME);
   }

--- a/src/storage/Keys.js
+++ b/src/storage/Keys.js
@@ -1,4 +1,5 @@
 import { startsWith } from '../utils/lang';
+import { SplitError } from '../utils/lang/Errors';
 
 const everythingAtTheEnd = /[^.]+$/;
 const everythingAfterCount = /count\.([^/]+)$/;
@@ -91,7 +92,7 @@ class KeyBuilder {
     if (s && s.length) {
       return s[0];
     } else {
-      throw 'Invalid latency key provided';
+      throw new SplitError('Invalid latency key provided');
     }
   }
 
@@ -101,7 +102,7 @@ class KeyBuilder {
     if (m && m.length) {
       return m[1]; // everything after count
     } else {
-      throw 'Invalid counter key provided';
+      throw new SplitError('Invalid counter key provided');
     }
   }
 
@@ -114,7 +115,7 @@ class KeyBuilder {
         bucketNumber: parts[2]
       };
     } else {
-      throw 'Invalid counter key provided';
+      throw new SplitError('Invalid counter key provided');
     }
   }
 }

--- a/src/sync/AuthClient/index.js
+++ b/src/sync/AuthClient/index.js
@@ -2,6 +2,7 @@ import objectAssign from 'object-assign';
 import authService from '../../services/auth';
 import authRequest from '../../services/auth/auth';
 import { decodeJWTtoken } from '../../utils/jwt';
+import { SplitError } from '../../utils/lang/Errors';
 
 /**
  * Run authentication requests to Auth Server, and handle response decoding the JTW token.
@@ -19,7 +20,7 @@ export default function authenticate(settings, userKeys) {
     .then(json => {
       if (json.token) { // empty token when `"pushEnabled": false`
         const decodedToken = decodeJWTtoken(json.token);
-        if (typeof decodedToken.iat !== 'number' || typeof decodedToken.exp !== 'number') throw 'token properties "issuedAt" (iat) or "expiration" (exp) are missing or invalid';
+        if (typeof decodedToken.iat !== 'number' || typeof decodedToken.exp !== 'number') throw new SplitError('token properties "issuedAt" (iat) or "expiration" (exp) are missing or invalid');
         const channels = JSON.parse(decodedToken['x-ably-capability']);
         return objectAssign({
           decodedToken,


### PR DESCRIPTION

for ref: https://nodejs.dev/learn/error-handling-in-nodejs

# JS SDK

## What did you accomplish?

It is preferable in javascript, and especially in node to throw Error objects. I noticed that SplitError already existed, so wrapped the thrown strings in that.

## How do we test the changes introduced in this PR?


## Extra Notes

Unfortunately this is technically backwards incompatible as anyone catching the error will get an error object now. 
