### PR TITLE
[JS-commons migration] Avoid appending `SPLITIO` suffix twice in storage prefix

### DIFF
--- a/src/__tests__/errorCatching/browser.spec.js
+++ b/src/__tests__/errorCatching/browser.spec.js
@@ -19,7 +19,7 @@ const settings = settingsFactory({
 
 // prepare localstorage to emit SDK_READY_FROM_CACHE
 localStorage.clear();
-localStorage.setItem('errorCatching.SPLITIO.splits.till', 25);
+localStorage.setItem('SPLITIO.splits.till', 25);
 
 fetchMock.get(url(settings, '/splitChanges?since=25'), function () {
   return new Promise((res) => { setTimeout(() => res({ status: 200, body: splitChangesMock1 }), 1000); });
@@ -54,7 +54,7 @@ tape('Error catching on callbacks - Browsers', assert => {
     },
     storage: {
       type: 'LOCALSTORAGE',
-      prefix: 'errorCatching'
+      // Default prefix 'SPLITIO.'
     },
     streamingEnabled: false
   });

--- a/src/__tests__/node_redis.spec.js
+++ b/src/__tests__/node_redis.spec.js
@@ -10,6 +10,7 @@ import { exec } from 'child_process';
 import { SplitFactory } from '../';
 import { merge } from '@splitsoftware/splitio-commons/src/utils/lang';
 import { KeyBuilderSS } from '@splitsoftware/splitio-commons/src/storages/KeyBuilderSS';
+import { validatePrefix } from '@splitsoftware/splitio-commons/src/storages/KeyBuilder';
 import { settingsFactory } from '../settings';
 import { nearlyEqual } from './testUtils';
 
@@ -327,7 +328,7 @@ tape('NodeJS Redis', function (t) {
           // Redis client and keys required to check Redis store.
           const setting = settingsFactory(config);
           const connection = new RedisClient(setting.storage.options.url);
-          const keys = new KeyBuilderSS(setting.storage.prefix);
+          const keys = new KeyBuilderSS(validatePrefix(setting.storage.prefix));
           const eventKey = keys.buildEventsKey();
           const impressionsKey = keys.buildImpressionsKey();
 

--- a/src/settings/__tests__/node.spec.js
+++ b/src/settings/__tests__/node.spec.js
@@ -44,11 +44,11 @@ tape('SETTINGS / Redis options should be properly parsed', assert => {
   });
 
   assert.deepEqual(settingsWithUrl.storage, {
-    type: 'REDIS', prefix: 'test_prefix.SPLITIO', options: { url: 'test_url', connectionTimeout: 11, operationTimeout: 22 }
+    type: 'REDIS', prefix: 'test_prefix', options: { url: 'test_url', connectionTimeout: 11, operationTimeout: 22 }
   }, 'Redis storage settings and options should be passed correctly, url settings takes precedence when we are pointing to Redis.');
 
   assert.deepEqual(settingsWithoutUrl.storage, {
-    type: 'REDIS', prefix: 'test_prefix.SPLITIO', options: { host: 'host', port: 'port', pass: 'pass', db: 'db', connectionTimeout: 33, operationTimeout: 44 }
+    type: 'REDIS', prefix: 'test_prefix', options: { host: 'host', port: 'port', pass: 'pass', db: 'db', connectionTimeout: 33, operationTimeout: 44 }
   }, 'Redis storage settings and options should be passed correctly, url settings takes precedence when we are pointing to Redis.');
 
   assert.end();

--- a/src/settings/storage/browser.js
+++ b/src/settings/storage/browser.js
@@ -15,12 +15,6 @@ export function validateStorage(settings) {
   } = settings;
   let __originalType;
 
-  if (prefix) {
-    prefix += '.SPLITIO';
-  } else {
-    prefix = 'SPLITIO';
-  }
-
   const fallbackToMemory = () => {
     __originalType = type;
     type = STORAGE_MEMORY;

--- a/src/settings/storage/node.js
+++ b/src/settings/storage/node.js
@@ -11,12 +11,6 @@ export function validateStorage(settings) {
     } = { type: STORAGE_MEMORY }
   } = settings;
 
-  if (prefix) {
-    prefix += '.SPLITIO';
-  } else {
-    prefix = 'SPLITIO';
-  }
-
   // We can have MEMORY, REDIS or an invalid storage type
   switch (type) {
     case STORAGE_REDIS: {


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

Bug fix. Set `SPLITIO` as prefix instead of `SPLITIO.SPLITIO` if no prefix is provided for Local and Redis Storage.

## How do we test the changes introduced in this PR?

## Extra Notes