### PR TITLE
Add impressions queue size limit functionality

### DIFF
--- a/src/__tests__/browserSuites/impressions.debug.spec.js
+++ b/src/__tests__/browserSuites/impressions.debug.spec.js
@@ -34,7 +34,8 @@ export default function (fetchMock, assert) {
       featuresRefreshRate: 0.5,
       segmentsRefreshRate: 0.5,
       metricsRefreshRate: 3000,
-      impressionsRefreshRate: 0.5
+      impressionsRefreshRate: 3000,
+      impressionsQueueSize: 3 // flush impressions when 3 are queued
     },
     startup: {
       eventsFirstPushWindow: 3000

--- a/ts-tests/index.ts
+++ b/ts-tests/index.ts
@@ -466,6 +466,7 @@ let fullBrowserSettings: SplitIO.IBrowserSettings = {
   scheduler: {
     featuresRefreshRate: 1,
     impressionsRefreshRate: 1,
+    impressionsQueueSize: 1,
     metricsRefreshRate: 1,
     segmentsRefreshRate: 1,
     offlineRefreshRate: 1,
@@ -511,6 +512,7 @@ let fullNodeSettings: SplitIO.INodeSettings = {
   scheduler: {
     featuresRefreshRate: 1,
     impressionsRefreshRate: 1,
+    impressionsQueueSize: 1,
     metricsRefreshRate: 1,
     segmentsRefreshRate: 1,
     offlineRefreshRate: 1,
@@ -555,6 +557,7 @@ let fullAsyncSettings: SplitIO.INodeAsyncSettings = {
   scheduler: {
     featuresRefreshRate: 1,
     impressionsRefreshRate: 1,
+    impressionsQueueSize: 1,
     metricsRefreshRate: 1,
     segmentsRefreshRate: 1,
     offlineRefreshRate: 1,

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -69,6 +69,7 @@ interface ISettings {
   readonly scheduler: {
     featuresRefreshRate: number,
     impressionsRefreshRate: number,
+    impressionsQueueSize: number,
     metricsRefreshRate: number,
     segmentsRefreshRate: number,
     offlineRefreshRate: number,
@@ -249,6 +250,13 @@ interface INodeBasicSettings extends ISharedSettings {
      * @default 300
      */
     impressionsRefreshRate?: number,
+    /**
+     * The maximum number of impression items we want to queue. If we queue more values, it will trigger a flush and reset the timer.
+     * If you use a 0 here, the queue will have no maximum size.
+     * @property {number} impressionsQueueSize
+     * @default 30000
+     */
+    impressionsQueueSize?: number,
     /**
      * The SDK sends diagnostic metrics to Split servers. This parameters controls this metric flush period in seconds.
      * @property {number} metricsRefreshRate
@@ -887,6 +895,13 @@ declare namespace SplitIO {
        * @default 60
        */
       impressionsRefreshRate?: number,
+      /**
+       * The maximum number of impression items we want to queue. If we queue more values, it will trigger a flush and reset the timer.
+       * If you use a 0 here, the queue will have no maximum size.
+       * @property {number} impressionsQueueSize
+       * @default 30000
+       */
+      impressionsQueueSize?: number,
       /**
        * The SDK sends diagnostic metrics to Split servers. This parameters controls this metric flush period in seconds.
        * @property {number} metricsRefreshRate


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

- Update type definitions
- Update E2E tests to validate `impressionsQueueSize` config param

## How do we test the changes introduced in this PR?

## Extra Notes