### PR TITLE
Upgrade node-fetch to 2.6.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4978,9 +4978,33 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-modules-regexp": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ioredis": "^4.28.0",
     "ip": "1.1.5",
     "js-yaml": "3.13.1",
-    "node-fetch": "^2.6.1",
+    "node-fetch": "^2.6.7",
     "object-assign": "^4.1.1",
     "unfetch": "^4.2.0"
   },


### PR DESCRIPTION
# JS SDK

## What did you accomplish?
Upgraded node-fetch to fix CVE-2022-0235.

## How do we test the changes introduced in this PR?
Verify that `npm audit --registry https://registry.npmjs.org --audit-level "moderate" --parseable --production` has no output.

## Extra Notes
See https://github.com/advisories/GHSA-r683-j2x4-v87g for details.