### PR TITLE
[JS-commons migration] User consent integration and config validation for NodeJS and Browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -437,9 +437,9 @@
       "dev": true
     },
     "@splitsoftware/splitio-commons": {
-      "version": "1.2.1-rc.4",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.2.1-rc.4.tgz",
-      "integrity": "sha512-C+CVlo8b3K6gR3JnxPdB8AbMrlb6NWRUO2TZy7Mq7LaeJBr2I1BeVlphN817/EUbZi2bPl98DiypWaJFmg8Ocw==",
+      "version": "1.2.1-rc.5",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.2.1-rc.5.tgz",
+      "integrity": "sha512-Pk5subG7tWke4KuXS3wBnxnsCZ6cNSFSGJsv/BLYmm5pH3SUTDTL0biq80xJdtzRET+9ESAvO8ECqzCePre7BA==",
       "requires": {
         "tslib": "^2.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "node": ">=6"
   },
   "dependencies": {
-    "@splitsoftware/splitio-commons": "1.2.1-rc.4",
+    "@splitsoftware/splitio-commons": "1.2.1-rc.5",
     "@types/google.analytics": "0.0.40",
     "ioredis": "^4.28.0",
     "ip": "1.1.5",

--- a/src/factory/browser.js
+++ b/src/factory/browser.js
@@ -12,6 +12,7 @@ import { __InLocalStorageMockFactory } from '@splitsoftware/splitio-commons/src/
 import { sdkFactory } from '@splitsoftware/splitio-commons/src/sdkFactory';
 import { LOCALHOST_MODE, STORAGE_LOCALSTORAGE } from '@splitsoftware/splitio-commons/src/utils/constants';
 import { shouldAddPt } from '@splitsoftware/splitio-commons/src/trackers/impressionObserver/utils';
+import { userConsentProps } from '@splitsoftware/splitio-commons/src/sdkFactory/userConsentProps';
 
 import { settingsFactory } from '../settings/browser';
 import { platform, SignalListener } from '../platform';
@@ -54,6 +55,8 @@ function getModules(settings) {
     integrationsManagerFactory: settings.integrations && settings.integrations.length > 0 ? integrationsManagerFactory.bind(null, settings.integrations) : undefined,
 
     impressionsObserverFactory: shouldAddPt(settings) ? impressionObserverCSFactory : undefined,
+
+    extraProps: userConsentProps
   };
 
   switch (settings.mode) {

--- a/src/settings/__tests__/browser.spec.js
+++ b/src/settings/__tests__/browser.spec.js
@@ -30,3 +30,16 @@ tape('SETTINGS / Integrations should be properly parsed', assert => {
 
   assert.end();
 });
+
+tape('SETTINGS / Consent is overwritable and "GRANTED" by default in client-side', assert => {
+  let settings = settingsFactory({});
+  assert.equal(settings.userConsent, 'GRANTED', 'userConsent defaults to granted if not provided.');
+
+  settings = settingsFactory({ userConsent: 'INVALID-VALUE' });
+  assert.equal(settings.userConsent, 'GRANTED', 'userConsent defaults to granted if a wrong value is provided.');
+
+  settings = settingsFactory({ userConsent: 'UNKNOWN' });
+  assert.equal(settings.userConsent, 'UNKNOWN', 'userConsent can be overwritten.');
+
+  assert.end();
+});

--- a/src/settings/__tests__/node.spec.js
+++ b/src/settings/__tests__/node.spec.js
@@ -141,3 +141,10 @@ tape('SETTINGS / Log error and fallback to InMemory storage if no valid storage 
   logSpy.restore();
   assert.end();
 });
+
+tape('SETTINGS / Consent is not overwritable in server-side', assert => {
+  const settings = settingsFactory({ userConsent: 'UNKNOWN' });
+
+  assert.equal(settings.userConsent, undefined, 'userConsent cannot be overwritten in NodeJS.');
+  assert.end();
+});

--- a/src/settings/browser.js
+++ b/src/settings/browser.js
@@ -5,6 +5,7 @@ import { validateStorage } from './storage/browser';
 import { validateIntegrations } from './integrations/browser';
 import { validateLogger } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/logger/builtinLogger';
 import { LocalhostFromObject } from '@splitsoftware/splitio-commons/src/sync/offline/LocalhostFromObject';
+import { validateConsent } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/consent';
 
 const params = {
   defaults,
@@ -13,6 +14,7 @@ const params = {
   integrations: validateIntegrations,
   logger: validateLogger,
   localhost: () => LocalhostFromObject(),
+  consent: validateConsent,
 };
 
 export function settingsFactory(config) {

--- a/src/settings/defaults/browser.js
+++ b/src/settings/defaults/browser.js
@@ -1,4 +1,5 @@
 import { packageVersion } from './version';
+import { CONSENT_GRANTED } from '@splitsoftware/splitio-commons/src/utils/constants';
 
 export const defaults = {
   startup: {
@@ -11,6 +12,9 @@ export const defaults = {
     // Amount of time we will wait before the first push of events.
     eventsFirstPushWindow: 10
   },
+
+  // Consent is considered granted by default
+  userConsent: CONSENT_GRANTED,
 
   // Instance version.
   version: `javascript-${packageVersion}`,

--- a/src/settings/node.js
+++ b/src/settings/node.js
@@ -11,6 +11,7 @@ const params = {
   storage: validateStorage,
   logger: validateLogger,
   localhost: () => LocalhostFromFile(),
+  consent: () => undefined, // resets settings.userConsent to the default
   // In Node.js the SDK ignores `config.integrations`, so a validator for integrations is not required
 };
 


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

- Integrated user consent modules from JS-commons.
- Added validation of `userConsent` config param. 
  - In server-side (NodeJS), the config is not overwritable: any provided value defaults to `undefined`. 
  - In client-side (Browser), the config is overwritable, with `'GRANTED'` as the default value.

## How do we test the changes introduced in this PR?

- Added unit tests

## Extra Notes