### PR TITLE
Add metadata headers to SSE connections

### DIFF
--- a/src/__tests__/browserSuites/push-fallbacking.spec.js
+++ b/src/__tests__/browserSuites/push-fallbacking.spec.js
@@ -106,7 +106,7 @@ export function testFallbacking(fetchMock, assert) {
   // mock SSE open and message events
   setMockListener(function (eventSourceInstance) {
 
-    const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolas.token}&v=1.1&heartbeats=true`;
+    const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolas.token}&v=1.1&heartbeats=true&SplitSDKVersion=${settings.version}&SplitSDKClientKey=h-1>`;
     assert.equals(eventSourceInstance.url, expectedSSEurl, 'EventSource URL is the expected');
 
     setTimeout(() => {
@@ -131,7 +131,7 @@ export function testFallbacking(fetchMock, assert) {
       secondClient = splitio.client(secondUserKey);
 
       setMockListener(function (eventSourceInstance) {
-        const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_MjE0MTkxOTU2Mg%3D%3D_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolasAndMarcio.token}&v=1.1&heartbeats=true`;
+        const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_MjE0MTkxOTU2Mg%3D%3D_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolasAndMarcio.token}&v=1.1&heartbeats=true&SplitSDKVersion=${settings.version}&SplitSDKClientKey=h-1>`;
         assert.equals(eventSourceInstance.url, expectedSSEurl, 'new EventSource URL is the expected');
         eventSourceInstance.emitOpen();
 

--- a/src/__tests__/browserSuites/push-initialization-retries.spec.js
+++ b/src/__tests__/browserSuites/push-initialization-retries.spec.js
@@ -116,10 +116,11 @@ export function testPushRetriesDueToSseErrors(fetchMock, assert) {
   let start, splitio, client, ready = false;
   const expectedTimeToSSEsuccess = (settings.scheduler.pushRetryBackoffBase * Math.pow(2, 0) + settings.scheduler.pushRetryBackoffBase * Math.pow(2, 1));
 
-  const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolas.token}&v=1.1&heartbeats=true`;
+  const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolas.token}&v=1.1&heartbeats=true&SplitSDKVersion=${settings.version}&SplitSDKClientKey=h-1>`;
   let sseattempts = 0;
   setMockListener(function (eventSourceInstance) {
     assert.equal(eventSourceInstance.url, expectedSSEurl, 'SSE url is correct');
+
     if (sseattempts < 2) {
       eventSourceInstance.emitError('some error');
     } else {

--- a/src/__tests__/browserSuites/push-refresh-token.spec.js
+++ b/src/__tests__/browserSuites/push-refresh-token.spec.js
@@ -58,7 +58,7 @@ export function testRefreshToken(fetchMock, assert) {
     sseCount++;
     if (sseCount > 2) assert.fail('expecting only 2 SSE connections');
 
-    const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolas.token}&v=1.1&heartbeats=true`;
+    const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolas.token}&v=1.1&heartbeats=true&SplitSDKVersion=${settings.version}&SplitSDKClientKey=h-1>`;
     assert.equals(eventSourceInstance.url, expectedSSEurl, 'EventSource URL is the expected');
 
     setTimeout(() => {

--- a/src/__tests__/browserSuites/push-synchronization-retries.spec.js
+++ b/src/__tests__/browserSuites/push-synchronization-retries.spec.js
@@ -87,7 +87,7 @@ export function testSynchronizationRetries(fetchMock, assert) {
   setMockListener(function (eventSourceInstance) {
     start = Date.now();
 
-    const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolas.token}&v=1.1&heartbeats=true`;
+    const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolas.token}&v=1.1&heartbeats=true&SplitSDKVersion=${settings.version}&SplitSDKClientKey=h-1>`;
     assert.equals(eventSourceInstance.url, expectedSSEurl, 'EventSource URL is the expected');
 
     /* events on first SSE connection */

--- a/src/__tests__/browserSuites/push-synchronization.spec.js
+++ b/src/__tests__/browserSuites/push-synchronization.spec.js
@@ -76,7 +76,7 @@ export function testSynchronization(fetchMock, assert) {
 
   // mock SSE open and message events
   setMockListener(function (eventSourceInstance) {
-    const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolas.token}&v=1.1&heartbeats=true`;
+    const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolas.token}&v=1.1&heartbeats=true&SplitSDKVersion=${settings.version}&SplitSDKClientKey=h-1>`;
     assert.equals(eventSourceInstance.url, expectedSSEurl, 'EventSource URL is the expected');
 
     /* events on first SSE connection */
@@ -122,7 +122,7 @@ export function testSynchronization(fetchMock, assert) {
       otherClient = splitio.client(otherUserKey);
 
       setMockListener(function (eventSourceInstance) {
-        const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_MjE0MTkxOTU2Mg%3D%3D_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolasAndMarcio.token}&v=1.1&heartbeats=true`;
+        const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_MjE0MTkxOTU2Mg%3D%3D_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolasAndMarcio.token}&v=1.1&heartbeats=true&SplitSDKVersion=${settings.version}&SplitSDKClientKey=h-1>`;
         assert.equals(eventSourceInstance.url, expectedSSEurl, 'new EventSource URL is the expected');
 
         /* events on second SSE connection */

--- a/src/__tests__/nodeSuites/push-synchronization.spec.js
+++ b/src/__tests__/nodeSuites/push-synchronization.spec.js
@@ -57,7 +57,7 @@ const MILLIS_DESTROY = 700;
  *  0.6 secs: SPLIT_UPDATE event with new segments -> /splitChanges, /segmentChanges/{newSegments}
  */
 export function testSynchronization(fetchMock, assert) {
-  assert.plan(21);
+  assert.plan(22);
   fetchMock.reset();
   __setEventSource(EventSourceMock);
 
@@ -67,6 +67,14 @@ export function testSynchronization(fetchMock, assert) {
   setMockListener(function (eventSourceInstance) {
     const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_segments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabled.token}&v=1.1&heartbeats=true`;
     assert.equals(eventSourceInstance.url, expectedSSEurl, 'EventSource URL is the expected');
+    assert.deepEqual(eventSourceInstance.__eventSourceInitDict, {
+      headers: {
+        SplitSDKClientKey: 'h-1>',
+        SplitSDKVersion: settings.version,
+        SplitSDKMachineIP: settings.runtime.ip,
+        SplitSDKMachineName: settings.runtime.hostname
+      }
+    }, 'EventSource headers are the expected');
 
     setTimeout(() => {
       eventSourceInstance.emitOpen();

--- a/src/sync/PushManager/index.js
+++ b/src/sync/PushManager/index.js
@@ -30,7 +30,7 @@ export default function PushManagerFactory(context, clientContexts /* undefined 
   const { splits: splitsEventEmitter } = context.get(context.constants.READINESS);
   const settings = context.get(context.constants.SETTINGS);
   const storage = context.get(context.constants.STORAGE);
-  const sseClient = SSEClient.getInstance(settings);
+  const sseClient = SSEClient.getInstance(settings, clientContexts ? false : true);
   const sseHandler = SSEHandlerFactory(pushEmitter);
   sseClient.setEventHandler(sseHandler);
 

--- a/src/sync/SSEClient/index.js
+++ b/src/sync/SSEClient/index.js
@@ -7,7 +7,7 @@ const CONTROL_CHANNEL_REGEX = /^control_/;
 /**
  * Build metadata headers for SSE connection.
  *
- * @param {Object} settings validated settings.
+ * @param {Object} settings Validated settings.
  */
 function buildSSEHeaders(settings) {
   const headers = {
@@ -27,8 +27,8 @@ export default class SSEClient {
 
   /**
    * Returns a SSEClient instance, or undefined if EventSource is not available.
-   * @param {Object} settings validated SDK settings.
-   * @param {boolean} useHeaders true for Node and false for Browser, used to send metadata as headers or query params respectively.
+   * @param {Object} settings Validated SDK settings.
+   * @param {boolean} useHeaders True for Node and false for Browser, used to send metadata as headers or query params respectively.
    */
   static getInstance(settings, useHeaders) {
     const EventSource = getEventSource();
@@ -59,7 +59,7 @@ export default class SSEClient {
    * Open the connection with a given authToken
    *
    * @param {Object} authToken
-   * @throws {TypeError} if `authToken` is undefined
+   * @throws {TypeError} Will throw an error if `authToken` is undefined
    */
   open(authToken) {
     this.close(); // it closes connection if previously opened

--- a/src/sync/SSEClient/index.js
+++ b/src/sync/SSEClient/index.js
@@ -28,12 +28,12 @@ export default class SSEClient {
   /**
    * Returns a SSEClient instance, or undefined if EventSource is not available.
    * @param {Object} settings validated SDK settings.
-   * @param {boolean} isNode true for Node and false for Browser, used to send metadata as headers or query params respectively.
+   * @param {boolean} useHeaders true for Node and false for Browser, used to send metadata as headers or query params respectively.
    */
-  static getInstance(settings, isNode) {
+  static getInstance(settings, useHeaders) {
     const EventSource = getEventSource();
     if (EventSource)
-      return new SSEClient(EventSource, settings, isNode);
+      return new SSEClient(EventSource, settings, useHeaders);
   }
 
   // Instance properties:
@@ -43,11 +43,11 @@ export default class SSEClient {
   //  handler: EventHandler for open, close, error and messages events
   //  authToken: Object | undefined
 
-  constructor(EventSource, settings, isNode) {
+  constructor(EventSource, settings, useHeaders) {
     this.EventSource = EventSource;
     this.streamingUrl = settings.url('/sse');
     this.reopen = this.reopen.bind(this);
-    this.isNode = isNode;
+    this.useHeaders = useHeaders;
     this.headers = buildSSEHeaders(settings);
   }
 
@@ -77,9 +77,9 @@ export default class SSEClient {
     this.connection = new this.EventSource(
       // For Browser, SplitSDKClientKey and SplitSDKClientKey headers are passed as query params,
       // because native EventSource implementations for browser doesn't support headers.
-      this.isNode ? url : url + `&SplitSDKVersion=${this.headers.SplitSDKVersion}&SplitSDKClientKey=${this.headers.SplitSDKClientKey}`,
+      this.useHeaders ? url : url + `&SplitSDKVersion=${this.headers.SplitSDKVersion}&SplitSDKClientKey=${this.headers.SplitSDKClientKey}`,
       // For Node, metadata headers are passed because 'eventsource' package supports them.
-      this.isNode ? { headers: this.headers } : undefined
+      this.useHeaders ? { headers: this.headers } : undefined
     );
 
     if (this.handler) { // no need to check if SSEClient is used only by PushManager

--- a/src/sync/__tests__/SSEClient/node.spec.js
+++ b/src/sync/__tests__/SSEClient/node.spec.js
@@ -15,11 +15,22 @@ const SSClient = proxyquireStrict('../../SSEClient/index', {
 
 const settings = SettingsFactory({
   core: {
+    authorizationKey: 'aaaabbbbcccc1234',
     key: 'emi@split.io'
   }
 });
 
-tape('SSClient', t => {
+const EXPECTED_URL = settings.url('/sse') +
+  '?channels=' + channelsQueryParamSample +
+  '&accessToken=' + authDataSample.token +
+  '&v=1.1&heartbeats=true';
+
+const EXPECTED_HEADERS = {
+  SplitSDKClientKey: '1234',
+  SplitSDKVersion: settings.version
+};
+
+tape('SSEClient', t => {
 
   t.test('getInstance', assert => {
     eventSourceReference = undefined;
@@ -98,19 +109,49 @@ tape('SSClient', t => {
     assert.end();
   });
 
-  t.test('open method: URL', assert => {
-
+  t.test('open method: URL with metadata query params for Browser', assert => {
     eventSourceReference = EventSourceMock;
-    const instance = SSClient.getInstance(settings);
+    const instance = SSClient.getInstance(settings, false);
     instance.open(authDataSample);
 
-    const EXPECTED_URL = settings.url('/sse') +
-      '?channels=' + channelsQueryParamSample +
-      '&accessToken=' + authDataSample.token +
-      '&v=1.1&heartbeats=true';
+    const EXPECTED_BROWSER_URL = EXPECTED_URL + `&SplitSDKVersion=${settings.version}&SplitSDKClientKey=${EXPECTED_HEADERS.SplitSDKClientKey}`;
+
+    assert.equal(instance.connection.url, EXPECTED_BROWSER_URL, 'URL is properly set for streaming connection');
+    assert.end();
+  });
+
+  t.test('open method: URL and metadata headers for Node', assert => {
+
+    eventSourceReference = EventSourceMock;
+    const instance = SSClient.getInstance(settings, true);
+    instance.open(authDataSample);
 
     assert.equal(instance.connection.url, EXPECTED_URL, 'URL is properly set for streaming connection');
+    assert.deepEqual(instance.connection.__eventSourceInitDict, {
+      headers: {
+        ...EXPECTED_HEADERS,
+        SplitSDKMachineIP: settings.runtime.ip,
+        SplitSDKMachineName: settings.runtime.hostname
+      }
+    }, 'Headers are properly set for streaming connection');
+    assert.end();
+  });
 
+  t.test('open method: URL and metadata headers for Node, without IPAddressesEnabled', assert => {
+
+    eventSourceReference = EventSourceMock;
+    const settingsWithoutRuntime = SettingsFactory({
+      core: {
+        authorizationKey: 'aaaabbbbcccc1234',
+        key: 'emi@split.io',
+        IPAddressesEnabled: false,
+      }
+    });
+    const instance = SSClient.getInstance(settingsWithoutRuntime, true);
+    instance.open(authDataSample);
+
+    assert.equal(instance.connection.url, EXPECTED_URL, 'URL is properly set for streaming connection');
+    assert.deepEqual(instance.connection.__eventSourceInitDict, { headers: EXPECTED_HEADERS }, 'Headers are properly set for streaming connection');
     assert.end();
   });
 

--- a/src/sync/__tests__/SSEClient/node.spec.js
+++ b/src/sync/__tests__/SSEClient/node.spec.js
@@ -117,6 +117,7 @@ tape('SSEClient', t => {
     const EXPECTED_BROWSER_URL = EXPECTED_URL + `&SplitSDKVersion=${settings.version}&SplitSDKClientKey=${EXPECTED_HEADERS.SplitSDKClientKey}`;
 
     assert.equal(instance.connection.url, EXPECTED_BROWSER_URL, 'URL is properly set for streaming connection');
+    assert.equal(instance.connection.__eventSourceInitDict, undefined, 'No headers are passed for streaming connection');
     assert.end();
   });
 

--- a/src/sync/__tests__/mocks/eventSourceMock.js
+++ b/src/sync/__tests__/mocks/eventSourceMock.js
@@ -34,7 +34,7 @@ export default class EventSource {
     this.readyState = 0;
     // eslint-disable-next-line no-undef
     this.__emitter = new EventEmitter();
-    this.__eventSourceInitDict = eventSourceInitDict;
+    this.__eventSourceInitDict = arguments[1];
     sources[url] = this;
     if (__listener) setTimeout(__listener, 0, this);
   }

--- a/src/sync/__tests__/mocks/eventSourceMock.js
+++ b/src/sync/__tests__/mocks/eventSourceMock.js
@@ -27,13 +27,14 @@ export default class EventSource {
 
   constructor(
     url,
-    configuration = defaultOptions
+    eventSourceInitDict = defaultOptions
   ) {
     this.url = url;
-    this.withCredentials = configuration.withCredentials;
+    this.withCredentials = eventSourceInitDict.withCredentials;
     this.readyState = 0;
     // eslint-disable-next-line no-undef
     this.__emitter = new EventEmitter();
+    this.__eventSourceInitDict = eventSourceInitDict;
     sources[url] = this;
     if (__listener) setTimeout(__listener, 0, this);
   }


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

Added SSE metadata headers for Node and metadata query params for Browser.

## How do we test the changes introduced in this PR?

Added new asserts to E2E push tests, and SSEClient unit tests.

## Extra Notes