### PR TITLE
[JS-commons migration] User consent type definitions

### DIFF
--- a/ts-tests/index.ts
+++ b/ts-tests/index.ts
@@ -421,7 +421,14 @@ let attr: SplitIO.Attributes = {
 
 stored = browserClient.setAttributes(attr);
 let storedAttr: SplitIO.Attributes = browserClient.getAttributes();
-removed = browserClient.clearAttributes()
+removed = browserClient.clearAttributes();
+
+/**** Tests for user consent setter/getter ****/
+
+let userConsent: SplitIO.ConsentStatus;
+userConsent = BrowserSDK.getUserConsent();
+BrowserSDK.setUserConsent(true);
+BrowserSDK.setUserConsent(false);
 
 /**** Tests for fully crowded settings interfaces ****/
 
@@ -498,10 +505,13 @@ let fullBrowserSettings: SplitIO.IBrowserSettings = {
   sync: {
     splitFilters: splitFilters,
     impressionsMode: 'DEBUG'
-  }
+  },
+  userConsent: 'GRANTED'
 };
 fullBrowserSettings.storage.type = 'MEMORY';
 fullBrowserSettings.integrations[0].type = 'GOOGLE_ANALYTICS_TO_SPLIT';
+fullBrowserSettings.userConsent = 'DECLINED';
+fullBrowserSettings.userConsent = 'UNKNOWN';
 
 let fullNodeSettings: SplitIO.INodeSettings = {
   core: {

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -111,7 +111,7 @@ interface ISettings {
     impressionsMode: SplitIO.ImpressionsMode,
   }
   /**
-   * User consent status if using in browser, or undefined if using in Node.
+   * User consent status if using in browser. Undefined if using in Node.
    */
   readonly userConsent?: ConsentStatus
 }
@@ -1015,10 +1015,10 @@ declare namespace SplitIO {
     integrations?: BrowserIntegration[],
     /**
      * User consent status. Possible values are `'GRANTED'`, which is the default, `'DECLINED'` or `'UNKNOWN'`.
-     * - `'GRANTED'`: the user has granted consent for tracking events and impressions. The SDK will internally track and send them to Split cloud.
-     * - `'DECLINED'`: the user has declined consent for tracking events and impressions. The SDK will not internally track neither send them to Split cloud.
-     * - `'UNKNOWN'`: the user has neither granted nor declined consent for tracking events and impressions. The SDK will track them in its storage, and eventually send
-     * them or not if the consent status is set to 'GRANTED' or 'DECLINED' respectively. The status can be updated at any time with the `setUserConsent` factory method.
+     * - `'GRANTED'`: the user has granted consent for tracking events and impressions. The SDK will send them to Split cloud.
+     * - `'DECLINED'`: the user has declined consent for tracking events and impressions. The SDK will not send them to Split cloud.
+     * - `'UNKNOWN'`: the user has neither granted nor declined consent for tracking events and impressions. The SDK will track them in its internal storage, and eventually send
+     * them or not if the consent status is updated to 'GRANTED' or 'DECLINED' respectively. The status can be updated at any time with the `setUserConsent` factory method.
      *
      * @typedef {string} userConsent
      * @default 'GRANTED'
@@ -1150,14 +1150,14 @@ declare namespace SplitIO {
     client(key: SplitKey, trafficType?: string): IBrowserClient
     /**
      * Set or update the user consent status. Possible values are `true` and `false`, which represent user consent `'GRANTED'` and `'DECLINED'` respectively.
-     * - `'GRANTED'`: the user has granted consent for tracking events and impressions. The SDK will internally track and send them to Split cloud.
-     * - `'DECLINED'`: the user has declined consent for tracking events and impressions. The SDK will not internally track neither send them to Split cloud.
+     * - `true ('GRANTED')`: the user has granted consent for tracking events and impressions. The SDK will send them to Split cloud.
+     * - `false ('DECLINED')`: the user has declined consent for tracking events and impressions. The SDK will not send them to Split cloud.
      *
      * NOTE: calling this method updates the user consent at a factory level, affecting all clients of the same factory.
      *
      * @function setUserConsent
      * @param {boolean} userConsent The user consent status, true for 'GRANTED' and false for 'DECLINED'.
-     * @returns {boolean} Whether the consent status was updated successfully or not. The latter occurs if the provided param is not a boolean value.
+     * @returns {boolean} Whether the provided param is a valid value (i.e., a boolean value) or not.
      */
     setUserConsent(userConsent: boolean): boolean;
     /**

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -53,6 +53,11 @@ type SDKMode = 'standalone' | 'consumer';
  */
 type StorageType = 'MEMORY' | 'LOCALSTORAGE' | 'REDIS';
 /**
+ * User consent status.
+ * @typedef {string} ConsentStatus
+ */
+type ConsentStatus = 'granted' | 'declined' | 'unknown';
+/**
  * Settings interface. This is a representation of the settings the SDK expose, that's why
  * most of it's props are readonly. Only features should be rewritten when localhost mode is active.
  * @interface ISettings
@@ -105,6 +110,10 @@ interface ISettings {
     splitFilters: SplitIO.SplitFilter[],
     impressionsMode: SplitIO.ImpressionsMode,
   }
+  /**
+   * User consent status if using in browser, or undefined if using in Node.
+   */
+  userConsent?: ConsentStatus
 }
 /**
  * Log levels.
@@ -1004,6 +1013,17 @@ declare namespace SplitIO {
      * @property {Object} integrations
      */
     integrations?: BrowserIntegration[],
+    /**
+     * User consent status. Possible values are 'granted', which is the default, 'declined' or 'unknown'.
+     * - 'granted': the user has granted consent for tracking events and impressions. The SDK will internally track and send them to Split cloud.
+     * - 'declined': the user has declined consent for tracking events and impressions. The SDK will not internally track neither send them to Split cloud.
+     * - 'unknown': the user has neither granted nor declined consent for tracking events and impressions. The SDK will track them in its storage,
+     * and eventually send or drop them if the user consent is set to 'granted' or 'declined' respectively.
+     * User consent status can be updated dinamically with the `setUserConsent` factory method.
+     *
+     * @typedef {string} ConsentStatus
+     */
+    userConsent?: ConsentStatus
   }
   /**
    * Settings interface for SDK instances created on NodeJS.
@@ -1128,6 +1148,24 @@ declare namespace SplitIO {
      * @returns {IBrowserClient} The client instance.
      */
     client(key: SplitKey, trafficType?: string): IBrowserClient
+    /**
+     * Set the user consent status. Possible values are 'granted', 'declined' or 'unknown'.
+     * - 'granted': the user has granted consent for tracking events and impressions. The SDK will internally track and send them to Split cloud.
+     * - 'declined': the user has declined consent for tracking events and impressions. The SDK will not internally track neither send them to Split cloud.
+     * - 'unknown': the user has neither granted nor declined consent for tracking events and impressions. The SDK will track them in its storage,
+     * and eventually send or drop them if the user consent is set to 'granted' or 'declined' respectively.
+     *
+     * @function setUserConsent
+     * @param {ConsentStatus} userConsent The user consent status.
+     */
+    setUserConsent(userConsent: ConsentStatus): void;
+    /**
+     * Get the user consent status.
+     *
+     * @function getUserConsent
+     * @returns {ConsentStatus} userConsent The user consent status.
+     */
+    getUserConsent(): ConsentStatus;
   }
   /**
    * This represents the interface for the SDK instance with asynchronous storage.

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -56,7 +56,7 @@ type StorageType = 'MEMORY' | 'LOCALSTORAGE' | 'REDIS';
  * User consent status.
  * @typedef {string} ConsentStatus
  */
-type ConsentStatus = 'granted' | 'declined' | 'unknown';
+type ConsentStatus = 'GRANTED' | 'DECLINED' | 'UNKNOWN';
 /**
  * Settings interface. This is a representation of the settings the SDK expose, that's why
  * most of it's props are readonly. Only features should be rewritten when localhost mode is active.
@@ -1014,13 +1014,14 @@ declare namespace SplitIO {
      */
     integrations?: BrowserIntegration[],
     /**
-     * User consent status. Possible values are `'granted'`, which is the default, `'declined'` or `'unknown'`.
-     * - `'granted'`: the user has granted consent for tracking events and impressions. The SDK will internally track and send them to Split cloud.
-     * - `'declined'`: the user has declined consent for tracking events and impressions. The SDK will not internally track neither send them to Split cloud.
-     * - `'unknown'`: the user has neither granted nor declined consent for tracking events and impressions. The SDK will track them in its storage, and eventually send
-     * them or not if the consent status is set to 'granted' or 'declined' respectively. The status can be updated at any time with the `setUserConsent` factory method.
+     * User consent status. Possible values are `'GRANTED'`, which is the default, `'DECLINED'` or `'UNKNOWN'`.
+     * - `'GRANTED'`: the user has granted consent for tracking events and impressions. The SDK will internally track and send them to Split cloud.
+     * - `'DECLINED'`: the user has declined consent for tracking events and impressions. The SDK will not internally track neither send them to Split cloud.
+     * - `'UNKNOWN'`: the user has neither granted nor declined consent for tracking events and impressions. The SDK will track them in its storage, and eventually send
+     * them or not if the consent status is set to 'GRANTED' or 'DECLINED' respectively. The status can be updated at any time with the `setUserConsent` factory method.
      *
-     * @typedef {string} ConsentStatus
+     * @typedef {string} userConsent
+     * @default 'GRANTED'
      */
     userConsent?: ConsentStatus
   }
@@ -1148,14 +1149,14 @@ declare namespace SplitIO {
      */
     client(key: SplitKey, trafficType?: string): IBrowserClient
     /**
-     * Set or update the user consent status. Possible values are `true` and `false`, which represent user consent `'granted'` and `'declined'` respectively.
-     * - `'granted'`: the user has granted consent for tracking events and impressions. The SDK will internally track and send them to Split cloud.
-     * - `'declined'`: the user has declined consent for tracking events and impressions. The SDK will not internally track neither send them to Split cloud.
+     * Set or update the user consent status. Possible values are `true` and `false`, which represent user consent `'GRANTED'` and `'DECLINED'` respectively.
+     * - `'GRANTED'`: the user has granted consent for tracking events and impressions. The SDK will internally track and send them to Split cloud.
+     * - `'DECLINED'`: the user has declined consent for tracking events and impressions. The SDK will not internally track neither send them to Split cloud.
      *
      * NOTE: calling this method updates the user consent at a factory level, affecting all clients of the same factory.
      *
      * @function setUserConsent
-     * @param {boolean} userConsent The user consent status, true for 'granted' and false for 'declined'.
+     * @param {boolean} userConsent The user consent status, true for 'GRANTED' and false for 'DECLINED'.
      * @returns {boolean} Whether the consent status was updated successfully or not. The latter occurs if the provided param is not a boolean value.
      */
     setUserConsent(userConsent: boolean): boolean;

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -1017,9 +1017,8 @@ declare namespace SplitIO {
      * User consent status. Possible values are `'granted'`, which is the default, `'declined'` or `'unknown'`.
      * - `'granted'`: the user has granted consent for tracking events and impressions. The SDK will internally track and send them to Split cloud.
      * - `'declined'`: the user has declined consent for tracking events and impressions. The SDK will not internally track neither send them to Split cloud.
-     * - `'unknown'`: the user has neither granted nor declined consent for tracking events and impressions. The SDK will track them in its storage,
-     * and eventually send or drop them if the user consent is set to 'granted' or 'declined' respectively.
-     * User consent status can be changed dinamically with the `setUserConsent` client method.
+     * - `'unknown'`: the user has neither granted nor declined consent for tracking events and impressions. The SDK will track them in its storage, and eventually send
+     * them or not if the consent status is set to 'granted' or 'declined' respectively. The status can be updated at any time with the `setUserConsent` factory method.
      *
      * @typedef {string} ConsentStatus
      */
@@ -1148,6 +1147,25 @@ declare namespace SplitIO {
      * @returns {IBrowserClient} The client instance.
      */
     client(key: SplitKey, trafficType?: string): IBrowserClient
+    /**
+     * Set or update the user consent status. Possible values are `true` and `false`, which represent user consent `'granted'` and `'declined'` respectively.
+     * - `'granted'`: the user has granted consent for tracking events and impressions. The SDK will internally track and send them to Split cloud.
+     * - `'declined'`: the user has declined consent for tracking events and impressions. The SDK will not internally track neither send them to Split cloud.
+     *
+     * NOTE: calling this method updates the user consent at a factory level, affecting all clients of the same factory.
+     *
+     * @function setUserConsent
+     * @param {boolean} userConsent The user consent status, true for 'granted' and false for 'declined'.
+     * @returns {boolean} Whether the consent status was updated successfully or not. The latter occurs if the provided param is not a boolean value.
+     */
+    setUserConsent(userConsent: boolean): boolean;
+    /**
+     * Get the user consent status.
+     *
+     * @function getUserConsent
+     * @returns {ConsentStatus} The user consent status.
+     */
+    getUserConsent(): ConsentStatus;
   }
   /**
    * This represents the interface for the SDK instance with asynchronous storage.
@@ -1334,28 +1352,7 @@ declare namespace SplitIO {
      *
      * @returns {boolean} true if all attribute were removed and false otherwise
      */
-    clearAttributes(): boolean,
-    /**
-     * Update the user consent status. Possible values are `'granted'`, `'declined'` or `'unknown'`.
-     * Other possible values are `true`, equivalent to `'granted'`, and `false`, equivalent to `'declined'`.
-     * - `'granted'`: the user has granted consent for tracking events and impressions. The SDK will internally track and send them to Split cloud.
-     * - `'declined'`: the user has declined consent for tracking events and impressions. The SDK will not internally track neither send them to Split cloud.
-     * - `'unknown'`: the user has neither granted nor declined consent for tracking events and impressions. The SDK will track them in its storage,
-     * and eventually send or drop them if the user consent is set to 'granted' or 'declined' respectively.
-     *
-     * NOTE: calling this method updates the user consent at a factory level, affecting all clients of the same factory.
-     *
-     * @function setUserConsent
-     * @param {ConsentStatus | boolean} userConsent The user consent status.
-     */
-    setUserConsent(userConsent: ConsentStatus | boolean): void;
-    /**
-     * Get the user consent status.
-     *
-     * @function getUserConsent
-     * @returns {ConsentStatus} userConsent The user consent status.
-     */
-    getUserConsent(): ConsentStatus;
+    clearAttributes(): boolean
   }
   /**
    * This represents the interface for the Client instance with asynchronous storage.

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -113,7 +113,7 @@ interface ISettings {
   /**
    * User consent status if using in browser, or undefined if using in Node.
    */
-  userConsent?: ConsentStatus
+  readonly userConsent?: ConsentStatus
 }
 /**
  * Log levels.
@@ -1149,7 +1149,7 @@ declare namespace SplitIO {
      */
     client(key: SplitKey, trafficType?: string): IBrowserClient
     /**
-     * Set the user consent status. Possible values are 'granted', 'declined' or 'unknown'.
+     * Update the user consent status. Possible values are 'granted', 'declined' or 'unknown'.
      * - 'granted': the user has granted consent for tracking events and impressions. The SDK will internally track and send them to Split cloud.
      * - 'declined': the user has declined consent for tracking events and impressions. The SDK will not internally track neither send them to Split cloud.
      * - 'unknown': the user has neither granted nor declined consent for tracking events and impressions. The SDK will track them in its storage,

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -1014,12 +1014,12 @@ declare namespace SplitIO {
      */
     integrations?: BrowserIntegration[],
     /**
-     * User consent status. Possible values are 'granted', which is the default, 'declined' or 'unknown'.
-     * - 'granted': the user has granted consent for tracking events and impressions. The SDK will internally track and send them to Split cloud.
-     * - 'declined': the user has declined consent for tracking events and impressions. The SDK will not internally track neither send them to Split cloud.
-     * - 'unknown': the user has neither granted nor declined consent for tracking events and impressions. The SDK will track them in its storage,
+     * User consent status. Possible values are `'granted'`, which is the default, `'declined'` or `'unknown'`.
+     * - `'granted'`: the user has granted consent for tracking events and impressions. The SDK will internally track and send them to Split cloud.
+     * - `'declined'`: the user has declined consent for tracking events and impressions. The SDK will not internally track neither send them to Split cloud.
+     * - `'unknown'`: the user has neither granted nor declined consent for tracking events and impressions. The SDK will track them in its storage,
      * and eventually send or drop them if the user consent is set to 'granted' or 'declined' respectively.
-     * User consent status can be updated dinamically with the `setUserConsent` factory method.
+     * User consent status can be changed dinamically with the `setUserConsent` client method.
      *
      * @typedef {string} ConsentStatus
      */
@@ -1148,24 +1148,6 @@ declare namespace SplitIO {
      * @returns {IBrowserClient} The client instance.
      */
     client(key: SplitKey, trafficType?: string): IBrowserClient
-    /**
-     * Update the user consent status. Possible values are 'granted', 'declined' or 'unknown'.
-     * - 'granted': the user has granted consent for tracking events and impressions. The SDK will internally track and send them to Split cloud.
-     * - 'declined': the user has declined consent for tracking events and impressions. The SDK will not internally track neither send them to Split cloud.
-     * - 'unknown': the user has neither granted nor declined consent for tracking events and impressions. The SDK will track them in its storage,
-     * and eventually send or drop them if the user consent is set to 'granted' or 'declined' respectively.
-     *
-     * @function setUserConsent
-     * @param {ConsentStatus} userConsent The user consent status.
-     */
-    setUserConsent(userConsent: ConsentStatus): void;
-    /**
-     * Get the user consent status.
-     *
-     * @function getUserConsent
-     * @returns {ConsentStatus} userConsent The user consent status.
-     */
-    getUserConsent(): ConsentStatus;
   }
   /**
    * This represents the interface for the SDK instance with asynchronous storage.
@@ -1352,7 +1334,28 @@ declare namespace SplitIO {
      *
      * @returns {boolean} true if all attribute were removed and false otherwise
      */
-    clearAttributes(): boolean
+    clearAttributes(): boolean,
+    /**
+     * Update the user consent status. Possible values are `'granted'`, `'declined'` or `'unknown'`.
+     * Other possible values are `true`, equivalent to `'granted'`, and `false`, equivalent to `'declined'`.
+     * - `'granted'`: the user has granted consent for tracking events and impressions. The SDK will internally track and send them to Split cloud.
+     * - `'declined'`: the user has declined consent for tracking events and impressions. The SDK will not internally track neither send them to Split cloud.
+     * - `'unknown'`: the user has neither granted nor declined consent for tracking events and impressions. The SDK will track them in its storage,
+     * and eventually send or drop them if the user consent is set to 'granted' or 'declined' respectively.
+     *
+     * NOTE: calling this method updates the user consent at a factory level, affecting all clients of the same factory.
+     *
+     * @function setUserConsent
+     * @param {ConsentStatus | boolean} userConsent The user consent status.
+     */
+    setUserConsent(userConsent: ConsentStatus | boolean): void;
+    /**
+     * Get the user consent status.
+     *
+     * @function getUserConsent
+     * @returns {ConsentStatus} userConsent The user consent status.
+     */
+    getUserConsent(): ConsentStatus;
   }
   /**
    * This represents the interface for the Client instance with asynchronous storage.

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -53,11 +53,6 @@ type SDKMode = 'standalone' | 'consumer';
  */
 type StorageType = 'MEMORY' | 'LOCALSTORAGE' | 'REDIS';
 /**
- * User consent status.
- * @typedef {string} ConsentStatus
- */
-type ConsentStatus = 'GRANTED' | 'DECLINED' | 'UNKNOWN';
-/**
  * Settings interface. This is a representation of the settings the SDK expose, that's why
  * most of it's props are readonly. Only features should be rewritten when localhost mode is active.
  * @interface ISettings
@@ -113,7 +108,7 @@ interface ISettings {
   /**
    * User consent status if using in browser. Undefined if using in Node.
    */
-  readonly userConsent?: ConsentStatus
+  readonly userConsent?: SplitIO.ConsentStatus
 }
 /**
  * Log levels.
@@ -848,6 +843,11 @@ declare namespace SplitIO {
   * @typedef {string} ImpressionsMode
   */
   type ImpressionsMode = 'OPTIMIZED' | 'DEBUG';
+  /**
+   * User consent status.
+   * @typedef {string} ConsentStatus
+   */
+  type ConsentStatus = 'GRANTED' | 'DECLINED' | 'UNKNOWN';
   /**
    * Settings interface for SDK instances created on the browser
    * @interface IBrowserSettings


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

Added in client-side API:
- User consent config param
- Methods to set/get user consent dynamically

## How do we test the changes introduced in this PR?

- Updated type definition tests

## Extra Notes