### PR TITLE
Updated promise wrapper

### DIFF
--- a/src/utils/promise/wrapper.js
+++ b/src/utils/promise/wrapper.js
@@ -25,7 +25,7 @@ export default function promiseWrapper(customPromise, defaultOnRejected) {
     const newPromise = new Promise((res, rej) => {
       return promise.then(
         res,
-        function(value) {
+        function (value) {
           if (hasOnRejected) {
             rej(value);
           } else {
@@ -37,16 +37,19 @@ export default function promiseWrapper(customPromise, defaultOnRejected) {
 
     const originalThen = newPromise.then;
 
-    newPromise.then = function(onfulfilled, onrejected) {
-      const result = originalThen.call(newPromise, onfulfilled, onrejected);
-      if (typeof onfulfilled === 'function') hasOnFulfilled = true;
-      if (typeof onrejected === 'function') {
-        hasOnRejected = true;
-        return result;
-      } else {
-        return chain(result);
+    // Using `defineProperty` in case Promise.prototype.then property is not writable
+    Object.defineProperty(newPromise, 'then', {
+      value: function (onfulfilled, onrejected) {
+        const result = originalThen.call(newPromise, onfulfilled, onrejected);
+        if (typeof onfulfilled === 'function') hasOnFulfilled = true;
+        if (typeof onrejected === 'function') {
+          hasOnRejected = true;
+          return result;
+        } else {
+          return chain(result);
+        }
       }
-    };
+    });
 
     return newPromise;
   }


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

Updated promise wrapper to support the case where `Promise.prototype.then` property is not writable.

## How do we test the changes introduced in this PR?

Validated manually overwriting `Promise.prototype.then` descriptor.

## Extra Notes