### PR TITLE
[JS Migration] Update E2E tests

### DIFF
--- a/src/__tests__/browser.spec.js
+++ b/src/__tests__/browser.spec.js
@@ -1,9 +1,10 @@
 import tape from 'tape-catch';
 import fetchMock from './testUtils/fetchMock';
+import { url } from './testUtils';
 import evaluationsSuite from './browserSuites/evaluations.spec';
 import impressionsSuite from './browserSuites/impressions.spec';
 import impressionsSuiteDebug from './browserSuites/impressions.debug.spec';
-import metricsSuite from './browserSuites/metrics.spec';
+// import metricsSuite from './browserSuites/metrics.spec';
 import impressionsListenerSuite from './browserSuites/impressions-listener.spec';
 import readinessSuite from './browserSuites/readiness.spec';
 import readyFromCache from './browserSuites/ready-from-cache.spec';
@@ -19,7 +20,7 @@ import useBeaconDebugApiSuite from './browserSuites/use-beacon-api.debug.spec';
 import readyPromiseSuite from './browserSuites/ready-promise.spec';
 import fetchSpecificSplits from './browserSuites/fetch-specific-splits.spec';
 
-import SettingsFactory from '../utils/settings';
+import { settingsFactory } from '../settings';
 
 import splitChangesMock1 from './mocks/splitchanges.since.-1.json';
 import splitChangesMock2 from './mocks/splitchanges.since.1457552620999.json';
@@ -28,7 +29,7 @@ import mySegmentsNicolas from './mocks/mysegments.nicolas@split.io.json';
 import mySegmentsMarcio from './mocks/mysegments.marcio@split.io.json';
 import mySegmentsEmmanuel from './mocks/mysegments.emmanuel@split.io.json';
 
-const settings = SettingsFactory({
+const settings = settingsFactory({
   core: {
     key: 'facundo@split.io'
   },
@@ -88,14 +89,14 @@ tape('## E2E CI Tests ##', function(assert) {
   //If we change the mocks, we need to clear localstorage. Cleaning up after testing ensures "fresh data".
   localStorage.clear();
 
-  fetchMock.get(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
-  fetchMock.get(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock2 });
-  fetchMock.get(settings.url('/mySegments/facundo%40split.io'), { status: 200, body: mySegmentsFacundo });
-  fetchMock.get(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolas });
-  fetchMock.get(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
-  fetchMock.get(settings.url('/mySegments/emmanuel%40split.io'), { status: 200, body: mySegmentsEmmanuel });
-  fetchMock.post(settings.url('/testImpressions/bulk'), 200);
-  fetchMock.post(settings.url('/testImpressions/count'), 200);
+  fetchMock.get(url(settings, '/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
+  fetchMock.get(url(settings, '/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock2 });
+  fetchMock.get(url(settings, '/mySegments/facundo%40split.io'), { status: 200, body: mySegmentsFacundo });
+  fetchMock.get(url(settings, '/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolas });
+  fetchMock.get(url(settings, '/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.get(url(settings, '/mySegments/emmanuel%40split.io'), { status: 200, body: mySegmentsEmmanuel });
+  fetchMock.post(url(settings, '/testImpressions/bulk'), 200);
+  fetchMock.post(url(settings, '/testImpressions/count'), 200);
 
   /* Check client evaluations. */
   assert.test('E2E / In Memory', evaluationsSuite.bind(null, configInMemory, fetchMock));
@@ -107,7 +108,8 @@ tape('## E2E CI Tests ##', function(assert) {
   /* Check impression listener */
   assert.test('E2E / Impression listener', impressionsListenerSuite);
   /* Check metrics */
-  assert.test('E2E / Metrics', metricsSuite.bind(null, fetchMock));
+  // @TODO uncomment when telemetry is implemented
+  // assert.test('E2E / Metrics', metricsSuite.bind(null, fetchMock));
   /* Check events */
   assert.test('E2E / Events', withoutBindingTT.bind(null, fetchMock));
   assert.test('E2E / Events with TT binded', bindingTT.bind(null, fetchMock));

--- a/src/__tests__/browserSuites/events.spec.js
+++ b/src/__tests__/browserSuites/events.spec.js
@@ -1,7 +1,8 @@
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
+import { settingsFactory } from '../../settings';
+import { url } from '../testUtils';
 
-const settings = SettingsFactory({
+const settings = settingsFactory({
   core: {
     key: 'asd'
   },
@@ -32,7 +33,7 @@ export function withoutBindingTT(fetchMock, assert) {
 
   let tsStart, tsEnd;
 
-  fetchMock.postOnce(settings.url('/events/bulk'), (url, opts) => {
+  fetchMock.postOnce(url(settings, '/events/bulk'), (url, opts) => {
     const resp = JSON.parse(opts.body);
 
     // We will test the first and last item in detail.
@@ -101,7 +102,7 @@ export function bindingTT(fetchMock, assert) {
 
   let tsStart, tsEnd;
 
-  fetchMock.postOnce(settings.url('/events/bulk'), (url, opts) => {
+  fetchMock.postOnce(url(settings, '/events/bulk'), (url, opts) => {
     const resp = JSON.parse(opts.body);
 
     // We will test the first and last item in detail.

--- a/src/__tests__/browserSuites/ignore-ip-addresses-setting.spec.js
+++ b/src/__tests__/browserSuites/ignore-ip-addresses-setting.spec.js
@@ -1,7 +1,8 @@
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
+import { settingsFactory } from '../../settings';
 import splitChangesMock1 from '../mocks/splitchanges.since.-1.json';
-import { DEBUG } from '../../utils/constants';
+import { DEBUG } from '@splitsoftware/splitio-commons/src/utils/constants';
+import { url } from '../testUtils';
 
 // Header keys and expected values. Expected values are obtained with the runtime function evaluated with IPAddressesEnabled in true.
 const HEADER_SPLITSDKMACHINEIP = 'SplitSDKMachineIP';
@@ -70,8 +71,9 @@ const configSamples = [
 const postEndpoints = [
   '/events/bulk',
   '/testImpressions/bulk',
-  '/metrics/times',
-  '/metrics/counters'
+  // @TODO uncomment when telemetry is implemented
+  // '/metrics/times',
+  // '/metrics/counters'
 ];
 
 export default function (fetchMock, assert) {
@@ -102,10 +104,10 @@ export default function (fetchMock, assert) {
     };
 
     // Mock GET endpoints before creating the client
-    const settings = SettingsFactory(config);
-    fetchMock.getOnce(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
-    fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
-    fetchMock.getOnce(settings.url(`/mySegments/${encodeURIComponent(config.core.key)}`), { status: 200, body: { mySegments: [] } });
+    const settings = settingsFactory(config);
+    fetchMock.getOnce(url(settings, '/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
+    fetchMock.getOnce(url(settings, '/splitChanges?since=1457552620999'), { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
+    fetchMock.getOnce(url(settings, `/mySegments/${encodeURIComponent(config.core.key)}`), { status: 200, body: { mySegments: [] } });
 
     // Init Split client
     const splitio = SplitFactory(config);
@@ -123,7 +125,7 @@ export default function (fetchMock, assert) {
 
     // Mock and assert POST endpoints
     postEndpoints.forEach(postEndpoint => {
-      fetchMock.postOnce(settings.url(postEndpoint), (url, opts) => {
+      fetchMock.postOnce(url(settings, postEndpoint), (url, opts) => {
         assertHeaders(settings.core.IPAddressesEnabled, opts);
         finishConfig.next();
         return 200;

--- a/src/__tests__/browserSuites/impressions-listener.spec.js
+++ b/src/__tests__/browserSuites/impressions-listener.spec.js
@@ -1,8 +1,8 @@
 import sinon from 'sinon';
 
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
-const settings = SettingsFactory({
+import { settingsFactory } from '../../settings';
+const settings = settingsFactory({
   core: {
     key: '<fake id>'
   },

--- a/src/__tests__/browserSuites/impressions.debug.spec.js
+++ b/src/__tests__/browserSuites/impressions.debug.spec.js
@@ -1,16 +1,17 @@
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
+import { settingsFactory } from '../../settings';
 import splitChangesMock1 from '../mocks/splitchanges.since.-1.json';
 import splitChangesMock2 from '../mocks/splitchanges.since.1457552620999.json';
 import mySegmentsFacundo from '../mocks/mysegments.facundo@split.io.json';
-import { DEBUG } from '../../utils/constants';
+import { DEBUG } from '@splitsoftware/splitio-commons/src/utils/constants';
+import { url } from '../testUtils';
 
 const baseUrls = {
   sdk: 'https://sdk.baseurl/impressionsSuite',
   events: 'https://events.baseurl/impressionsSuite'
 };
 
-const settings = SettingsFactory({
+const settings = settingsFactory({
   core: {
     key: 'asd'
   },
@@ -20,9 +21,9 @@ const settings = SettingsFactory({
 
 export default function (fetchMock, assert) {
   // Mocking this specific route to make sure we only get the items we want to test from the handlers.
-  fetchMock.getOnce(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
-  fetchMock.get(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock2 });
-  fetchMock.get(settings.url('/mySegments/facundo%40split.io'), { status: 200, body: mySegmentsFacundo });
+  fetchMock.getOnce(url(settings, '/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
+  fetchMock.get(url(settings, '/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock2 });
+  fetchMock.get(url(settings, '/mySegments/facundo%40split.io'), { status: 200, body: mySegmentsFacundo });
 
   const splitio = SplitFactory({
     core: {
@@ -78,7 +79,7 @@ export default function (fetchMock, assert) {
     });
   };
 
-  fetchMock.postOnce(settings.url('/testImpressions/bulk'), (url, req) => {
+  fetchMock.postOnce(url(settings, '/testImpressions/bulk'), (url, req) => {
     assert.equal(req.headers.SplitSDKImpressionsMode, DEBUG);
     assertPayload(req);
 
@@ -87,7 +88,7 @@ export default function (fetchMock, assert) {
 
     return 200;
   });
-  fetchMock.postOnce(settings.url('/testImpressions/bulk'), 200);
+  fetchMock.postOnce(url(settings, '/testImpressions/bulk'), 200);
 
   client.ready().then(() => {
     client.getTreatment('split_with_config');

--- a/src/__tests__/browserSuites/manager.spec.js
+++ b/src/__tests__/browserSuites/manager.spec.js
@@ -1,9 +1,10 @@
 import { SplitFactory } from '../../';
 import splitChangesMockReal from '../mocks/splitchanges.real.json';
 import map from 'lodash/map';
+import { url } from '../testUtils';
 
 export default async function(settings, fetchMock, assert) {
-  fetchMock.getOnce({ url: settings.url('/splitChanges?since=-1'), overwriteRoutes: true }, { status: 200, body: splitChangesMockReal });
+  fetchMock.getOnce({ url: url(settings, '/splitChanges?since=-1'), overwriteRoutes: true }, { status: 200, body: splitChangesMockReal });
 
   const mockSplits = splitChangesMockReal;
 

--- a/src/__tests__/browserSuites/push-corner-cases.spec.js
+++ b/src/__tests__/browserSuites/push-corner-cases.spec.js
@@ -1,14 +1,14 @@
 import splitChangesMock1 from '../mocks/splitchanges.since.-1.json';
 import splitKillMessage from '../mocks/message.SPLIT_KILL.1457552650000.json';
 import authPushEnabledNicolas from '../mocks/auth.pushEnabled.nicolas@split.io.json';
-import { nearlyEqual } from '../testUtils';
+import { nearlyEqual, url } from '../testUtils';
 
 // Replace original EventSource with mock
-import EventSourceMock, { setMockListener } from '../../sync/__tests__/mocks/eventSourceMock';
+import EventSourceMock, { setMockListener } from '../testUtils/eventSourceMock';
 window.EventSource = EventSourceMock;
 
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
+import { settingsFactory } from '../../settings';
 
 const userKey = 'nicolas@split.io';
 
@@ -28,7 +28,7 @@ const config = {
     prefix: 'pushCornerCase'
   },
 };
-const settings = SettingsFactory(config);
+const settings = settingsFactory(config);
 
 const MILLIS_SSE_OPEN = 100;
 const MILLIS_SPLIT_KILL_EVENT = 200;
@@ -69,13 +69,13 @@ export function testSplitKillOnReadyFromCache(fetchMock, assert) {
   });
 
   // 1 auth request
-  fetchMock.getOnce(settings.url(`/v2/auth?users=${encodeURIComponent(userKey)}`), { status: 200, body: authPushEnabledNicolas });
+  fetchMock.getOnce(url(settings, `/v2/auth?users=${encodeURIComponent(userKey)}`), { status: 200, body: authPushEnabledNicolas });
   // 2 mySegments requests: initial sync and after SSE opened
-  fetchMock.get({ url: settings.url('/mySegments/nicolas%40split.io'), repeat: 2 }, { status: 200, body: { mySegments: [] } });
+  fetchMock.get({ url: url(settings, '/mySegments/nicolas%40split.io'), repeat: 2 }, { status: 200, body: { mySegments: [] } });
 
   // 2 splitChanges request: initial sync and after SSE opened. Sync after SPLIT_KILL is not performed because SplitsSyncTask is "executing"
-  fetchMock.getOnce(settings.url('/splitChanges?since=25'), { status: 200, body: splitChangesMock1}, {delay: MILLIS_SPLIT_CHANGES_RESPONSE, /* delay response */ });
-  fetchMock.getOnce(settings.url('/splitChanges?since=25'), { status: 200, body: splitChangesMock1}, {delay: MILLIS_SPLIT_CHANGES_RESPONSE - 100, /* delay response */ });
+  fetchMock.getOnce(url(settings, '/splitChanges?since=25'), { status: 200, body: splitChangesMock1}, {delay: MILLIS_SPLIT_CHANGES_RESPONSE, /* delay response */ });
+  fetchMock.getOnce(url(settings, '/splitChanges?since=25'), { status: 200, body: splitChangesMock1}, {delay: MILLIS_SPLIT_CHANGES_RESPONSE - 100, /* delay response */ });
 
   fetchMock.get(new RegExp('.*'), function (url) {
     assert.fail('unexpected GET request with url: ' + url);

--- a/src/__tests__/browserSuites/push-fallbacking.spec.js
+++ b/src/__tests__/browserSuites/push-fallbacking.spec.js
@@ -27,13 +27,13 @@ import authPushEnabledNicolasAndMarcio from '../mocks/auth.pushEnabled.nicolas@s
 
 import streamingResetMessage from '../mocks/message.STREAMING_RESET.json';
 
-import { nearlyEqual } from '../testUtils';
+import { nearlyEqual, url } from '../testUtils';
 
-import EventSourceMock, { setMockListener } from '../../sync/__tests__/mocks/eventSourceMock';
+import EventSourceMock, { setMockListener } from '../testUtils/eventSourceMock';
 window.EventSource = EventSourceMock;
 
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
+import { settingsFactory } from '../../settings';
 
 const userKey = 'nicolas@split.io';
 const secondUserKey = 'marcio@split.io';
@@ -58,7 +58,7 @@ const config = {
   streamingEnabled: true,
   // debug: true,
 };
-const settings = SettingsFactory(config);
+const settings = settingsFactory(config);
 
 const MILLIS_SSE_OPEN = 100;
 const MILLIS_STREAMING_DOWN_OCCUPANCY = MILLIS_SSE_OPEN + 100;
@@ -114,7 +114,7 @@ export function testFallbacking(fetchMock, assert) {
   // mock SSE open and message events
   setMockListener((eventSourceInstance) => {
 
-    const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolas.token}&v=1.1&heartbeats=true&SplitSDKVersion=${settings.version}&SplitSDKClientKey=h-1>`;
+    const expectedSSEurl = `${url(settings, '/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolas.token}&v=1.1&heartbeats=true&SplitSDKVersion=${settings.version}&SplitSDKClientKey=h-1>`;
     assert.equals(eventSourceInstance.url, expectedSSEurl, 'EventSource URL is the expected');
 
     setTimeout(() => {
@@ -140,7 +140,7 @@ export function testFallbacking(fetchMock, assert) {
       secondClient = splitio.client(secondUserKey);
 
       setMockListener((eventSourceInstance) => {
-        const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_MjE0MTkxOTU2Mg%3D%3D_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolasAndMarcio.token}&v=1.1&heartbeats=true&SplitSDKVersion=${settings.version}&SplitSDKClientKey=h-1>`;
+        const expectedSSEurl = `${url(settings, '/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_MjE0MTkxOTU2Mg%3D%3D_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolasAndMarcio.token}&v=1.1&heartbeats=true&SplitSDKVersion=${settings.version}&SplitSDKClientKey=h-1>`;
         assert.equals(eventSourceInstance.url, expectedSSEurl, 'new EventSource URL is the expected');
         eventSourceInstance.emitOpen();
 
@@ -210,90 +210,90 @@ export function testFallbacking(fetchMock, assert) {
 
   });
 
-  fetchMock.getOnce(settings.url(`/v2/auth?users=${encodeURIComponent(userKey)}`), function (url, opts) {
+  fetchMock.getOnce(url(settings, `/v2/auth?users=${encodeURIComponent(userKey)}`), function (url, opts) {
     if (!opts.headers['Authorization']) assert.fail('`/v2/auth` request must include `Authorization` header');
     assert.pass('auth success');
     return { status: 200, body: authPushEnabledNicolas };
   });
 
   // initial split and mySegment sync
-  fetchMock.getOnce(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(url(settings, '/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
+  fetchMock.getOnce(url(settings, '/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 
   // split and segment sync after SSE opened
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552620999'), { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
+  fetchMock.getOnce(url(settings, '/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 
   // fetches due to first fallback to polling
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552620999'), { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
+  fetchMock.getOnce(url(settings, '/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552620999'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_STREAMING_DOWN_OCCUPANCY + settings.scheduler.featuresRefreshRate), 'fetch due to first fallback to polling');
     return { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } };
   });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(url(settings, '/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 
   // split and segment sync due to streaming up (OCCUPANCY event)
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552620999'), { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
+  fetchMock.getOnce(url(settings, '/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 
   // creating of second client during streaming: initial mysegment sync, reauth and syncAll due to new client
-  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
-  fetchMock.get({ url: settings.url(`/v2/auth?users=${encodeURIComponent(userKey)}&users=${encodeURIComponent(secondUserKey)}`), repeat: 3 /* initial + 2 STREAMING_RESET */ }, (url, opts) => {
+  fetchMock.getOnce(url(settings, '/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.get({ url: url(settings, `/v2/auth?users=${encodeURIComponent(userKey)}&users=${encodeURIComponent(secondUserKey)}`), repeat: 3 /* initial + 2 STREAMING_RESET */ }, (url, opts) => {
     if (!opts.headers['Authorization']) assert.fail('`/v2/auth` request must include `Authorization` header');
     assert.pass('second auth success');
     return { status: 200, body: authPushEnabledNicolasAndMarcio };
   });
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
-  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552620999'), { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
+  fetchMock.getOnce(url(settings, '/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(url(settings, '/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
 
   // fetch due to SPLIT_UPDATE event
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552620999'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_SPLIT_UPDATE_EVENT_DURING_PUSH), 'sync due to SPLIT_UPDATE event');
     return { status: 200, body: splitChangesMock2 };
   });
 
   // fetches due to second fallback to polling
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), { status: 200, body: { splits: [], since: 1457552649999, till: 1457552649999 } });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
-  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552649999'), { status: 200, body: { splits: [], since: 1457552649999, till: 1457552649999 } });
+  fetchMock.getOnce(url(settings, '/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(url(settings, '/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
 
   // continue fetches due to second fallback to polling
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), function () {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552649999'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_STREAMING_PAUSED_CONTROL + settings.scheduler.featuresRefreshRate), 'fetch due to second fallback to polling');
     return { status: 200, body: { splits: [], since: 1457552649999, till: 1457552649999 } };
   });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
-  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(url(settings, '/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(url(settings, '/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
 
   // split and segment sync due to streaming up (CONTROL event)
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), { status: 200, body: { splits: [], since: 1457552649999, till: 1457552649999 } });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
-  fetchMock.getOnce(settings.url('/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552649999'), { status: 200, body: { splits: [], since: 1457552649999, till: 1457552649999 } });
+  fetchMock.getOnce(url(settings, '/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(url(settings, '/mySegments/marcio%40split.io'), { status: 200, body: mySegmentsMarcio });
 
   // fetch due to MY_SEGMENTS_UPDATE event
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), function () {
+  fetchMock.getOnce(url(settings, '/mySegments/nicolas%40split.io'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_MY_SEGMENTS_UPDATE_EVENT_DURING_PUSH), 'sync due to MY_SEGMENTS_UPDATE event');
     return { status: 200, body: mySegmentsNicolasMock2 };
   });
 
   // fetches due to third fallback to polling (STREAMING_PAUSED), two sync all (two STREAMING_RESET events) and fourth fallback (STREAMING_DISABLED)
-  fetchMock.get({ url: settings.url('/splitChanges?since=1457552649999'), repeat: 4 }, { status: 200, body: { splits: [], since: 1457552649999, till: 1457552649999 } });
-  fetchMock.get({ url: settings.url('/mySegments/nicolas%40split.io'), repeat: 4 }, { status: 200, body: mySegmentsNicolasMock1 });
-  fetchMock.get({ url: settings.url('/mySegments/marcio%40split.io'), repeat: 4 }, { status: 200, body: mySegmentsMarcio });
+  fetchMock.get({ url: url(settings, '/splitChanges?since=1457552649999'), repeat: 4 }, { status: 200, body: { splits: [], since: 1457552649999, till: 1457552649999 } });
+  fetchMock.get({ url: url(settings, '/mySegments/nicolas%40split.io'), repeat: 4 }, { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.get({ url: url(settings, '/mySegments/marcio%40split.io'), repeat: 4 }, { status: 200, body: mySegmentsMarcio });
 
   // Periodic fetch due to polling (mySegments is not fetched due to smart pausing)
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), function () {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552649999'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_STREAMING_DISABLED_CONTROL + settings.scheduler.featuresRefreshRate, 75), 'fetch due to fourth fallback to polling');
     return { status: 200, body: splitChangesMock3 };
   });
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552669999'), function () {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552669999'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_STREAMING_DISABLED_CONTROL + settings.scheduler.featuresRefreshRate * 2, 75), 'fetch due to fourth fallback to polling');
     return { status: 200, body: { splits: [], since: 1457552669999, till: 1457552669999 } };

--- a/src/__tests__/browserSuites/push-initialization-retries.spec.js
+++ b/src/__tests__/browserSuites/push-initialization-retries.spec.js
@@ -5,12 +5,12 @@ import authPushEnabledNicolas from '../mocks/auth.pushEnabled.nicolas@split.io.j
 import authPushBadToken from '../mocks/auth.pushBadToken.json';
 import mySegmentsNicolasMock from '../mocks/mysegments.nicolas@split.io.json';
 
-import { nearlyEqual } from '../testUtils';
+import { nearlyEqual, url } from '../testUtils';
 
-import EventSourceMock, { setMockListener } from '../../sync/__tests__/mocks/eventSourceMock';
+import EventSourceMock, { setMockListener } from '../testUtils/eventSourceMock';
 
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
+import { settingsFactory } from '../../settings';
 
 const baseUrls = {
   sdk: 'https://sdk.push-initialization-retries/api',
@@ -37,7 +37,7 @@ const config = {
   streamingEnabled: true,
   // debug: true,
 };
-const settings = SettingsFactory(config);
+const settings = settingsFactory(config);
 
 /**
  * Sequence of calls:
@@ -52,39 +52,39 @@ export function testPushRetriesDueToAuthErrors(fetchMock, assert) {
 
   let start, splitio, client, ready = false;
 
-  fetchMock.getOnce(settings.url(`/v2/auth?users=${encodeURIComponent(userKey)}`), function (url, opts) {
+  fetchMock.getOnce(url(settings, `/v2/auth?users=${encodeURIComponent(userKey)}`), function (url, opts) {
     if (!opts.headers['Authorization']) assert.fail('`/v2/auth` request must include `Authorization` header');
     assert.pass('first auth attempt');
     return { status: 200, body: authPushBadToken };
   });
-  fetchMock.getOnce(settings.url(`/v2/auth?users=${encodeURIComponent(userKey)}`), { throws: new TypeError('Network error') });
-  fetchMock.getOnce(settings.url(`/v2/auth?users=${encodeURIComponent(userKey)}`), function (url, opts) {
+  fetchMock.getOnce(url(settings, `/v2/auth?users=${encodeURIComponent(userKey)}`), { throws: new TypeError('Network error') });
+  fetchMock.getOnce(url(settings, `/v2/auth?users=${encodeURIComponent(userKey)}`), function (url, opts) {
     if (!opts.headers['Authorization']) assert.fail('`/v2/auth` request must include `Authorization` header');
     const lapse = Date.now() - start;
     const expected = (settings.scheduler.pushRetryBackoffBase * Math.pow(2, 0) + settings.scheduler.pushRetryBackoffBase * Math.pow(2, 1));
     assert.true(nearlyEqual(lapse, expected), 'third auth attempt (aproximately in 0.3 seconds from first attempt)');
     return { status: 200, body: authPushDisabled };
   });
-  fetchMock.get({ url: settings.url('/mySegments/nicolas%40split.io'), repeat: 4 }, { status: 200, body: mySegmentsNicolasMock });
+  fetchMock.get({ url: url(settings, '/mySegments/nicolas%40split.io'), repeat: 4 }, { status: 200, body: mySegmentsNicolasMock });
 
-  fetchMock.getOnce(settings.url('/splitChanges?since=-1'), function () {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=-1'), function () {
     console.log('split changes');
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, 0), 'initial sync');
     return { status: 200, body: splitChangesMock1 };
   });
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552620999'), function () {
     assert.true(ready, 'client ready before first polling fetch');
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, 0), 'fallback to polling');
     return { status: 200, body: splitChangesMock2 };
   });
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552620999'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, settings.scheduler.featuresRefreshRate), 'polling');
     return { status: 200, body: splitChangesMock2 };
   });
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552620999'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, settings.scheduler.featuresRefreshRate * 2), 'keep polling since auth success buth with push disabled');
     client.destroy().then(() => {
@@ -116,7 +116,7 @@ export function testPushRetriesDueToSseErrors(fetchMock, assert) {
   let start, splitio, client, ready = false;
   const expectedTimeToSSEsuccess = (settings.scheduler.pushRetryBackoffBase * Math.pow(2, 0) + settings.scheduler.pushRetryBackoffBase * Math.pow(2, 1));
 
-  const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolas.token}&v=1.1&heartbeats=true&SplitSDKVersion=${settings.version}&SplitSDKClientKey=h-1>`;
+  const expectedSSEurl = `${url(settings, '/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolas.token}&v=1.1&heartbeats=true&SplitSDKVersion=${settings.version}&SplitSDKClientKey=h-1>`;
   let sseattempts = 0;
   setMockListener(function (eventSourceInstance) {
     assert.equal(eventSourceInstance.url, expectedSSEurl, 'SSE url is correct');
@@ -132,30 +132,30 @@ export function testPushRetriesDueToSseErrors(fetchMock, assert) {
     sseattempts++;
   });
 
-  fetchMock.get({ url: settings.url(`/v2/auth?users=${encodeURIComponent(userKey)}`), repeat: 3 /* 3 push attempts */ }, function (url, opts) {
+  fetchMock.get({ url: url(settings, `/v2/auth?users=${encodeURIComponent(userKey)}`), repeat: 3 /* 3 push attempts */ }, function (url, opts) {
     if (!opts.headers['Authorization']) assert.fail('`/v2/auth` request must include `Authorization` header');
     assert.pass('auth success');
     return { status: 200, body: authPushEnabledNicolas };
   });
-  fetchMock.get({ url: settings.url('/mySegments/nicolas%40split.io'), repeat: 4 }, { status: 200, body: mySegmentsNicolasMock });
+  fetchMock.get({ url: url(settings, '/mySegments/nicolas%40split.io'), repeat: 4 }, { status: 200, body: mySegmentsNicolasMock });
 
-  fetchMock.getOnce(settings.url('/splitChanges?since=-1'), function () {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=-1'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, 0), 'initial sync');
     return { status: 200, body: splitChangesMock1 };
   });
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552620999'), function () {
     assert.true(ready, 'client ready before first polling fetch');
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, 0), 'fallback to polling');
     return { status: 200, body: splitChangesMock2 };
   });
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552620999'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, settings.scheduler.featuresRefreshRate), 'polling');
     return { status: 200, body: splitChangesMock2 };
   });
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552620999'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, expectedTimeToSSEsuccess), 'sync due to success SSE connection');
     client.destroy().then(() => {
@@ -191,10 +191,10 @@ export function testSdkDestroyWhileAuthSuccess(fetchMock, assert) {
 
   let splitio, client, ready = false;
 
-  fetchMock.getOnce(settings.url(`/v2/auth?users=${encodeURIComponent(userKey)}`), { status: 200, body: authPushEnabledNicolas }, { delay: 100 });
+  fetchMock.getOnce(url(settings, `/v2/auth?users=${encodeURIComponent(userKey)}`), { status: 200, body: authPushEnabledNicolas }, { delay: 100 });
 
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock });
-  fetchMock.getOnce(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
+  fetchMock.getOnce(url(settings, '/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock });
+  fetchMock.getOnce(url(settings, '/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
 
   setTimeout(() => {
     client.destroy().then(() => {
@@ -226,9 +226,9 @@ export function testSdkDestroyWhileConnDelay(fetchMock, assert) {
     assert.fail('unexpected EventSource request with url: ' + eventSourceInstance.url);
   });
 
-  fetchMock.getOnce(settings.url(`/v2/auth?users=${encodeURIComponent(userKey)}`), { status: 200, body: { ...authPushEnabledNicolas, connDelay: 0.1 } });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock });
-  fetchMock.getOnce(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
+  fetchMock.getOnce(url(settings, `/v2/auth?users=${encodeURIComponent(userKey)}`), { status: 200, body: { ...authPushEnabledNicolas, connDelay: 0.1 } });
+  fetchMock.getOnce(url(settings, '/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock });
+  fetchMock.getOnce(url(settings, '/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
 
   const client = SplitFactory(config).client();
   setTimeout(() => {
@@ -257,12 +257,12 @@ export function testSdkDestroyWhileAuthRetries(fetchMock, assert) {
 
   let splitio, client, ready = false;
 
-  fetchMock.getOnce(settings.url(`/v2/auth?users=${encodeURIComponent(userKey)}`), { status: 200, body: authPushBadToken });
-  fetchMock.getOnce(settings.url(`/v2/auth?users=${encodeURIComponent(userKey)}`), { throws: new TypeError('Network error') }, { delay: 100 });
+  fetchMock.getOnce(url(settings, `/v2/auth?users=${encodeURIComponent(userKey)}`), { status: 200, body: authPushBadToken });
+  fetchMock.getOnce(url(settings, `/v2/auth?users=${encodeURIComponent(userKey)}`), { throws: new TypeError('Network error') }, { delay: 100 });
 
-  fetchMock.get({ url: settings.url('/mySegments/nicolas%40split.io'), repeat: 2 }, { status: 200, body: mySegmentsNicolasMock });
-  fetchMock.getOnce(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock2 });
+  fetchMock.get({ url: url(settings, '/mySegments/nicolas%40split.io'), repeat: 2 }, { status: 200, body: mySegmentsNicolasMock });
+  fetchMock.getOnce(url(settings, '/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock2 });
 
   fetchMock.get(new RegExp('.*'), function (url) {
     assert.fail('unexpected GET request with url: ' + url);

--- a/src/__tests__/browserSuites/push-synchronization-retries.spec.js
+++ b/src/__tests__/browserSuites/push-synchronization-retries.spec.js
@@ -11,15 +11,15 @@ import splitKillMessage from '../mocks/message.SPLIT_KILL.1457552650000.json';
 
 import authPushEnabledNicolas from '../mocks/auth.pushEnabled.nicolas@split.io.json';
 
-import { nearlyEqual } from '../testUtils';
-import Backoff from '../../utils/backoff';
+import { nearlyEqual, url } from '../testUtils';
+import { Backoff } from '@splitsoftware/splitio-commons/src/utils/Backoff';
 
 // Replace original EventSource with mock
-import EventSourceMock, { setMockListener } from '../../sync/__tests__/mocks/eventSourceMock';
+import EventSourceMock, { setMockListener } from '../testUtils/eventSourceMock';
 window.EventSource = EventSourceMock;
 
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
+import { settingsFactory } from '../../settings';
 
 const userKey = 'nicolas@split.io';
 
@@ -37,7 +37,7 @@ const config = {
   streamingEnabled: true,
   // debug: true,
 };
-const settings = SettingsFactory(config);
+const settings = settingsFactory(config);
 
 const MILLIS_SSE_OPEN = 100;
 
@@ -87,7 +87,7 @@ export function testSynchronizationRetries(fetchMock, assert) {
   setMockListener(function (eventSourceInstance) {
     start = Date.now();
 
-    const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolas.token}&v=1.1&heartbeats=true&SplitSDKVersion=${settings.version}&SplitSDKClientKey=h-1>`;
+    const expectedSSEurl = `${url(settings, '/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_NTcwOTc3MDQx_mySegments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabledNicolas.token}&v=1.1&heartbeats=true&SplitSDKVersion=${settings.version}&SplitSDKClientKey=h-1>`;
     assert.equals(eventSourceInstance.url, expectedSSEurl, 'EventSource URL is the expected');
 
     /* events on first SSE connection */
@@ -134,59 +134,59 @@ export function testSynchronizationRetries(fetchMock, assert) {
   });
 
   // initial auth
-  fetchMock.getOnce(settings.url(`/v2/auth?users=${encodeURIComponent(userKey)}`), function (url, opts) {
+  fetchMock.getOnce(url(settings, `/v2/auth?users=${encodeURIComponent(userKey)}`), function (url, opts) {
     if (!opts.headers['Authorization']) assert.fail('`/v2/auth` request must include `Authorization` header');
     assert.pass('auth success');
     return { status: 200, body: authPushEnabledNicolas };
   });
 
   // initial split and mySegments sync
-  fetchMock.getOnce(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(url(settings, '/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
+  fetchMock.getOnce(url(settings, '/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 
   // split and segment sync after SSE opened
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552620999'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_SSE_OPEN), 'sync after SSE connection is opened');
     return { status: 200, body: splitChangesMock2 };
   });
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
+  fetchMock.getOnce(url(settings, '/mySegments/nicolas%40split.io'), { status: 200, body: mySegmentsNicolasMock1 });
 
   // fetch due to SPLIT_UPDATE event
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock2 });
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock2 });
   // fetch retry for SPLIT_UPDATE event, due to previous unexpected response (response till minor than SPLIT_UPDATE changeNumber)
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function () {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552620999'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_RETRY_FOR_FIRST_SPLIT_UPDATE_EVENT), 'fetch retry due to SPLIT_UPDATE event');
     return { status: 200, body: splitChangesMock3 };
   });
 
   // fetch due to first MY_SEGMENTS_UPDATE event
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { throws: new TypeError('Network error') });
+  fetchMock.getOnce(url(settings, '/mySegments/nicolas%40split.io'), { throws: new TypeError('Network error') });
   // fetch retry for MY_SEGMENTS_UPDATE event, due to previous fail
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 200, body: '{ "since": 1457552620999, "til' }); // invalid JSON response
+  fetchMock.getOnce(url(settings, '/mySegments/nicolas%40split.io'), { status: 200, body: '{ "since": 1457552620999, "til' }); // invalid JSON response
   // fetch retry for MY_SEGMENTS_UPDATE event, due to previous fail
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), { status: 500, body: 'server error' });
+  fetchMock.getOnce(url(settings, '/mySegments/nicolas%40split.io'), { status: 500, body: 'server error' });
   // second fetch retry for MY_SEGMENTS_UPDATE event, due to previous fail
-  fetchMock.getOnce(settings.url('/mySegments/nicolas%40split.io'), function () {
+  fetchMock.getOnce(url(settings, '/mySegments/nicolas%40split.io'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_THIRD_RETRY_FOR_MYSEGMENT_UPDATE_EVENT), 'sync second retry for MY_SEGMENTS_UPDATE event');
     return { status: 200, body: mySegmentsNicolasMock2 };
   });
 
   // fetch due to SPLIT_KILL event
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), function () {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552649999'), function () {
     assert.equal(client.getTreatment('whitelist'), 'not_allowed', 'evaluation with split killed immediately, before fetch is done');
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_SPLIT_KILL_EVENT), 'sync due to SPLIT_KILL event');
     return { status: 200, body: { since: 1457552649999, till: 1457552649999, splits: [] } }; // returning old state
   });
   // first fetch retry for SPLIT_KILL event, due to previous unexpected response (response till minor than SPLIT_KILL changeNumber)
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), { throws: new TypeError('Network error') });
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552649999'), { throws: new TypeError('Network error') });
   // second fetch retry for SPLIT_KILL event
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), { status: 200, body: '{ "since": 1457552620999, "til' }); // invalid JSON response
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552649999'), { status: 200, body: '{ "since": 1457552620999, "til' }); // invalid JSON response
   // third fetch retry for SPLIT_KILL event
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), function () {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552649999'), function () {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_THIRD_RETRY_FOR_SPLIT_KILL_EVENT), 'third fetch retry due to SPLIT_KILL event');
 

--- a/src/__tests__/browserSuites/ready-from-cache.spec.js
+++ b/src/__tests__/browserSuites/ready-from-cache.spec.js
@@ -4,8 +4,9 @@ import splitChangesMock1 from '../mocks/splitchanges.since.-1.json';
 import splitChangesMock2 from '../mocks/splitchanges.since.1457552620999.json';
 import mySegmentsNicolas from '../mocks/mysegments.nicolas@split.io.json';
 
-import { DEFAULT_CACHE_EXPIRATION_IN_MILLIS } from '../../storage/browser';
 import { nearlyEqual } from '../testUtils';
+
+const DEFAULT_CACHE_EXPIRATION_IN_MILLIS = 864000000; // 10 days
 
 const alwaysOnSplitInverted = JSON.stringify({
   'environment': null,

--- a/src/__tests__/browserSuites/ready-promise.spec.js
+++ b/src/__tests__/browserSuites/ready-promise.spec.js
@@ -31,13 +31,13 @@ function assertGetTreatmentWhenReady(assert, client) {
 function assertGetTreatmentControlNotReady(assert, client) {
   consoleSpy.log.resetHistory();
   assert.equal(client.getTreatment('hierarchical_splits_test'), 'control', 'We should get control if client is not ready.');
-  assert.true(consoleSpy.log.calledWithExactly('[WARN]  getTreatment: the SDK is not ready, results may be incorrect. Make sure to wait for SDK readiness before using this method.'), 'Telling us that calling getTreatment would return CONTROL since SDK is not ready at this point.');
+  assert.true(consoleSpy.log.calledWithExactly('[WARN]  splitio => getTreatment: the SDK is not ready, results may be incorrect. Make sure to wait for SDK readiness before using this method.'), 'Telling us that calling getTreatment would return CONTROL since SDK is not ready at this point.');
 }
 
 function assertGetTreatmentControlNotReadyOnDestroy(assert, client) {
   consoleSpy.log.resetHistory();
   assert.equal(client.getTreatment('hierarchical_splits_test'), 'control', 'We should get control if client has been destroyed.');
-  assert.true(consoleSpy.log.calledWithExactly('[ERROR] Client has already been destroyed - no calls possible.'), 'Telling us that client has been destroyed. Calling getTreatment would return CONTROL.');
+  assert.true(consoleSpy.log.calledWithExactly('[ERROR] splitio => getTreatment: Client has already been destroyed - no calls possible.'), 'Telling us that client has been destroyed. Calling getTreatment would return CONTROL.');
 }
 
 /* Validate readiness state transitions, warning and error messages when using ready promises. */
@@ -527,29 +527,29 @@ export default function readyPromiseAssertions(fetchMock, assert) {
       client.ready();
 
       assertGetTreatmentWhenReady(t, client);
-      t.true(consoleSpy.log.calledWithExactly('[WARN]  No listeners for SDK Readiness detected. Incorrect control treatments could have been logged if you called getTreatment/s while the SDK was not yet ready.'),
+      t.true(consoleSpy.log.calledWithExactly('[WARN]  splitio => No listeners for SDK Readiness detected. Incorrect control treatments could have been logged if you called getTreatment/s while the SDK was not yet ready.'),
         'Warning that there are not listeners for SDK_READY event');
 
       // assert error messages when adding event listeners after SDK has already triggered them
       consoleSpy.log.resetHistory();
       client.on(client.Event.SDK_READY, () => { });
       client.on(client.Event.SDK_READY_TIMED_OUT, () => { });
-      t.true(consoleSpy.log.calledWithExactly('[ERROR] A listener was added for SDK_READY on the SDK, which has already fired and won\'t be emitted again. The callback won\'t be executed.'),
+      t.true(consoleSpy.log.calledWithExactly('[ERROR] splitio => A listener was added for SDK_READY on the SDK, which has already fired and won\'t be emitted again. The callback won\'t be executed.'),
         'Logging error that a listeners for SDK_READY event was added after triggered');
-      t.true(consoleSpy.log.calledWithExactly('[ERROR] A listener was added for SDK_READY_TIMED_OUT on the SDK, which has already fired and won\'t be emitted again. The callback won\'t be executed.'),
+      t.true(consoleSpy.log.calledWithExactly('[ERROR] splitio => A listener was added for SDK_READY_TIMED_OUT on the SDK, which has already fired and won\'t be emitted again. The callback won\'t be executed.'),
         'Logging error that a listeners for SDK_READY_TIMED_OUT event was added after triggered');
 
       // assert 'No listener warning' on shared clients
       consoleSpy.log.resetHistory();
       const sharedClientWithCb = splitio.client('nicolas@split.io');
       sharedClientWithCb.on(client.Event.SDK_READY, () => {
-        t.false(consoleSpy.log.calledWithExactly('[WARN]  No listeners for SDK Readiness detected. Incorrect control treatments could have been logged if you called getTreatment/s while the SDK was not yet ready.'),
+        t.false(consoleSpy.log.calledWithExactly('[WARN]  splitio => No listeners for SDK Readiness detected. Incorrect control treatments could have been logged if you called getTreatment/s while the SDK was not yet ready.'),
           'No warning logged');
 
         // eslint-disable-next-line no-unused-vars
         const sharedClientWithoutCb = splitio.client('emiliano@split.io');
         setTimeout(() => {
-          t.true(consoleSpy.log.calledWithExactly('[WARN]  No listeners for SDK Readiness detected. Incorrect control treatments could have been logged if you called getTreatment/s while the SDK was not yet ready.'),
+          t.true(consoleSpy.log.calledWithExactly('[WARN]  splitio => No listeners for SDK Readiness detected. Incorrect control treatments could have been logged if you called getTreatment/s while the SDK was not yet ready.'),
             'Warning logged');
           client.destroy().then(() => {
             client.ready()

--- a/src/__tests__/browserSuites/shared-instantiation.spec.js
+++ b/src/__tests__/browserSuites/shared-instantiation.spec.js
@@ -1,6 +1,7 @@
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
-const settings = SettingsFactory({
+import { settingsFactory } from '../../settings';
+import { url } from '../testUtils';
+const settings = settingsFactory({
   core: {
     key: 'asd'
   },
@@ -9,8 +10,8 @@ const settings = SettingsFactory({
 
 export default function (startWithTT, fetchMock, assert) {
   // mocking mySegments endpoints with delays for new clients
-  fetchMock.get(settings.url('/mySegments/emiliano%2Fsplit.io'), { status: 200, body: { mySegments: [] } }, { delay: 100 });
-  fetchMock.get(settings.url('/mySegments/matias%25split.io'), { status: 200, body: { mySegments: [] } }, { delay: 200 });
+  fetchMock.get(url(settings, '/mySegments/emiliano%2Fsplit.io'), { status: 200, body: { mySegments: [] } }, { delay: 100 });
+  fetchMock.get(url(settings, '/mySegments/matias%25split.io'), { status: 200, body: { mySegments: [] } }, { delay: 200 });
 
   const factory = SplitFactory({
     core: {
@@ -92,7 +93,7 @@ export default function (startWithTT, fetchMock, assert) {
    */
   const trackAssertions = () => {
     // Prepare the mock to check for events having correct values
-    fetchMock.postOnce(settings.url('/events/bulk'), (url, opts) => {
+    fetchMock.postOnce(url(settings, '/events/bulk'), (url, opts) => {
       const events = JSON.parse(opts.body);
 
       assert.equal(events.length, 3, 'Tracked only valid events');

--- a/src/__tests__/browserSuites/use-beacon-api.debug.spec.js
+++ b/src/__tests__/browserSuites/use-beacon-api.debug.spec.js
@@ -1,9 +1,10 @@
 import sinon from 'sinon';
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
+import { settingsFactory } from '../../settings';
 import splitChangesMock1 from '../mocks/splitchanges.since.-1.json';
 import mySegmentsFacundo from '../mocks/mysegments.facundo@split.io.json';
-import { DEBUG } from '../../utils/constants';
+import { DEBUG } from '@splitsoftware/splitio-commons/src/utils/constants';
+import { url } from '../testUtils';
 import { triggerUnloadEvent } from '../testUtils/browser';
 
 const config = {
@@ -21,7 +22,7 @@ const config = {
   }
 };
 
-const settings = SettingsFactory(config);
+const settings = settingsFactory(config);
 
 // Spy calls to Beacon API method
 let sendBeaconSpyDebug;
@@ -44,7 +45,7 @@ const assertCallsToBeaconAPI = (assert) => {
 
   // The first call is for flushing impressions
   const impressionsCallArgs = sendBeaconSpyDebug.firstCall.args;
-  assert.equal(impressionsCallArgs[0], settings.url('/testImpressions/beacon'), 'assert correct url');
+  assert.equal(impressionsCallArgs[0], url(settings, '/testImpressions/beacon'), 'assert correct url');
   let parsedPayload = JSON.parse(impressionsCallArgs[1]);
   assert.equal(parsedPayload.token, '...', 'assert correct payload token');
   assert.equal(parsedPayload.sdk, settings.version, 'assert correct sdk version');
@@ -53,7 +54,7 @@ const assertCallsToBeaconAPI = (assert) => {
 
   // The second call is for flushing events
   const eventsCallArgs = sendBeaconSpyDebug.secondCall.args;
-  assert.equal(eventsCallArgs[0], settings.url('/events/beacon'), 'assert correct url');
+  assert.equal(eventsCallArgs[0], url(settings, '/events/beacon'), 'assert correct url');
   parsedPayload = JSON.parse(eventsCallArgs[1]);
   assert.equal(parsedPayload.token, '...', 'assert correct payload token');
   assert.equal(parsedPayload.sdk, settings.version, 'assert correct sdk version');
@@ -65,9 +66,9 @@ function beaconApiNotSendTestDebug(fetchMock, assert) {
   sendBeaconSpyDebug = sinon.spy(window.navigator, 'sendBeacon');
 
   // Mocking this specific route to make sure we only get the items we want to test from the handlers.
-  fetchMock.get(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
-  fetchMock.get(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
-  fetchMock.get(settings.url('/mySegments/facundo%40split.io'), { status: 200, body: mySegmentsFacundo });
+  fetchMock.get(url(settings, '/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
+  fetchMock.get(url(settings, '/splitChanges?since=1457552620999'), { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
+  fetchMock.get(url(settings, '/mySegments/facundo%40split.io'), { status: 200, body: mySegmentsFacundo });
 
   // Init and run Split client
   const splitio = SplitFactory(config);
@@ -136,14 +137,14 @@ function fallbackTest(fetchMock, assert) {
   })();
 
   // Mock endpoints used by Axios
-  fetchMock.postOnce(settings.url('/testImpressions/bulk'), (url, opts) => {
+  fetchMock.postOnce(url(settings, '/testImpressions/bulk'), (url, opts) => {
     const resp = JSON.parse(opts.body);
     assert.ok(opts, 'Fallback to /testImpressions/bulk');
     assertImpressionSent(assert, resp[0]);
     finish.next();
     return 200;
   });
-  fetchMock.postOnce(settings.url('/events/bulk'), (url, opts) => {
+  fetchMock.postOnce(url(settings, '/events/bulk'), (url, opts) => {
     const resp = JSON.parse(opts.body);
     assert.ok(opts, 'Fallback to /events/bulk');
     assertEventSent(assert, resp[0]);

--- a/src/__tests__/destroy/browser.spec.js
+++ b/src/__tests__/destroy/browser.spec.js
@@ -1,28 +1,29 @@
 import tape from 'tape-catch';
 import fetchMock from '../testUtils/fetchMock';
+import { url } from '../testUtils';
 import map from 'lodash/map';
 import pick from 'lodash/pick';
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
+import { settingsFactory } from '../../settings';
 
 import splitChangesMock1 from './splitChanges.since.-1.json';
 import splitChangesMock2 from './splitChanges.since.1500492097547.json';
 import mySegmentsMock from './mySegments.json';
 import impressionsMock from './impressions.json';
 
-const settings = SettingsFactory({
+const settings = settingsFactory({
   core: {
     key: 'facundo@split.io'
   },
   streamingEnabled: false
 });
 
-fetchMock.getOnce(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
-fetchMock.getOnce(settings.url('/splitChanges?since=-1500492097547'), { status: 200, body: splitChangesMock2 });
+fetchMock.getOnce(url(settings, '/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
+fetchMock.getOnce(url(settings, '/splitChanges?since=-1500492097547'), { status: 200, body: splitChangesMock2 });
 
-fetchMock.getOnce(settings.url('/mySegments/ut1'), { status: 200, body: mySegmentsMock });
-fetchMock.getOnce(settings.url('/mySegments/ut2'), { status: 200, body: mySegmentsMock });
-fetchMock.getOnce(settings.url('/mySegments/ut3'), { status: 200, body: mySegmentsMock });
+fetchMock.getOnce(url(settings, '/mySegments/ut1'), { status: 200, body: mySegmentsMock });
+fetchMock.getOnce(url(settings, '/mySegments/ut2'), { status: 200, body: mySegmentsMock });
+fetchMock.getOnce(url(settings, '/mySegments/ut3'), { status: 200, body: mySegmentsMock });
 
 tape('SDK destroy for BrowserJS', async function (assert) {
   const config = {
@@ -48,7 +49,7 @@ tape('SDK destroy for BrowserJS', async function (assert) {
   client3.track('tt2', 'otherEventType', 3);
 
   // Assert we are sending the impressions while doing the destroy
-  fetchMock.postOnce(settings.url('/testImpressions/bulk'), (url, opts) => {
+  fetchMock.postOnce(url(settings, '/testImpressions/bulk'), (url, opts) => {
     const impressions = JSON.parse(opts.body);
 
     impressions[0].i = map(impressions[0].i, imp => pick(imp, ['k', 't']));
@@ -59,7 +60,7 @@ tape('SDK destroy for BrowserJS', async function (assert) {
   });
 
   // Assert we are sending the impressions count while doing the destroy
-  fetchMock.postOnce(settings.url('/testImpressions/count'), (url, opts) => {
+  fetchMock.postOnce(url(settings, '/testImpressions/count'), (url, opts) => {
     const impressionsCount = JSON.parse(opts.body);
 
     assert.equal(impressionsCount.pf.length, 1);
@@ -70,7 +71,7 @@ tape('SDK destroy for BrowserJS', async function (assert) {
   });
 
   // Assert we are sending the events while doing the destroy
-  fetchMock.postOnce(settings.url('/events/bulk'), (url, opts) => {
+  fetchMock.postOnce(url(settings, '/events/bulk'), (url, opts) => {
     const events = JSON.parse(opts.body);
 
     /* 3 events were pushed */

--- a/src/__tests__/destroy/node.spec.js
+++ b/src/__tests__/destroy/node.spec.js
@@ -2,10 +2,11 @@ import tape from 'tape-catch';
 import map from 'lodash/map';
 import pick from 'lodash/pick';
 import fetchMock from '../testUtils/fetchMock';
+import { url } from '../testUtils';
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
+import { settingsFactory } from '../../settings';
 
-const settings = SettingsFactory({
+const settings = settingsFactory({
   core: {
     key: 'facundo@split.io'
   },
@@ -16,8 +17,8 @@ import splitChangesMock1 from './splitChanges.since.-1.json';
 import splitChangesMock2 from './splitChanges.since.1500492097547.json';
 import impressionsMock from './impressions.json';
 
-fetchMock.get(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
-fetchMock.get(settings.url('/splitChanges?since=-1500492097547'), { status: 200, body: splitChangesMock2 });
+fetchMock.get(url(settings, '/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
+fetchMock.get(url(settings, '/splitChanges?since=-1500492097547'), { status: 200, body: splitChangesMock2 });
 
 tape('SDK destroy for NodeJS', async function (assert) {
   const config = {
@@ -34,7 +35,7 @@ tape('SDK destroy for NodeJS', async function (assert) {
   const manager = factory.manager();
 
   // Assert we are sending the impressions while doing the destroy
-  fetchMock.postOnce(settings.url('/testImpressions/bulk'), (url, opts) => {
+  fetchMock.postOnce(url(settings, '/testImpressions/bulk'), (url, opts) => {
     const impressions = JSON.parse(opts.body);
 
     impressions[0].i = map(impressions[0].i, imp => pick(imp, ['k', 't']));
@@ -45,7 +46,7 @@ tape('SDK destroy for NodeJS', async function (assert) {
   });
 
   // Assert we are sending the impressions count while doing the destroy
-  fetchMock.postOnce(settings.url('/testImpressions/count'), (url, opts) => {
+  fetchMock.postOnce(url(settings, '/testImpressions/count'), (url, opts) => {
     const impressionsCount = JSON.parse(opts.body);
 
     assert.equal(impressionsCount.pf.length, 1);
@@ -60,7 +61,7 @@ tape('SDK destroy for NodeJS', async function (assert) {
   client.track('nicolas.zelaya@gmail.com','tt', 'validEventType', 1);
 
   // Assert we are sending the events while doing the destroy
-  fetchMock.postOnce(settings.url('/events/bulk'), (url, opts) => {
+  fetchMock.postOnce(url(settings, '/events/bulk'), (url, opts) => {
     const events = JSON.parse(opts.body);
 
     assert.equal(events.length, 1, 'Should flush all events on destroy.');

--- a/src/__tests__/errorCatching/browser.spec.js
+++ b/src/__tests__/errorCatching/browser.spec.js
@@ -2,14 +2,15 @@
 import tape from 'tape';
 import includes from 'lodash/includes';
 import fetchMock from '../testUtils/fetchMock';
+import { url } from '../testUtils';
 import splitChangesMock1 from './splitChanges.since.-1.json';
 import mySegmentsMock from './mySegments.nico@split.io.json';
 import splitChangesMock2 from './splitChanges.since.1500492097547.json';
 import splitChangesMock3 from './splitChanges.since.1500492297547.json';
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
+import { settingsFactory } from '../../settings';
 
-const settings = SettingsFactory({
+const settings = settingsFactory({
   core: {
     authorizationKey: '<fake-token>'
   },
@@ -20,12 +21,12 @@ const settings = SettingsFactory({
 localStorage.clear();
 localStorage.setItem('errorCatching.SPLITIO.splits.till', 25);
 
-fetchMock.get(settings.url('/splitChanges?since=25'), function () {
+fetchMock.get(url(settings, '/splitChanges?since=25'), function () {
   return new Promise((res) => { setTimeout(() => res({ status: 200, body: splitChangesMock1 }), 1000); });
 });
-fetchMock.get(settings.url('/splitChanges?since=1500492097547'), { status: 200, body: splitChangesMock2 });
-fetchMock.get(settings.url('/splitChanges?since=1500492297547'), { status: 200, body: splitChangesMock3 });
-fetchMock.get(settings.url('/mySegments/nico%40split.io'), { status: 200, body: mySegmentsMock });
+fetchMock.get(url(settings, '/splitChanges?since=1500492097547'), { status: 200, body: splitChangesMock2 });
+fetchMock.get(url(settings, '/splitChanges?since=1500492297547'), { status: 200, body: splitChangesMock3 });
+fetchMock.get(url(settings, '/mySegments/nico%40split.io'), { status: 200, body: mySegmentsMock });
 fetchMock.post('*', 200);
 
 const assertionsPlanned = 4;
@@ -88,13 +89,13 @@ tape('Error catching on callbacks - Browsers', assert => {
   }
 
   client.on(client.Event.SDK_READY_TIMED_OUT, () => {
-    assert.true(client.__context.get(client.__context.constants.HAS_TIMEDOUT, true)); // SDK status should be already updated
+    assert.true(client.__getStatus().hasTimedout); // SDK status should be already updated
     attachErrorHandlerIfApplicable();
     null.willThrowForTimedOut();
   });
 
   client.once(client.Event.SDK_READY, () => {
-    assert.true(client.__context.get(client.__context.constants.READY, true)); // SDK status should be already updated
+    assert.true(client.__getStatus().isReady); // SDK status should be already updated
     attachErrorHandlerIfApplicable();
     null.willThrowForReady();
   });
@@ -105,7 +106,7 @@ tape('Error catching on callbacks - Browsers', assert => {
   });
 
   client.once(client.Event.SDK_READY_FROM_CACHE, () => {
-    assert.true(client.__context.get(client.__context.constants.READY_FROM_CACHE, true)); // SDK status should be already updated
+    assert.true(client.__getStatus().isReadyFromCache); // SDK status should be already updated
     attachErrorHandlerIfApplicable();
     null.willThrowForReadyFromCache();
   });

--- a/src/__tests__/errorCatching/node.spec.js
+++ b/src/__tests__/errorCatching/node.spec.js
@@ -2,9 +2,10 @@
 import tape from 'tape';
 import includes from 'lodash/includes';
 import fetchMock from '../testUtils/fetchMock';
+import { url } from '../testUtils';
 
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
+import { settingsFactory } from '../../settings';
 
 import splitChangesMock1 from './splitChanges.since.-1.json';
 import splitChangesMock2 from './splitChanges.since.1500492097547.json';
@@ -13,16 +14,16 @@ import splitChangesMock3 from './splitChanges.since.1500492297547.json';
 // Option object used to configure mocked routes with a delay of 1.5 seconds.
 const responseDelay = { delay: 1500 };
 
-const settings = SettingsFactory({
+const settings = settingsFactory({
   core: {
     authorizationKey: '<fake-token>'
   },
   streamingEnabled: false
 });
 
-fetchMock.get(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 }, responseDelay);
-fetchMock.get(settings.url('/splitChanges?since=1500492097547'), { status: 200, body: splitChangesMock2 }, responseDelay);
-fetchMock.get(settings.url('/splitChanges?since=1500492297547'), { status: 200, body: splitChangesMock3 }, responseDelay);
+fetchMock.get(url(settings, '/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 }, responseDelay);
+fetchMock.get(url(settings, '/splitChanges?since=1500492097547'), { status: 200, body: splitChangesMock2 }, responseDelay);
+fetchMock.get(url(settings, '/splitChanges?since=1500492297547'), { status: 200, body: splitChangesMock3 }, responseDelay);
 
 
 tape('Error catching on callbacks', assert => {

--- a/src/__tests__/gaIntegration/both-integrations.spec.js
+++ b/src/__tests__/gaIntegration/both-integrations.spec.js
@@ -1,8 +1,9 @@
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
+import { settingsFactory } from '../../settings';
 import { gaSpy, gaTag } from './gaTestUtils';
 import includes from 'lodash/includes';
-import { DEBUG } from '../../utils/constants';
+import { DEBUG } from '@splitsoftware/splitio-commons/src/utils/constants';
+import { url } from '../testUtils';
 
 function countImpressions(parsedImpressionsBulkPayload) {
   return parsedImpressionsBulkPayload
@@ -24,7 +25,7 @@ const config = {
     impressionsMode: DEBUG,
   }
 };
-const settings = SettingsFactory(config);
+const settings = settingsFactory(config);
 
 export default function (fetchMock, assert) {
 
@@ -49,7 +50,7 @@ export default function (fetchMock, assert) {
       }, 0);
     })();
 
-    fetchMock.postOnce(settings.url('/testImpressions/bulk'), (url, opts) => {
+    fetchMock.postOnce(url(settings, '/testImpressions/bulk'), (url, opts) => {
       // we can assert payload and ga hits, once ga is ready and after `SplitToGa.queue`, that is timeout wrapped, make to the queue stack.
       window.ga(() => {
         setTimeout(() => {
@@ -70,7 +71,7 @@ export default function (fetchMock, assert) {
       return 200;
     });
 
-    fetchMock.postOnce(settings.url('/events/bulk'), (url, opts) => {
+    fetchMock.postOnce(url(settings, '/events/bulk'), (url, opts) => {
       window.ga(() => {
         setTimeout(() => {
           try {

--- a/src/__tests__/gaIntegration/browser.spec.js
+++ b/src/__tests__/gaIntegration/browser.spec.js
@@ -1,15 +1,16 @@
 import tape from 'tape-catch';
 import fetchMock from '../testUtils/fetchMock';
+import { url } from '../testUtils';
 import gaToSplitSuite from './ga-to-split.spec';
 import splitToGaSuite from './split-to-ga.spec';
 import bothIntegrationsSuite from './both-integrations.spec';
 
-import SettingsFactory from '../../utils/settings';
+import { settingsFactory } from '../../settings';
 
 import splitChangesMock1 from '../mocks/splitchanges.since.-1.json';
 import mySegmentsFacundo from '../mocks/mysegments.facundo@split.io.json';
 
-const settings = SettingsFactory({
+const settings = settingsFactory({
   core: {
     key: 'facundo@split.io'
   }
@@ -17,8 +18,8 @@ const settings = SettingsFactory({
 
 tape('## E2E CI Tests ##', function(assert) {
 
-  fetchMock.get(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
-  fetchMock.get(settings.url('/mySegments/facundo%40split.io'), { status: 200, body: mySegmentsFacundo });
+  fetchMock.get(url(settings, '/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
+  fetchMock.get(url(settings, '/mySegments/facundo%40split.io'), { status: 200, body: mySegmentsFacundo });
 
   /* Validate GA integration */
   assert.test('E2E / GA-to-Split', gaToSplitSuite.bind(null, fetchMock));

--- a/src/__tests__/node.spec.js
+++ b/src/__tests__/node.spec.js
@@ -1,12 +1,13 @@
 import tape from 'tape-catch';
 import fetchMock from './testUtils/fetchMock';
-import SettingsFactory from '../utils/settings';
+import { url } from './testUtils';
+import { settingsFactory } from '../settings';
 
 import evaluationsSuite from './nodeSuites/evaluations.spec';
 import eventsSuite from './nodeSuites/events.spec';
 import impressionsSuite from './nodeSuites/impressions.spec';
 import impressionsSuiteDebug from './nodeSuites/impressions.debug.spec';
-import metricsSuite from './nodeSuites/metrics.spec';
+// import metricsSuite from './nodeSuites/metrics.spec';
 import impressionsListenerSuite from './nodeSuites/impressions-listener.spec';
 import expectedTreatmentsSuite from './nodeSuites/expected-treatments.spec';
 import managerSuite from './nodeSuites/manager.spec';
@@ -18,7 +19,7 @@ import fetchSpecificSplits from './nodeSuites/fetch-specific-splits.spec';
 import splitChangesMock1 from './mocks/splitchanges.since.-1.json';
 import splitChangesMock2 from './mocks/splitchanges.since.1457552620999.json';
 
-const settings = SettingsFactory({
+const settings = settingsFactory({
   core: {
     authorizationKey: '<fake-token>'
   },
@@ -40,9 +41,9 @@ const config = {
 
 const key = 'facundo@split.io';
 
-fetchMock.get(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
-fetchMock.get(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock2 });
-fetchMock.get(new RegExp(`${settings.url('/segmentChanges')}/*`), {
+fetchMock.get(url(settings, '/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
+fetchMock.get(url(settings, '/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock2 });
+fetchMock.get(new RegExp(`${url(settings, '/segmentChanges')}/*`), {
   status: 200, body: {
     'name': 'segment',
     'added': [],
@@ -51,8 +52,8 @@ fetchMock.get(new RegExp(`${settings.url('/segmentChanges')}/*`), {
     'till': 1
   }
 });
-fetchMock.post(settings.url('/testImpressions/bulk'), 200);
-fetchMock.post(settings.url('/testImpressions/count'), 200);
+fetchMock.post(url(settings, '/testImpressions/bulk'), 200);
+fetchMock.post(url(settings, '/testImpressions/count'), 200);
 
 tape('## Node JS - E2E CI Tests ##', async function (assert) {
   /* Check client evaluations. */
@@ -63,8 +64,9 @@ tape('## Node JS - E2E CI Tests ##', async function (assert) {
   assert.test('E2E / Impressions Debug Mode', impressionsSuiteDebug.bind(null, key, fetchMock));
   assert.test('E2E / Impressions listener', impressionsListenerSuite);
 
-  /* Check metrics */
-  assert.test('E2E / Metrics', metricsSuite.bind(null, key, fetchMock));
+  // /* Check metrics */
+  // @TODO uncomment when telemetry is implemented
+  // assert.test('E2E / Metrics', metricsSuite.bind(null, key, fetchMock));
 
   /* Check events in memory */
   assert.test('E2E / Events', eventsSuite.bind(null, fetchMock));

--- a/src/__tests__/nodeSuites/events.spec.js
+++ b/src/__tests__/nodeSuites/events.spec.js
@@ -1,8 +1,9 @@
 
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
+import { settingsFactory } from '../../settings';
+import { url } from '../testUtils';
 
-const settings = SettingsFactory({
+const settings = settingsFactory({
   core: {
     key: 'asd'
   },
@@ -32,7 +33,7 @@ export default function trackAssertions(fetchMock, assert) {
 
   let tsStart, tsEnd;
 
-  fetchMock.postOnce(settings.url('/events/bulk'), (url, opts) => {
+  fetchMock.postOnce(url(settings, '/events/bulk'), (url, opts) => {
     const resp = JSON.parse(opts.body);
 
     // We will test the first and last item in detail.

--- a/src/__tests__/nodeSuites/expected-treatments.spec.js
+++ b/src/__tests__/nodeSuites/expected-treatments.spec.js
@@ -1,11 +1,12 @@
 import { SplitFactory } from '../../';
 import fs from 'fs';
 import rl from 'readline';
+import { url } from '../testUtils';
 
 import splitChangesMockReal from '../mocks/splitchanges.real.json';
 
 export default async function (config, settings, fetchMock, assert) {
-  fetchMock.get({ url: settings.url('/splitChanges?since=-1'), overwriteRoutes: true }, { status: 200, body: splitChangesMockReal });
+  fetchMock.get({ url: url(settings, '/splitChanges?since=-1'), overwriteRoutes: true }, { status: 200, body: splitChangesMockReal });
 
   const splitio = SplitFactory(config);
   const client = splitio.client();

--- a/src/__tests__/nodeSuites/impressions-listener.spec.js
+++ b/src/__tests__/nodeSuites/impressions-listener.spec.js
@@ -1,8 +1,8 @@
 import sinon from 'sinon';
 
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
-const settings = SettingsFactory({
+import { settingsFactory } from '../../settings';
+const settings = settingsFactory({
   core: {
     key: '<fake id>'
   },

--- a/src/__tests__/nodeSuites/impressions.debug.spec.js
+++ b/src/__tests__/nodeSuites/impressions.debug.spec.js
@@ -1,15 +1,16 @@
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
+import { settingsFactory } from '../../settings';
 import splitChangesMock1 from '../mocks/splitchanges.since.-1.json';
 import splitChangesMock2 from '../mocks/splitchanges.since.1457552620999.json';
-import { DEBUG } from '../../utils/constants';
+import { DEBUG } from '@splitsoftware/splitio-commons/src/utils/constants';
+import { url } from '../testUtils';
 
 const baseUrls = {
   sdk: 'https://sdk.baseurl/impressionsSuite',
   events: 'https://events.baseurl/impressionsSuite'
 };
 
-const settings = SettingsFactory({
+const settings = settingsFactory({
   core: {
     key: '<fake id>'
   },
@@ -39,15 +40,15 @@ const config = {
 
 export default async function(key, fetchMock, assert) {
   // Mocking this specific route to make sure we only get the items we want to test from the handlers.
-  fetchMock.getOnce(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
-  fetchMock.get(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock2 });
-  fetchMock.get(new RegExp(`${settings.url('/segmentChanges/')}.*`), { status: 200, body: {since:10, till:10, name: 'segmentName', added: [], removed: []} });
+  fetchMock.getOnce(url(settings, '/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
+  fetchMock.get(url(settings, '/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock2 });
+  fetchMock.get(new RegExp(`${url(settings, '/segmentChanges/')}.*`), { status: 200, body: {since:10, till:10, name: 'segmentName', added: [], removed: []} });
 
   const splitio = SplitFactory(config);
   const client = splitio.client();
   let evaluationsStart = 0, readyEvaluationsStart = 0, evaluationsEnd = 0;
 
-  fetchMock.postOnce(settings.url('/testImpressions/bulk'), (url, opts) => {
+  fetchMock.postOnce(url(settings, '/testImpressions/bulk'), (url, opts) => {
     assert.equal(opts.headers.SplitSDKImpressionsMode, DEBUG);
     const data = JSON.parse(opts.body);
 
@@ -87,7 +88,7 @@ export default async function(key, fetchMock, assert) {
 
     return 200;
   });
-  fetchMock.postOnce(settings.url('/testImpressions/bulk'), 200);
+  fetchMock.postOnce(url(settings, '/testImpressions/bulk'), 200);
 
   splitio.Logger.enable();
   evaluationsStart = Date.now();

--- a/src/__tests__/nodeSuites/impressions.spec.js
+++ b/src/__tests__/nodeSuites/impressions.spec.js
@@ -1,17 +1,18 @@
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
-import { SDK_NOT_READY } from '../../utils/labels';
+import { settingsFactory } from '../../settings';
+import { SDK_NOT_READY } from '@splitsoftware/splitio-commons/src/utils/labels';
 import splitChangesMock1 from '../mocks/splitchanges.since.-1.json';
 import splitChangesMock2 from '../mocks/splitchanges.since.1457552620999.json';
-import { OPTIMIZED } from '../../utils/constants';
-import { truncateTimeFrame } from '../../utils/time';
+import { OPTIMIZED } from '@splitsoftware/splitio-commons/src/utils/constants';
+import { truncateTimeFrame } from '@splitsoftware/splitio-commons/src/utils/time';
+import { url } from '../testUtils';
 
 const baseUrls = {
   sdk: 'https://sdk.baseurl/impressionsSuite',
   events: 'https://events.baseurl/impressionsSuite'
 };
 
-const settings = SettingsFactory({
+const settings = settingsFactory({
   core: {
     key: '<fake id>'
   },
@@ -40,15 +41,15 @@ let truncatedTimeFrame;
 
 export default async function(key, fetchMock, assert) {
   // Mocking this specific route to make sure we only get the items we want to test from the handlers.
-  fetchMock.getOnce(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
-  fetchMock.get(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock2 });
-  fetchMock.get(new RegExp(`${settings.url('/segmentChanges/')}.*`), { status: 200, body: {since:10, till:10, name: 'segmentName', added: [], removed: []} });
+  fetchMock.getOnce(url(settings, '/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
+  fetchMock.get(url(settings, '/splitChanges?since=1457552620999'), { status: 200, body: splitChangesMock2 });
+  fetchMock.get(new RegExp(`${url(settings, '/segmentChanges/')}.*`), { status: 200, body: {since:10, till:10, name: 'segmentName', added: [], removed: []} });
 
   const splitio = SplitFactory(config);
   const client = splitio.client();
   let evaluationsStart = 0, readyEvaluationsStart = 0, evaluationsEnd = 0;
 
-  fetchMock.postOnce(settings.url('/testImpressions/bulk'), (url, opts) => {
+  fetchMock.postOnce(url(settings, '/testImpressions/bulk'), (url, opts) => {
     assert.equal(opts.headers.SplitSDKImpressionsMode, OPTIMIZED);
     const data = JSON.parse(opts.body);
 
@@ -104,9 +105,9 @@ export default async function(key, fetchMock, assert) {
 
     return 200;
   });
-  fetchMock.postOnce(settings.url('/testImpressions/bulk'), 200);
+  fetchMock.postOnce(url(settings, '/testImpressions/bulk'), 200);
 
-  fetchMock.postOnce(settings.url('/testImpressions/count'), (url, opts) => {
+  fetchMock.postOnce(url(settings, '/testImpressions/count'), (url, opts) => {
     const data = JSON.parse(opts.body);
 
     assert.equal(data.pf.length, 3, 'We should generated impressions for three features.');

--- a/src/__tests__/nodeSuites/ip-addresses-setting.spec.js
+++ b/src/__tests__/nodeSuites/ip-addresses-setting.spec.js
@@ -1,9 +1,10 @@
 import osFunction from 'os';
 import ipFunction from 'ip';
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
+import { settingsFactory } from '../../settings';
 import splitChangesMock1 from '../mocks/splitchanges.since.-1.json';
-import { STANDALONE_MODE, CONSUMER_MODE } from '../../utils/constants';
+import { STANDALONE_MODE, CONSUMER_MODE } from '@splitsoftware/splitio-commons/src/utils/constants';
+import { url } from '../testUtils';
 
 // Header keys and expected values. Expected values are obtained with the runtime function evaluated with IPAddressesEnabled in true.
 const HEADER_SPLITSDKMACHINEIP = 'SplitSDKMachineIP';
@@ -69,8 +70,9 @@ const configSamples = [
 const postEndpoints = [
   '/events/bulk',
   '/testImpressions/bulk',
-  '/metrics/times',
-  '/metrics/counters'
+  // @TODO uncomment when telemetry is implemented
+  // '/metrics/times',
+  // '/metrics/counters'
 ];
 
 export default function ipAddressesSettingAssertions(fetchMock, assert) {
@@ -109,7 +111,7 @@ export default function ipAddressesSettingAssertions(fetchMock, assert) {
     };
     const splitio = SplitFactory(config);
     const client = splitio.client();
-    const settings = SettingsFactory(config);
+    const settings = settingsFactory(config);
 
     // Generator to synchronize the destruction of the client when all the post endpoints where called once.
     const finishConfig = (function* () {
@@ -122,21 +124,21 @@ export default function ipAddressesSettingAssertions(fetchMock, assert) {
     })();
 
     // Mock GET endpoints to run client normally
-    fetchMock.getOnce(settings.url('/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
-    fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
-    fetchMock.get(new RegExp(`${settings.url('/segmentChanges/')}.*`), { status: 200, body: { since: 10, till: 10, name: 'segmentName', added: [], removed: [] } });
+    fetchMock.getOnce(url(settings, '/splitChanges?since=-1'), { status: 200, body: splitChangesMock1 });
+    fetchMock.getOnce(url(settings, '/splitChanges?since=1457552620999'), { status: 200, body: { splits: [], since: 1457552620999, till: 1457552620999 } });
+    fetchMock.get(new RegExp(`${url(settings, '/segmentChanges/')}.*`), { status: 200, body: { since: 10, till: 10, name: 'segmentName', added: [], removed: [] } });
 
     // Mock and assert POST endpoints
     postEndpoints.forEach(postEndpoint => {
-      fetchMock.postOnce(settings.url(postEndpoint), (url, opts) => {
+      fetchMock.postOnce(url(settings, postEndpoint), (url, opts) => {
         assertHeaders(settings.core.IPAddressesEnabled, opts);
         finishConfig.next();
         return 200;
       });
-      fetchMock.post(settings.url(postEndpoint), 200);
+      fetchMock.post(url(settings, postEndpoint), 200);
     });
 
-    fetchMock.postOnce(settings.url('/testImpressions/count'), (url, opts) => {
+    fetchMock.postOnce(url(settings, '/testImpressions/count'), (url, opts) => {
       assertHeaders(settings.core.IPAddressesEnabled, opts);
       return 200;
     });

--- a/src/__tests__/nodeSuites/manager.spec.js
+++ b/src/__tests__/nodeSuites/manager.spec.js
@@ -1,9 +1,10 @@
 import { SplitFactory } from '../../';
 import splitChangesMockReal from '../mocks/splitchanges.real.json';
 import map from 'lodash/map';
+import { url } from '../testUtils';
 
 export default async function(settings, fetchMock, assert) {
-  fetchMock.get({ url: settings.url('/splitChanges?since=-1'), overwriteRoutes: true }, { status: 200, body: splitChangesMockReal });
+  fetchMock.get({ url: url(settings, '/splitChanges?since=-1'), overwriteRoutes: true }, { status: 200, body: splitChangesMockReal });
 
   const mockSplits = splitChangesMockReal;
 

--- a/src/__tests__/nodeSuites/push-synchronization.spec.js
+++ b/src/__tests__/nodeSuites/push-synchronization.spec.js
@@ -12,13 +12,13 @@ import splitUpdateWithNewSegmentsMessage from '../mocks/message.SPLIT_UPDATE.145
 
 import authPushEnabled from '../mocks/auth.pushEnabled.node.json';
 
-import { nearlyEqual, mockSegmentChanges, hasNoCacheHeader } from '../testUtils';
+import { nearlyEqual, mockSegmentChanges, url, hasNoCacheHeader } from '../testUtils';
 
-import EventSourceMock, { setMockListener } from '../../sync/__tests__/mocks/eventSourceMock';
-import { __setEventSource } from '../../services/getEventSource/node';
+import EventSourceMock, { setMockListener } from '../testUtils/eventSourceMock';
+import { __setEventSource } from '../../platform/getEventSource/node';
 
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
+import { settingsFactory } from '../../settings';
 
 const key = 'nicolas@split.io';
 const otherUserKey = 'marcio@split.io';
@@ -36,7 +36,7 @@ const config = {
   streamingEnabled: true,
   // debug: true,
 };
-const settings = SettingsFactory(config);
+const settings = settingsFactory(config);
 
 const MILLIS_SSE_OPEN = 100;
 const MILLIS_FIRST_SPLIT_UPDATE_EVENT = 200;
@@ -65,7 +65,7 @@ export function testSynchronization(fetchMock, assert) {
 
   // mock SSE open and message events
   setMockListener(function (eventSourceInstance) {
-    const expectedSSEurl = `${settings.url('/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_segments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabled.token}&v=1.1&heartbeats=true`;
+    const expectedSSEurl = `${url(settings, '/sse')}?channels=NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_segments,NzM2MDI5Mzc0_NDEzMjQ1MzA0Nw%3D%3D_splits,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_pri,%5B%3Foccupancy%3Dmetrics.publishers%5Dcontrol_sec&accessToken=${authPushEnabled.token}&v=1.1&heartbeats=true`;
     assert.equals(eventSourceInstance.url, expectedSSEurl, 'EventSource URL is the expected');
     assert.deepEqual(eventSourceInstance.__eventSourceInitDict, {
       headers: {
@@ -132,73 +132,73 @@ export function testSynchronization(fetchMock, assert) {
   });
 
   // initial auth
-  fetchMock.getOnce(settings.url('/v2/auth'), function (url, opts) {
+  fetchMock.getOnce(url(settings, '/v2/auth'), function (url, opts) {
     if (!opts.headers['Authorization']) assert.fail('`/v2/auth` request must include `Authorization` header');
     assert.pass('auth success');
     return { status: 200, body: authPushEnabled };
   });
 
   // initial split and segment sync
-  fetchMock.getOnce(settings.url('/splitChanges?since=-1'), function (url, opts) {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=-1'), function (url, opts) {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, 0), 'initial sync');
     if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
     return { status: 200, body: splitChangesMock1 };
   });
-  fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=-1'), function (url, opts) {
+  fetchMock.getOnce(url(settings, '/segmentChanges/splitters?since=-1'), function (url, opts) {
     if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
     return { status: 200, body: { since: -1, till: 1457552620999, name: 'splitters', added: [key], removed: [] } };
   });
   // extra retry due to double request (greedy fetch). @TODO: remove once `SplitChangesUpdaterFactory` and `segmentChangesFetcher` are updated
-  fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=1457552620999'), function (url, opts) {
+  fetchMock.getOnce(url(settings, '/segmentChanges/splitters?since=1457552620999'), function (url, opts) {
     if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
     return { status: 200, body: { since: 1457552620999, till: 1457552620999, name: 'splitters', added: [], removed: [] } };
   });
 
   // split and segment sync after SSE opened
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function (url, opts) {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552620999'), function (url, opts) {
     const lapse = Date.now() - start;
     assert.true(nearlyEqual(lapse, MILLIS_SSE_OPEN), 'sync after SSE connection is opened');
     if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
     return { status: 200, body: splitChangesMock2 };
   });
-  fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=1457552620999'), function (url, opts) {
+  fetchMock.getOnce(url(settings, '/segmentChanges/splitters?since=1457552620999'), function (url, opts) {
     if (hasNoCacheHeader(opts)) assert.fail('request must not include `Cache-Control` header');
     return { status: 200, body: { since: 1457552620999, till: 1457552620999, name: 'splitters', added: [], removed: [] } };
   });
 
   // fetch due to SPLIT_UPDATE event
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552620999'), function (url, opts) {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552620999'), function (url, opts) {
     if (!hasNoCacheHeader(opts)) assert.fail('request must include `Cache-Control` header');
     return { status: 200, body: splitChangesMock3 };
   });
 
   // fetch due to SEGMENT_UPDATE event
-  fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=1457552620999'), function (url, opts) {
+  fetchMock.getOnce(url(settings, '/segmentChanges/splitters?since=1457552620999'), function (url, opts) {
     if (!hasNoCacheHeader(opts)) assert.fail('request must include `Cache-Control` header');
     return { status: 200, body: { since: 1457552620999, till: 1457552640000, name: 'splitters', added: [], removed: [key] } };
   });
   // extra retry (greedyFetch until since === till)
-  fetchMock.getOnce(settings.url('/segmentChanges/splitters?since=1457552640000'), function (url, opts) {
+  fetchMock.getOnce(url(settings, '/segmentChanges/splitters?since=1457552640000'), function (url, opts) {
     if (!hasNoCacheHeader(opts)) assert.fail('request must include `Cache-Control` header');
     return { status: 200, body: { since: 1457552640000, till: 1457552640000, name: 'splitters', added: [], removed: [] } };
   });
 
   // fetch due to SPLIT_KILL event
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552649999'), function (url, opts) {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552649999'), function (url, opts) {
     if (!hasNoCacheHeader(opts)) assert.fail('request must include `Cache-Control` header');
     assert.equal(client.getTreatment(key, 'whitelist'), 'not_allowed', 'evaluation with split killed immediately, before fetch is done');
     return { status: 200, body: splitChangesMock4 };
   });
 
   // fetch due to SPLIT_UPDATE event, with an update that involves a new segment
-  fetchMock.getOnce(settings.url('/splitChanges?since=1457552650000'), function (url, opts) {
+  fetchMock.getOnce(url(settings, '/splitChanges?since=1457552650000'), function (url, opts) {
     if (!hasNoCacheHeader(opts)) assert.fail('request must include `Cache-Control` header');
     return { status: 200, body: splitChangesMock5 };
   });
 
-  mockSegmentChanges(fetchMock, new RegExp(`${settings.url('/segmentChanges')}/(employees|developers)`), [key]);
-  mockSegmentChanges(fetchMock, { url: new RegExp(`${settings.url('/segmentChanges')}/new_segment`), repeat: 2 }, [otherUserKey]);
+  mockSegmentChanges(fetchMock, new RegExp(`${url(settings, '/segmentChanges')}/(employees|developers)`), [key]);
+  mockSegmentChanges(fetchMock, { url: new RegExp(`${url(settings, '/segmentChanges')}/new_segment`), repeat: 2 }, [otherUserKey]);
 
   fetchMock.get(new RegExp('.*'), function (url) {
     assert.fail('unexpected GET request with url: ' + url);

--- a/src/__tests__/nodeSuites/ready-promise.spec.js
+++ b/src/__tests__/nodeSuites/ready-promise.spec.js
@@ -28,13 +28,13 @@ function assertGetTreatmentWhenReady(assert, client, key) {
 function assertGetTreatmentControlNotReady(assert, client, key) {
   consoleSpy.log.resetHistory();
   assert.equal(client.getTreatment(key, 'hierarchical_splits_test'), 'control', 'We should get control if client is not ready.');
-  assert.true(consoleSpy.log.calledWithExactly('[WARN]  getTreatment: the SDK is not ready, results may be incorrect. Make sure to wait for SDK readiness before using this method.'), 'Telling us that calling getTreatment would return CONTROL since SDK is not ready at this point.');
+  assert.true(consoleSpy.log.calledWithExactly('[WARN]  splitio => getTreatment: the SDK is not ready, results may be incorrect. Make sure to wait for SDK readiness before using this method.'), 'Telling us that calling getTreatment would return CONTROL since SDK is not ready at this point.');
 }
 
 function assertGetTreatmentControlNotReadyOnDestroy(assert, client, key) {
   consoleSpy.log.resetHistory();
   assert.equal(client.getTreatment(key, 'hierarchical_splits_test'), 'control', 'We should get control if client has been destroyed.');
-  assert.true(consoleSpy.log.calledWithExactly('[ERROR] Client has already been destroyed - no calls possible.'), 'Telling us that client has been destroyed. Calling getTreatment would return CONTROL.');
+  assert.true(consoleSpy.log.calledWithExactly('[ERROR] splitio => getTreatment: Client has already been destroyed - no calls possible.'), 'Telling us that client has been destroyed. Calling getTreatment would return CONTROL.');
 }
 
 /* Validate readiness state transitions, warning and error messages when using ready promises. */
@@ -496,16 +496,16 @@ export default function readyPromiseAssertions(key, fetchMock, assert) {
       client.ready();
 
       assertGetTreatmentWhenReady(t, client, key);
-      t.true(consoleSpy.log.calledWithExactly('[WARN]  No listeners for SDK Readiness detected. Incorrect control treatments could have been logged if you called getTreatment/s while the SDK was not yet ready.'),
+      t.true(consoleSpy.log.calledWithExactly('[WARN]  splitio => No listeners for SDK Readiness detected. Incorrect control treatments could have been logged if you called getTreatment/s while the SDK was not yet ready.'),
         'Warning that there are not listeners for SDK_READY event');
 
       // assert error messages when adding event listeners after SDK has already triggered them
       consoleSpy.log.resetHistory();
       client.on(client.Event.SDK_READY, () => { });
       client.on(client.Event.SDK_READY_TIMED_OUT, () => { });
-      t.true(consoleSpy.log.calledWithExactly('[ERROR] A listener was added for SDK_READY on the SDK, which has already fired and won\'t be emitted again. The callback won\'t be executed.'),
+      t.true(consoleSpy.log.calledWithExactly('[ERROR] splitio => A listener was added for SDK_READY on the SDK, which has already fired and won\'t be emitted again. The callback won\'t be executed.'),
         'Logging error that a listeners for SDK_READY event was added after triggered');
-      t.true(consoleSpy.log.calledWithExactly('[ERROR] A listener was added for SDK_READY_TIMED_OUT on the SDK, which has already fired and won\'t be emitted again. The callback won\'t be executed.'),
+      t.true(consoleSpy.log.calledWithExactly('[ERROR] splitio => A listener was added for SDK_READY_TIMED_OUT on the SDK, which has already fired and won\'t be emitted again. The callback won\'t be executed.'),
         'Logging error that a listeners for SDK_READY_TIMED_OUT event was added after triggered');
 
       client.destroy().then(() => {

--- a/src/__tests__/node_redis.spec.js
+++ b/src/__tests__/node_redis.spec.js
@@ -8,9 +8,9 @@ import RedisServer from 'redis-server';
 import RedisClient from 'ioredis';
 import { exec } from 'child_process';
 import { SplitFactory } from '../';
-import { merge } from '../utils/lang';
-import KeyBuilder from '../storage/Keys';
-import SettingsFactory from '../utils/settings';
+import { merge } from '@splitsoftware/splitio-commons/src/utils/lang';
+import { KeyBuilderSS } from '@splitsoftware/splitio-commons/src/storages/KeyBuilderSS';
+import { settingsFactory } from '../settings';
 import { nearlyEqual } from './testUtils';
 
 const IP_VALUE = ipFunction.address();
@@ -18,6 +18,8 @@ const HOSTNAME_VALUE = osFunction.hostname();
 const NA = 'NA';
 
 const redisPort = '6385';
+
+// @TODO something should be failing here, because we are not setting READY_FROM_CACHE (operational) in consumer mode
 
 const config = {
   core: {
@@ -322,9 +324,9 @@ tape('NodeJS Redis', function (t) {
         for (let config of configs) {
 
           // Redis client and keys required to check Redis store.
-          const setting = SettingsFactory(config);
+          const setting = settingsFactory(config);
           const connection = new RedisClient(setting.storage.options.url);
-          const keys = new KeyBuilder(setting);
+          const keys = new KeyBuilderSS(setting.storage.prefix);
           const eventKey = keys.buildEventsKey();
           const impressionsKey = keys.buildImpressionsKey();
 

--- a/src/__tests__/offline/node.spec.js
+++ b/src/__tests__/offline/node.spec.js
@@ -3,10 +3,11 @@ import path from 'path';
 import tape from 'tape-catch';
 import sinon from 'sinon';
 import fetchMock from '../testUtils/fetchMock';
+import { url } from '../testUtils';
 import { SplitFactory } from '../../';
-import SettingsFactory from '../../utils/settings';
+import { settingsFactory } from '../../settings';
 
-const settings = SettingsFactory({ core: { key: 'facundo@split.io' } });
+const settings = settingsFactory({ core: { key: 'facundo@split.io' } });
 
 const spySplitChanges = sinon.spy();
 const spySegmentChanges = sinon.spy();
@@ -26,14 +27,14 @@ const replySpy = spy => {
 };
 
 const configMocks = () => {
-  fetchMock.mock(new RegExp(`${settings.url('/splitChanges/')}.*`), () => replySpy(spySplitChanges));
-  fetchMock.mock(new RegExp(`${settings.url('/segmentChanges/')}.*`), () => replySpy(spySegmentChanges));
-  fetchMock.mock(new RegExp(`${settings.url('/mySegments/')}.*`), () => replySpy(spyMySegments));
-  fetchMock.mock(settings.url('/events/bulk'), () => replySpy(spyEventsBulk));
-  fetchMock.mock(settings.url('/testImpressions/bulk'), () => replySpy(spyTestImpressionsBulk));
-  fetchMock.mock(settings.url('/testImpressions/count'), () => replySpy(spyTestImpressionsCount));
-  fetchMock.mock(settings.url('/metrics/times'), () => replySpy(spyMetricsTimes));
-  fetchMock.mock(settings.url('/metrics/counters'), () => replySpy(spyMetricsCounters));
+  fetchMock.mock(new RegExp(`${url(settings, '/splitChanges/')}.*`), () => replySpy(spySplitChanges));
+  fetchMock.mock(new RegExp(`${url(settings, '/segmentChanges/')}.*`), () => replySpy(spySegmentChanges));
+  fetchMock.mock(new RegExp(`${url(settings, '/mySegments/')}.*`), () => replySpy(spyMySegments));
+  fetchMock.mock(url(settings, '/events/bulk'), () => replySpy(spyEventsBulk));
+  fetchMock.mock(url(settings, '/testImpressions/bulk'), () => replySpy(spyTestImpressionsBulk));
+  fetchMock.mock(url(settings, '/testImpressions/count'), () => replySpy(spyTestImpressionsCount));
+  fetchMock.mock(url(settings, '/metrics/times'), () => replySpy(spyMetricsTimes));
+  fetchMock.mock(url(settings, '/metrics/counters'), () => replySpy(spyMetricsCounters));
   fetchMock.mock('*', () => replySpy(spyAny));
 };
 
@@ -87,7 +88,7 @@ tape('NodeJS Offline Mode', function (t) {
     client.on(client.Event.SDK_READY_TIMED_OUT, () => {
       assert.pass('If tried to load a file with invalid extension, we should emit SDK_READY_TIMED_OUT.');
 
-      assert.ok(console.log.calledWithMatch(`[ERROR] splitio-producer:offline => There was an issue loading the mock Splits data, no changes will be applied to the current cache. Error: Invalid extension specified for Splits mock file. Accepted extensions are ".yml" and ".yaml". Your specified file is ${config.features}`));
+      assert.ok(console.log.calledWithMatch(`[ERROR] splitio => sync:offline: There was an issue loading the mock Splits data, no changes will be applied to the current cache. Error: Invalid extension specified for Splits mock file. Accepted extensions are ".yml" and ".yaml". Your specified file is ${config.features}`));
 
       console.log.restore();
       client.destroy();

--- a/src/__tests__/push/browser.spec.js
+++ b/src/__tests__/push/browser.spec.js
@@ -1,6 +1,6 @@
 import tape from 'tape-catch';
 import fetchMock from '../testUtils/fetchMock';
-import { testAuthWithPushDisabled, testAuthWith401, testNoEventSource, testNoBase64Support, testSSEWithNonRetryableError } from '../browserSuites/push-initialization-nopush.spec';
+import { testAuthWithPushDisabled, testAuthWith401, testNoEventSource, testSSEWithNonRetryableError } from '../browserSuites/push-initialization-nopush.spec';
 import { testPushRetriesDueToAuthErrors, testPushRetriesDueToSseErrors, testSdkDestroyWhileAuthRetries, testSdkDestroyWhileAuthSuccess, testSdkDestroyWhileConnDelay } from '../browserSuites/push-initialization-retries.spec';
 import { testSynchronization } from '../browserSuites/push-synchronization.spec';
 import { testSynchronizationRetries } from '../browserSuites/push-synchronization-retries.spec';
@@ -16,7 +16,6 @@ tape('## Browser JS - E2E CI Tests for PUSH ##', function (assert) {
   assert.test('E2E / PUSH initialization: auth with push disabled', testAuthWithPushDisabled.bind(null, fetchMock));
   assert.test('E2E / PUSH initialization: auth with 401', testAuthWith401.bind(null, fetchMock));
   assert.test('E2E / PUSH initialization: fallback to polling if EventSource is not available', testNoEventSource.bind(null, fetchMock));
-  assert.test('E2E / PUSH initialization: fallback to polling if `atob` or `btoa` native functions are not available', testNoBase64Support.bind(null, fetchMock));
   assert.test('E2E / PUSH initialization: sse with non-recoverable Ably error', testSSEWithNonRetryableError.bind(null, fetchMock));
 
   // Recoverable issues on inizialization

--- a/src/__tests__/testUtils/fetchMock/node.js
+++ b/src/__tests__/testUtils/fetchMock/node.js
@@ -1,5 +1,5 @@
 import fetchMock from 'fetch-mock';
-import { __setFetch } from '../../../services/getFetch/node';
+import { __setFetch } from '../../../platform/getFetch/node';
 
 const sandboxFetchMock = fetchMock.sandbox();
 

--- a/src/__tests__/testUtils/index.js
+++ b/src/__tests__/testUtils/index.js
@@ -42,3 +42,28 @@ export function mockSegmentChanges(fetchMock, matcher, keys, changeNumber = 1457
 export function hasNoCacheHeader(fetchMockOpts) {
   return fetchMockOpts.headers['Cache-Control'] === 'no-cache';
 }
+
+const eventsEndpointMatcher = /^\/(testImpressions|metrics|events)/;
+const authEndpointMatcher = /^\/v2\/auth/;
+const streamingEndpointMatcher = /^\/(sse|event-stream)/;
+
+/**
+ * Switch URLs servers based on target.
+ * Only used for testing purposes.
+ *
+ * @param {Object} settings settings object
+ * @param {String} target url path
+ * @return {String}  completed url
+ */
+export function url(settings, target) {
+  if (eventsEndpointMatcher.test(target)) {
+    return `${settings.urls.events}${target}`;
+  }
+  if (authEndpointMatcher.test(target)) {
+    return `${settings.urls.auth}${target}`;
+  }
+  if (streamingEndpointMatcher.test(target)) {
+    return `${settings.urls.streaming}${target}`;
+  }
+  return `${settings.urls.sdk}${target}`;
+}


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

Changes in E2E tests are due to:
      - factory.settings.url function is not defined. A util function is used instead
      - client.__context --> client.__getStatus
      - location of internal modules (like constants or settingsFactory) have changed
      - changes in log messages
      - Removed a push browser test, "testNoBase64Support", since JS-commons includes a ponyfill of `atob` and `btoa`
      - Updated GaToSplit test. Need to call `factory.Logger.enable()`, because logger settings is per instance.
      - Updated SplitToGa E2E test due to a non-breaking behavior change: the integration checks the availability of the `ga` command on each queue call

## How do we test the changes introduced in this PR?

## Extra Notes