### PR TITLE
Browser listener update for streaming close [WIP]

### DIFF
--- a/src/listeners/__tests__/browser.spec.js
+++ b/src/listeners/__tests__/browser.spec.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import BrowserSignalListener from '../browser';
 import { DEBUG, OPTIMIZED } from '../../utils/constants';
 import ImpressionsCounter from '../../impressions/counter';
+import { triggerUnloadEvent } from '../../__tests__/testUtils/browser';
 
 const UNLOAD_DOM_EVENT = 'unload';
 
@@ -103,13 +104,6 @@ class ContextMock {
 const syncManagerMockWithPushManager = { pushManager: { stop: sinon.stub() } };
 
 /* Mocks end */
-
-function triggerUnloadEvent() {
-  const event = document.createEvent('HTMLEvents');
-  event.initEvent('unload', true, true);
-  event.eventName = 'unload';
-  window.dispatchEvent(event);
-}
 
 tape('Browser JS / Browser listener class constructor, start and stop methods', function (assert) {
   const { fakeStorage, fakeSettings } = generateContextMocks();

--- a/src/listeners/__tests__/node.spec.js
+++ b/src/listeners/__tests__/node.spec.js
@@ -10,6 +10,7 @@ sinon.stub(process, 'removeListener').callsFake(processRemoveListenerSpy);
 sinon.stub(process, 'kill').callsFake(processKillSpy);
 
 import NodeSignalListener from '../node';
+import { getUnloadDomEvent } from '../browser';
 
 tape('Node JS / Signal Listener class methods and start/stop functionality', function (assert) {
   const listener = new NodeSignalListener();
@@ -189,4 +190,17 @@ tape('Node JS / Signal Listener SIGTERM callback with async handler that throws 
   clock.next();
 
   return handlerPromise;
+});
+
+tape('getUnloadDomEvent', function (assert) {
+  assert.equal(getUnloadDomEvent(), 'unload', 'returns `unload` if userAgent property is not available');
+
+  global.navigator = { userAgent: 'Mozilla/5.0 (Android; Mobile; rv:13.0) Gecko/13.0 Firefox/13.0' };
+  assert.equal(getUnloadDomEvent(), 'beforeunload', 'returns `beforeunload` if using Firefox browser');
+
+  global.navigator.userAgent = 'Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0)';
+  assert.equal(getUnloadDomEvent(), 'unload', 'returns `unload` if using a different user agent than Firefox browser');
+
+  delete global.navigator;
+  assert.end();
 });

--- a/src/listeners/__tests__/node.spec.js
+++ b/src/listeners/__tests__/node.spec.js
@@ -192,7 +192,7 @@ tape('Node JS / Signal Listener SIGTERM callback with async handler that throws 
   return handlerPromise;
 });
 
-tape('getUnloadDomEvent', function (assert) {
+tape('Browser signal listener - getUnloadDomEvent', function (assert) {
   assert.equal(getUnloadDomEvent(), 'unload', 'returns `unload` if userAgent property is not available');
 
   global.navigator = { userAgent: 'Mozilla/5.0 (Android; Mobile; rv:13.0) Gecko/13.0 Firefox/13.0' };

--- a/src/listeners/browser.js
+++ b/src/listeners/browser.js
@@ -11,7 +11,15 @@ import objectAssign from 'object-assign';
 const log = logFactory('splitio-client:cleanup');
 
 // 'unload' event is used instead of 'beforeunload', since 'unload' is not a cancelable event, so no other listeners can stop the event from occurring.
-const UNLOAD_DOM_EVENT = 'unload';
+// In Firefox, 'beforeunload' is used to avoid issue with SSE (https://github.com/splitio/react-client/issues/71)
+export function getUnloadDomEvent() {
+  if (typeof navigator == 'object' && navigator.userAgent && navigator.userAgent.indexOf('Firefox/') !== -1) {
+    return 'beforeunload';
+  }
+  return 'unload';
+}
+
+const UNLOAD_DOM_EVENT = getUnloadDomEvent();
 
 /**
  * We'll listen for 'unload' event over the window object, since it's the standard way to listen page reload and close.


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

Updated browser listener to avoid a streaming connection error log when reloading a page in Firefox browser (https://github.com/splitio/react-client/issues/71).

## How do we test the changes introduced in this PR?

Added UT.

## Extra Notes