### PR TITLE
Offline SplitChanges updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ deploy:
     acl: public_read
     cache_control: "max-age=31536000, public"
     on:
-      branch: offline_splitchanges_update
+      branch: development
   - provider: s3
     access_key_id: ${AWS_ACCESS_KEY_ID_PROD}
     secret_access_key: ${AWS_SECRET_ACCESS_PROD}

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ deploy:
     acl: public_read
     cache_control: "max-age=31536000, public"
     on:
-      branch: development
+      branch: offline_splitchanges_update
   - provider: s3
     access_key_id: ${AWS_ACCESS_KEY_ID_PROD}
     secret_access_key: ${AWS_SECRET_ACCESS_PROD}

--- a/karma/config.js
+++ b/karma/config.js
@@ -52,6 +52,9 @@ module.exports = {
 
   webpack: {
     mode: 'production',
+
+    // devtool: 'inline-source-map', // Uncomment to debug with source map
+
     module: {
       rules: [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.15.6",
+  "version": "10.15.7-canary.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.15.6",
+  "version": "10.15.7-canary.0",
   "description": "Split SDK",
   "files": [
     "README.md",

--- a/src/__tests__/offline/node.spec.js
+++ b/src/__tests__/offline/node.spec.js
@@ -68,6 +68,8 @@ tape('NodeJS Offline Mode', function (t) {
   t.test('New format manager - .yaml extension', ManagerDotYamlTests.bind(null, 'split.yaml'));
   t.test('New format manager - .yml extension', ManagerDotYamlTests.bind(null, 'split2.yml'));
 
+  t.test('Evaluations and manager with multiple SDK instances', MultipleInstancesTests);
+
   t.test('Trying to specify an invalid extension it will timeout', assert => {
     const config = settingsGenerator('.forbidden');
 
@@ -330,4 +332,112 @@ function ManagerDotYamlTests(mockFileName, assert) {
       client.destroy().then(assert.end);
     });
   });
+}
+
+
+function MultipleInstancesTests(assert) {
+  configMocks();
+  const config = settingsGenerator('.split');
+
+  // Creates multiple factories with the same mock file
+  const factories = [SplitFactory(config), SplitFactory(config), SplitFactory({ ...config })];
+
+  // Creates another factory with a different mock file
+  const factoryWithYaml = SplitFactory(settingsGenerator('split.yaml'));
+  const clientWithYaml = factoryWithYaml.client();
+  let readyCount = 0, updateCount = 0;
+  clientWithYaml.on(clientWithYaml.Event.SDK_READY, () => { readyCount++; });
+  clientWithYaml.on(clientWithYaml.Event.SDK_UPDATE, () => { updateCount++; });
+
+  for (let i = 0; i < factories.length; i++) {
+    let factory = factories[i], client = factories[i].client(), manager = factories[i].manager();
+
+    /* Asserts on SDK client */
+
+    // Tracking some events to test they are not flushed.
+    client.track('a_key', 'a_tt', 'an_ev_id');
+    client.track('another_key', 'another_tt', 'another_ev_id', 25);
+
+    client.on(client.Event.SDK_READY, function () {
+      assert.equal(client.getTreatment('qa-user', 'testing_split'), 'on');
+      assert.equal(client.getTreatment('qa-user', 'testing_split_2'), 'control');
+      assert.deepEqual(client.getTreatmentWithConfig('qa-user', 'testing_split'), { treatment: 'on', config: null });
+      assert.deepEqual(client.getTreatmentWithConfig('qa-user', 'testing_split_2'), { treatment: 'control', config: null });
+
+      assert.deepEqual(client.getTreatments('qa-user', [
+        'testing_split',
+        'testing_split2',
+        'testing_split3',
+        'testing_not_exist'
+      ]), {
+        testing_split: 'on',
+        testing_split2: 'off',
+        testing_split3: 'custom_treatment',
+        testing_not_exist: 'control'
+      });
+      assert.deepEqual(client.getTreatmentsWithConfig('qa-user', [
+        'testing_split',
+        'testing_split2',
+        'testing_split3',
+        'testing_not_exist'
+      ]), {
+        testing_split: { treatment: 'on', config: null },
+        testing_split2: { treatment: 'off', config: null },
+        testing_split3: { treatment: 'custom_treatment', config: null },
+        testing_not_exist: { treatment: 'control', config: null }
+      });
+
+      setTimeout(() => { factory.settings.features = path.join(__dirname, '.split'); }, 290);
+      setTimeout(() => { factory.settings.features = path.join(__dirname, '.split'); }, 590);
+      setTimeout(() => { factory.settings.features = path.join(__dirname, '.split'); }, 890);
+      setTimeout(() => { factory.settings.features = path.join(__dirname, 'update.split'); }, 1000);
+
+      /* Asserts on SDK managers */
+      manager.on(manager.Event.SDK_READY, function () {
+        assert.deepEqual(manager.names(), ['testing_split', 'testing_split2', 'testing_split3']);
+
+        const expectedView1 = {
+          name: 'testing_split', changeNumber: 0, killed: false, trafficType: null,
+          treatments: ['on'], configs: {}
+        };
+        const expectedView2 = {
+          name: 'testing_split2', changeNumber: 0, killed: false, trafficType: null,
+          treatments: ['off'], configs: {}
+        };
+        const expectedView3 = {
+          name: 'testing_split3', changeNumber: 0, killed: false, trafficType: null,
+          treatments: ['custom_treatment'], configs: {}
+        };
+
+        assert.deepEqual(manager.split('testing_split'), expectedView1);
+        assert.deepEqual(manager.split('testing_split2'), expectedView2);
+        assert.deepEqual(manager.split('testing_split3'), expectedView3);
+        assert.equal(manager.split('split_not_existent'), null);
+
+        assert.deepEqual(manager.splits(), [expectedView1, expectedView2, expectedView3]);
+
+      });
+
+      client.once(client.Event.SDK_UPDATE, () => {
+        assert.equal(client.getTreatment('qa-user', 'testing_split4'), 'updated_treatment');
+
+        client.once(client.Event.SDK_UPDATE, function () { assert.fail('Should not emit a second SDK_UPDATE event'); });
+
+        setTimeout(() => {
+          networkAssertions(client, assert).then(() => {
+            client.destroy().then(() => {
+              // End test on the last factory
+              if (i === factories.length - 1) {
+                clientWithYaml.destroy();
+                assert.equal(readyCount, 1, 'The factory with a different mock file should have emitted SDK_READY');
+                assert.equal(updateCount, 0, 'The factory with a different mock file should not have emitted SDK_UPDATE');
+
+                assert.end();
+              }
+            });
+          });
+        });
+      });
+    });
+  }
 }

--- a/src/factory/offline.js
+++ b/src/factory/offline.js
@@ -12,8 +12,14 @@ function SplitFactoryOffline(context, sharedTrackers) {
   const storage = context.get(context.constants.STORAGE);
   const statusManager = context.get(context.constants.STATUS_MANAGER);
 
-  // In LOCALHOST mode, shared clients are ready in the next event cycle than created
-  if (sharedInstance) setTimeout(() => { readiness.gate.emit(readiness.gate.SDK_READY); }, 0);
+  // In LOCALHOST mode, shared clients are ready in the next event-loop cycle than created
+  // and then updated on each SDK_SPLITS_ARRIVED event
+  if (sharedInstance) setTimeout(() => {
+    readiness.splits.on(readiness.splits.SDK_SPLITS_ARRIVED, () => {
+      readiness.gate.emit(readiness.gate.SDK_UPDATE);
+    });
+    readiness.gate.emit(readiness.gate.SDK_READY);
+  }, 0);
 
   // Producer
   const producer = sharedInstance ? undefined : OfflineProducerFactory(context);

--- a/src/producer/updater/SplitChangesFromFeatures.js
+++ b/src/producer/updater/SplitChangesFromFeatures.js
@@ -17,4 +17,7 @@ limitations under the License.
 import FromSettingsFetcher from '../../services/splitChanges/offline';
 import SplitChangesFromObject from './SplitChangesFromObject';
 
-export default SplitChangesFromObject.bind(null, FromSettingsFetcher);
+export default function createSplitChangesFromObject(context) {
+  const fetcher = FromSettingsFetcher();
+  return SplitChangesFromObject(fetcher, context);
+}

--- a/src/producer/updater/SplitChangesFromFileSystem.js
+++ b/src/producer/updater/SplitChangesFromFileSystem.js
@@ -17,4 +17,7 @@ limitations under the License.
 import FromFileSystemFetcher from '../../services/splitChanges/offline';
 import SplitChangesFromObject from './SplitChangesFromObject';
 
-export default SplitChangesFromObject.bind(null, FromFileSystemFetcher);
+export default function createSplitChangesFromObject(context) {
+  const fetcher = FromFileSystemFetcher();
+  return SplitChangesFromObject(fetcher, context);
+}

--- a/src/producer/updater/SplitChangesFromObject.js
+++ b/src/producer/updater/SplitChangesFromObject.js
@@ -24,6 +24,8 @@ function FromObjectUpdaterFactory(Fetcher, context) {
     [context.constants.STORAGE]: storage
   } = context.getAll();
 
+  let firstTime = true;
+
   return function ObjectUpdater() {
     const splits = [];
     let loadError = null;
@@ -60,7 +62,11 @@ function FromObjectUpdaterFactory(Fetcher, context) {
         storage.splits.addSplits(splits)
       ]).then(() => {
         readiness.splits.emit(readiness.splits.SDK_SPLITS_ARRIVED);
-        readiness.segments.emit(readiness.segments.SDK_SEGMENTS_ARRIVED);
+        // Only emits SDK_SEGMENTS_ARRIVED the first time for SDK_READY
+        if (firstTime) {
+          firstTime = false;
+          readiness.segments.emit(readiness.segments.SDK_SEGMENTS_ARRIVED);
+        }
       });
     } else {
       return Promise.resolve();

--- a/src/services/splitChanges/offline/node.js
+++ b/src/services/splitChanges/offline/node.js
@@ -24,8 +24,6 @@ const log = logFactory('splitio-offline:splits-fetcher');
 
 const DEFAULT_FILENAME = '.split';
 
-let previousMock = 'NO_MOCK_LOADED';
-
 function configFilesPath(config = {}) {
   let configFilePath = config.features;
 
@@ -47,96 +45,6 @@ function configFilesPath(config = {}) {
     throw new Error(`Split configuration not found in ${configFilePath} - Please review your Split file location.`);
 
   return configFilePath;
-}
-
-// Parse `.split` configuration file and return a map of "Split Objects"
-function readSplitConfigFile(filePath) {
-  const SPLIT_POSITION = 0;
-  const TREATMENT_POSITION = 1;
-  let data;
-
-  try {
-    data = fs.readFileSync(filePath, 'utf-8');
-  } catch (e) {
-    log.error(e.message);
-
-    return {};
-  }
-
-  if (data === previousMock) return false;
-  previousMock = data;
-
-  const splitObjects = data.split(/\r?\n/).reduce((accum, line, index) => {
-    let tuple = line.trim();
-
-    if (tuple === '' || tuple.charAt(0) === '#') {
-      log.debug(`Ignoring empty line or comment at #${index}`);
-    } else {
-      tuple = tuple.split(/\s+/);
-
-      if (tuple.length !== 2) {
-        log.debug(`Ignoring line since it does not have exactly two columns #${index}`);
-      } else {
-        const splitName = tuple[SPLIT_POSITION];
-        const condition = parseCondition({ treatment: tuple[TREATMENT_POSITION] });
-        accum[splitName] = { conditions: [condition], configurations: {} };
-      }
-    }
-
-    return accum;
-  }, {});
-
-  return splitObjects;
-}
-
-// Parse `.yml` or `.yaml` configuration files and return a map of "Split Objects"
-function readYAMLConfigFile(filePath) {
-  let data = '';
-  let yamldoc = null;
-
-  try {
-    data = fs.readFileSync(filePath, 'utf8');
-
-    if (data === previousMock) return false;
-    previousMock = data;
-
-    yamldoc = yaml.safeLoad(data);
-  } catch (e) {
-    log.error(e);
-
-    return {};
-  }
-
-  // Each entry will be mapped to a condition, but we'll also keep the configurations map.
-  const mocksData = yamldoc.reduce((accum, splitEntry) => {
-    const splitName = Object.keys(splitEntry)[0];
-
-    if (!splitName || !isString(splitEntry[splitName].treatment))
-      log.error('Ignoring entry on YAML since the format is incorrect.');
-
-    const mockData = splitEntry[splitName];
-
-    // "Template" for each split accumulated data
-    if (!accum[splitName]) {
-      accum[splitName] = {
-        configurations: {}, conditions: [], treatments: [], trafficTypeName: 'localhost'
-      };
-    }
-
-    // Assign the config if there is one on the mock
-    if (mockData.config) accum[splitName].configurations[mockData.treatment] = mockData.config;
-    // Parse the condition from the entry.
-    const condition = parseCondition(mockData);
-    accum[splitName].conditions[condition.conditionType === 'ROLLOUT' ? 'push' : 'unshift'](condition);
-    // Also keep track of the treatments, will be useful for manager functionality.
-    accum[splitName].treatments.push(mockData.treatment);
-
-    return accum;
-  }, {});
-
-  arrangeConditions(mocksData);
-
-  return mocksData;
 }
 
 // This function is not pure nor meant to be. Here we apply modifications to cover
@@ -169,20 +77,114 @@ function arrangeConditions(mocksData) {
   });
 }
 
-// Load the content of a configuration file into an Object
-function getSplitConfigForFile(settings) {
-  const filePath = configFilesPath(settings);
-  let mockData = null;
+export default function createGetSplitConfigForFile() {
 
-  // If we have a filePath, it means the extension is correct, choose the parser.
-  if (endsWith(filePath, '.split')) {
-    log.warn('.split mocks will be deprecated soon in favor of YAML files, which provide more targeting power. Take a look in our documentation.');
-    mockData = readSplitConfigFile(filePath);
-  } else {
-    mockData = readYAMLConfigFile(filePath);
+  let previousMock = 'NO_MOCK_LOADED';
+
+  // Parse `.split` configuration file and return a map of "Split Objects"
+  function readSplitConfigFile(filePath) {
+    const SPLIT_POSITION = 0;
+    const TREATMENT_POSITION = 1;
+    let data;
+
+    try {
+      data = fs.readFileSync(filePath, 'utf-8');
+    } catch (e) {
+      log.error(e.message);
+
+      return {};
+    }
+
+    if (data === previousMock) return false;
+    previousMock = data;
+
+    const splitObjects = data.split(/\r?\n/).reduce((accum, line, index) => {
+      let tuple = line.trim();
+
+      if (tuple === '' || tuple.charAt(0) === '#') {
+        log.debug(`Ignoring empty line or comment at #${index}`);
+      } else {
+        tuple = tuple.split(/\s+/);
+
+        if (tuple.length !== 2) {
+          log.debug(`Ignoring line since it does not have exactly two columns #${index}`);
+        } else {
+          const splitName = tuple[SPLIT_POSITION];
+          const condition = parseCondition({ treatment: tuple[TREATMENT_POSITION] });
+          accum[splitName] = { conditions: [condition], configurations: {} };
+        }
+      }
+
+      return accum;
+    }, {});
+
+    return splitObjects;
   }
 
-  return mockData;
-}
+  // Parse `.yml` or `.yaml` configuration files and return a map of "Split Objects"
+  function readYAMLConfigFile(filePath) {
+    let data = '';
+    let yamldoc = null;
 
-export default getSplitConfigForFile;
+    try {
+      data = fs.readFileSync(filePath, 'utf8');
+
+      if (data === previousMock) return false;
+      previousMock = data;
+
+      yamldoc = yaml.safeLoad(data);
+    } catch (e) {
+      log.error(e);
+
+      return {};
+    }
+
+    // Each entry will be mapped to a condition, but we'll also keep the configurations map.
+    const mocksData = yamldoc.reduce((accum, splitEntry) => {
+      const splitName = Object.keys(splitEntry)[0];
+
+      if (!splitName || !isString(splitEntry[splitName].treatment))
+        log.error('Ignoring entry on YAML since the format is incorrect.');
+
+      const mockData = splitEntry[splitName];
+
+      // "Template" for each split accumulated data
+      if (!accum[splitName]) {
+        accum[splitName] = {
+          configurations: {}, conditions: [], treatments: [], trafficTypeName: 'localhost'
+        };
+      }
+
+      // Assign the config if there is one on the mock
+      if (mockData.config) accum[splitName].configurations[mockData.treatment] = mockData.config;
+      // Parse the condition from the entry.
+      const condition = parseCondition(mockData);
+      accum[splitName].conditions[condition.conditionType === 'ROLLOUT' ? 'push' : 'unshift'](condition);
+      // Also keep track of the treatments, will be useful for manager functionality.
+      accum[splitName].treatments.push(mockData.treatment);
+
+      return accum;
+    }, {});
+
+    arrangeConditions(mocksData);
+
+    return mocksData;
+  }
+
+  // Load the content of a configuration file into an Object
+  return function getSplitConfigForFile(settings) {
+    const filePath = configFilesPath(settings);
+    let mockData = null;
+
+    // If we have a filePath, it means the extension is correct, choose the parser.
+    if (endsWith(filePath, '.split')) {
+      log.warn('.split mocks will be deprecated soon in favor of YAML files, which provide more targeting power. Take a look in our documentation.');
+      mockData = readSplitConfigFile(filePath);
+    } else {
+      mockData = readYAMLConfigFile(filePath);
+    }
+
+    return mockData;
+  };
+
+}

--- a/src/utils/settings/index.js
+++ b/src/utils/settings/index.js
@@ -27,7 +27,7 @@ import { API } from '../../utils/logger';
 import { STANDALONE_MODE, STORAGE_MEMORY, CONSUMER_MODE, OPTIMIZED } from '../../utils/constants';
 import validImpressionsMode from './impressionsMode';
 
-const version = '10.15.6';
+const version = '10.15.7-canary.0';
 const eventsEndpointMatcher = /^\/(testImpressions|metrics|events)/;
 const authEndpointMatcher = /^\/auth/;
 const streamingEndpointMatcher = /^\/(sse|event-stream)/;


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

Updated offline mode for Node and Browser to:
  - support multiple factory instances.
  - avoid emitting duplicated SDK_UPDATE event. 
  - emit SDK_UPDATE on shared clients.

## How do we test the changes introduced in this PR?

- Added new E2E tests and asserts.
- Tested with reported [issue](https://github.com/splitio/react-client/issues/13#issuecomment-848283687) in React SDK.

## Extra Notes