### PR TITLE
Updated how global fetch and EventSource are used

### DIFF
--- a/src/services/getEventSource/browser.js
+++ b/src/services/getEventSource/browser.js
@@ -1,4 +1,3 @@
 export default function getEventSource() {
-  // eslint-disable-next-line compat/compat
-  return typeof window !== 'undefined' && typeof window.EventSource === 'function' ? window.EventSource : undefined;
+  return typeof EventSource === 'function' ? EventSource : undefined;
 }

--- a/src/services/getEventSource/node.js
+++ b/src/services/getEventSource/node.js
@@ -11,9 +11,10 @@ export function __restore() {
 }
 
 export default function getEventSource() {
-  // returns EventSource at `eventsource` package or undefined
+  // returns EventSource at `eventsource` package. If not available, return global EventSource or undefined
   try {
     return __isCustom ? __eventSource : require('eventsource');
-    // eslint-disable-next-line no-empty
-  } catch (error) { }
+  } catch (error) {
+    return typeof EventSource === 'function' ? EventSource : undefined;
+  }
 }

--- a/src/services/getFetch/browser.js
+++ b/src/services/getFetch/browser.js
@@ -1,6 +1,5 @@
 import unfetch from 'unfetch';
 
 export default function getFetch() {
-  // eslint-disable-next-line compat/compat
-  return typeof window !== 'undefined' && window.fetch || unfetch;
+  return typeof fetch === 'function' ? fetch : unfetch;
 }

--- a/src/services/getFetch/node.js
+++ b/src/services/getFetch/node.js
@@ -1,7 +1,15 @@
-let nodeFetch = require('node-fetch');
+let nodeFetch;
 
-// Handle node-fetch issue https://github.com/node-fetch/node-fetch/issues/1037
-if(typeof nodeFetch !== 'function') nodeFetch = nodeFetch.default;
+try {
+  nodeFetch = require('node-fetch');
+
+  // Handle node-fetch issue https://github.com/node-fetch/node-fetch/issues/1037
+  if (typeof nodeFetch !== 'function') nodeFetch = nodeFetch.default;
+
+} catch (error) {
+  // Try to access global fetch if `node-fetch` package couldn't be imported (e.g., not in a Node environment)
+  nodeFetch = typeof fetch === 'function' ? fetch : undefined;
+}
 
 // This function is only exposed for testing purposes.
 export function __setFetch(fetch) {

--- a/src/services/transport/index.js
+++ b/src/services/transport/index.js
@@ -3,11 +3,14 @@ import { SplitNetworkError } from '../../utils/lang/Errors';
 import logFactory from '../../utils/logger';
 const log = logFactory('splitio-services:service');
 
+const messageNoFetch = 'Global fetch API is not available.';
+
 export default function Fetcher(request) {
   // using `fetch(url, options)` signature to work with unfetch
   const url = request.url;
-  // @TODO: update to use global fetch when IE10+ is deprecated
-  return getFetch()(url, request)
+  const fetch = getFetch();
+
+  return fetch ? fetch(url, request)
     // https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#Checking_that_the_fetch_was_successful
     .then(response => {
       if (!response.ok) {
@@ -37,5 +40,5 @@ export default function Fetcher(request) {
 
       // passes `undefined` as statusCode if not an HTTP error (resp === undefined)
       throw new SplitNetworkError(msg, resp && resp.status);
-    });
+    }) : Promise.reject(new SplitNetworkError(messageNoFetch));
 }

--- a/src/services/transport/index.js
+++ b/src/services/transport/index.js
@@ -10,8 +10,8 @@ export default function Fetcher(request) {
   return getFetch()(url, request)
     // https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#Checking_that_the_fetch_was_successful
     .then(response => {
-      if (!response.ok) { // eslint-disable-next-line no-throw-literal
-        throw { response };
+      if (!response.ok) {
+        return response.text().then(message => Promise.reject({ response, message }));
       }
       return response;
     })
@@ -23,7 +23,8 @@ export default function Fetcher(request) {
         switch (resp.status) {
           case 404: msg = 'Invalid API key or resource not found.';
             break;
-          default: msg = resp.statusText;
+          // Don't use resp.statusText since reason phrase is removed in HTTP/2
+          default: msg = error.message;
             break;
         }
       } else { // Something else, either an error making the request or a Network error.

--- a/src/sync/PushManager/index.js
+++ b/src/sync/PushManager/index.js
@@ -90,7 +90,7 @@ export default function PushManagerFactory(context, clientContexts /* undefined 
       function (error) {
         if (disconnected) return;
 
-        log.error(`Failed to authenticate for streaming. Error: "${error.message}".`);
+        log.error(`Failed to authenticate for streaming. Error: ${error.message}.`);
 
         // Handle 4XX HTTP errors: 401 (invalid API Key) or 400 (using incorrect API Key, i.e., client-side API Key on server-side)
         if (error.statusCode >= 400 && error.statusCode < 500) {

--- a/ts-tests/index.ts
+++ b/ts-tests/index.ts
@@ -181,7 +181,7 @@ const instantiatedSettingsStorage: {
 } = SDK.settings.storage;
 const instantiatedSettingsUrls: {[key: string]: string} = SDK.settings.urls;
 const instantiatedSettingsVersion: string = SDK.settings.version;
-let instantiatedSettingsFeatures: {[key: string]: string} = SDK.settings.features;
+let instantiatedSettingsFeatures = SDK.settings.features as SplitIO.MockedFeaturesMap;
 // We should be able to write on features prop. The rest are readonly props.
 instantiatedSettingsFeatures.something = 'something';
 

--- a/ts-tests/package.json
+++ b/ts-tests/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": "splitio/javascript-client",
   "dependencies": {
-    "@types/node": "^14.14.35",
+    "@types/node": "^14.17.9",
     "typescript": "^3.7.4"
   }
 }

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -95,9 +95,10 @@ interface ISettings {
   },
   readonly debug: boolean | LogLevel,
   readonly version: string,
-  features: {
-    [featureName: string]: string
-  },
+  /**
+   * Mocked features map if using in browser, or mocked features file path string if using in Node.
+   */
+  features: SplitIO.MockedFeaturesMap | SplitIO.MockedFeaturesFilePath,
   readonly streamingEnabled: boolean,
   readonly sync: {
     splitFilters: SplitIO.SplitFilter[],


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

- Updated type definitions for ISettings['features'] type. Related to issue #560 
- Updated getFetch and getEventSource functions to support more environments: fallback to global objects in Node if package fails to be required, and avoid using `window` global reference for Browser.
- Fixed message log on HTTP errors: it uses now the body text content if available, instead of the status phrase, because it is not available in HTTP/2 and was leading to the incorrect `Split network error` log.

## How do we test the changes introduced in this PR?

- Updated type definition tests.

## Extra Notes