### PR TITLE
Update js-yaml dependency

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -51,14 +51,14 @@ jobs:
         run: BUILD_BRANCH=$(echo "${GITHUB_REF#refs/heads/}") BUILD_COMMIT=${{ github.sha }} npm run build
 
       - name: Configure AWS credentials (development)
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/development' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/refactor_localhostfromfile' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: arn:aws:iam::079419646996:role/public-assets
           aws-region: us-east-1
 
       - name: Upload to S3 (development)
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/development' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/refactor_localhostfromfile' }}
         run: aws s3 sync $SOURCE_DIR s3://$BUCKET/$DEST_DIR $ARGS
         env:
           BUCKET: split-public-stage

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -51,14 +51,14 @@ jobs:
         run: BUILD_BRANCH=$(echo "${GITHUB_REF#refs/heads/}") BUILD_COMMIT=${{ github.sha }} npm run build
 
       - name: Configure AWS credentials (development)
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/refactor_localhostfromfile' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/development' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: arn:aws:iam::079419646996:role/public-assets
           aws-region: us-east-1
 
       - name: Upload to S3 (development)
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/refactor_localhostfromfile' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/development' }}
         run: aws s3 sync $SOURCE_DIR s3://$BUCKET/$DEST_DIR $ARGS
         env:
           BUCKET: split-public-stage

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 10.20.1 (July XX, 2022)
 - Updated browser listener to push remaining impressions and events on 'visibilitychange' and 'pagehide' DOM events, instead of 'unload', which is not reliable in mobile and modern Web browsers (See https://developer.chrome.com/blog/page-lifecycle-api/#legacy-lifecycle-apis-to-avoid).
 - Updated the synchronization flow to be more reliable in the event of an edge case generating delay in cache purge propagation, keeping the SDK cache properly synced.
+- Bugfixing - Moved js-yaml dependency from @splitsoftware/splitio-commons to avoid issues in Node v14 when installing third-party dependencies that also uses js-yaml as a transitive dependency (Related to issue https://github.com/splitio/javascript-client/issues/662)
 
 10.20.0 (June 29, 2022)
 - Added a new config option to control the tasks that listen or poll for updates on feature flags and segments, via the new config sync.enabled . Running online Split will always pull the most recent updates upon initialization, this only affects updates fetching on a running instance. Useful when a consistent session experience is a must or to save resources when updates are not being used.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.20.1-rc.1",
+  "version": "10.20.1-rc.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -486,9 +486,9 @@
       "dev": true
     },
     "@splitsoftware/splitio-commons": {
-      "version": "1.5.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.5.1-rc.1.tgz",
-      "integrity": "sha512-NeVreo+igjYrlcWPq0gMEyE6QTxSv906S96X1XmibP/vcJFS90E9Vbr4GAAZKxrV0qh2FC5nMoGtYD7T4nhlhQ==",
+      "version": "1.5.1-rc.2",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.5.1-rc.2.tgz",
+      "integrity": "sha512-0A+SDFhrtjQvFB4nVxVJiil2jKxv2bLLJDiHAtIU8SQA6M98LMQlF59heO6BKoe9C7fKwp466SzyFgpNn2n1RQ==",
       "requires": {
         "tslib": "^2.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "10.20.1-rc.1",
+  "version": "10.20.1-rc.2",
   "description": "Split SDK",
   "files": [
     "README.md",
@@ -32,11 +32,11 @@
     "node": ">=6"
   },
   "dependencies": {
-    "@splitsoftware/splitio-commons": "1.5.1-rc.1",
+    "@splitsoftware/splitio-commons": "1.5.1-rc.2",
     "@types/google.analytics": "0.0.40",
     "@types/ioredis": "^4.28.0",
     "ioredis": "^4.28.0",
-    "js-yaml": "3.13.1",
+    "js-yaml": "^3.13.1",
     "node-fetch": "^2.6.7",
     "unfetch": "^4.2.0"
   },

--- a/src/settings/defaults/version.js
+++ b/src/settings/defaults/version.js
@@ -1,1 +1,1 @@
-export const packageVersion = '10.20.1-rc.1';
+export const packageVersion = '10.20.1-rc.2';

--- a/src/settings/node.js
+++ b/src/settings/node.js
@@ -1,6 +1,6 @@
 import { settingsValidation } from '@splitsoftware/splitio-commons/src/utils/settingsValidation';
 import { validateLogger } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/logger/builtinLogger';
-import { LocalhostFromFile } from '@splitsoftware/splitio-commons/src/sync/offline/LocalhostFromFile';
+import { LocalhostFromFile } from '../sync/offline/LocalhostFromFile';
 
 import { defaults } from './defaults/node';
 import { validateStorage } from './storage/node';

--- a/src/sync/offline/LocalhostFromFile.js
+++ b/src/sync/offline/LocalhostFromFile.js
@@ -1,0 +1,11 @@
+import { splitsParserFromFileFactory } from './splitsParserFromFile';
+import { syncManagerOfflineFactory } from '@splitsoftware/splitio-commons/src/sync/offline/syncManagerOffline';
+
+// Singleton instance of the factory function for offline SyncManager from YAML file (a.k.a. localhostFromFile)
+// Requires Node 'fs' and 'path' APIs.
+const localhostFromFile = syncManagerOfflineFactory(splitsParserFromFileFactory);
+localhostFromFile.type = 'LocalhostFromFile';
+
+export function LocalhostFromFile() {
+  return localhostFromFile;
+}

--- a/src/sync/offline/LocalhostFromFile.js
+++ b/src/sync/offline/LocalhostFromFile.js
@@ -2,7 +2,7 @@ import { splitsParserFromFileFactory } from './splitsParserFromFile';
 import { syncManagerOfflineFactory } from '@splitsoftware/splitio-commons/src/sync/offline/syncManagerOffline';
 
 // Singleton instance of the factory function for offline SyncManager from YAML file (a.k.a. localhostFromFile)
-// Requires Node 'fs' and 'path' APIs.
+// It uses NodeJS APIs.
 const localhostFromFile = syncManagerOfflineFactory(splitsParserFromFileFactory);
 localhostFromFile.type = 'LocalhostFromFile';
 

--- a/src/sync/offline/splitsParserFromFile.js
+++ b/src/sync/offline/splitsParserFromFile.js
@@ -1,0 +1,172 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import { isString, endsWith, find, forOwn, uniq, } from '@splitsoftware/splitio-commons/src/utils/lang';
+import { parseCondition } from '@splitsoftware/splitio-commons/src/sync/offline/splitsParser/parseCondition';
+
+const logPrefix = 'sync:offline:splits-fetcher: ';
+
+const DEFAULT_FILENAME = '.split';
+
+function configFilesPath(configFilePath) {
+  if (configFilePath === DEFAULT_FILENAME || !isString(configFilePath)) {
+    let root = process.env.HOME;
+
+    if (process.env.SPLIT_CONFIG_ROOT) root = process.env.SPLIT_CONFIG_ROOT;
+
+    if (!root) throw new Error('Missing split mock configuration root.');
+
+    configFilePath = path.join(root, DEFAULT_FILENAME);
+  }
+
+  // Validate the extensions
+  if (!(endsWith(configFilePath, '.yaml', true) || endsWith(configFilePath, '.yml', true) || endsWith(configFilePath, '.split', true)))
+    throw new Error(`Invalid extension specified for Splits mock file. Accepted extensions are ".yml" and ".yaml". Your specified file is ${configFilePath}`);
+
+  if (!fs.existsSync(configFilePath))
+    throw new Error(`Split configuration not found in ${configFilePath} - Please review your Split file location.`);
+
+  return configFilePath;
+}
+
+// This function is not pure nor meant to be. Here we apply modifications to cover
+// for behaviour that's ensured by the BE.
+function arrangeConditions(mocksData) {
+  // Iterate through each Split data
+  forOwn(mocksData, data => {
+    const conditions = data.conditions;
+
+    // On the manager, as the split jsons come with all treatments on the partitions prop,
+    // we'll add all the treatments to the first condition.
+    const firstRolloutCondition = find(conditions, cond => cond.conditionType === 'ROLLOUT');
+    // Malformed mocks may have
+    const treatments = uniq(data.treatments);
+    // If they're only specifying a whitelist we add the treatments there.
+    const allTreatmentsCondition = firstRolloutCondition ? firstRolloutCondition : conditions[0];
+
+    const fullyAllocatedTreatment = allTreatmentsCondition.partitions[0].treatment;
+
+    treatments.forEach(treatment => {
+      if (treatment !== fullyAllocatedTreatment) {
+        allTreatmentsCondition.partitions.push({
+          treatment, size: 0
+        });
+      }
+    });
+
+    // Don't need these anymore
+    delete data.treatments;
+  });
+}
+
+export function splitsParserFromFileFactory() {
+
+  let previousMock = 'NO_MOCK_LOADED';
+
+  // Parse `.split` configuration file and return a map of "Split Objects"
+  function readSplitConfigFile(log, filePath) {
+    const SPLIT_POSITION = 0;
+    const TREATMENT_POSITION = 1;
+    let data;
+
+    try {
+      data = fs.readFileSync(filePath, 'utf-8');
+    } catch (e) {
+      log.error(e && e.message);
+
+      return {};
+    }
+
+    if (data === previousMock) return false;
+    previousMock = data;
+
+    const splitObjects = data.split(/\r?\n/).reduce((accum, line, index) => {
+      let tuple = line.trim();
+
+      if (tuple === '' || tuple.charAt(0) === '#') {
+        log.debug(logPrefix + `Ignoring empty line or comment at #${index}`);
+      } else {
+        tuple = tuple.split(/\s+/);
+
+        if (tuple.length !== 2) {
+          log.debug(logPrefix + `Ignoring line since it does not have exactly two columns #${index}`);
+        } else {
+          const splitName = tuple[SPLIT_POSITION];
+          const condition = parseCondition({ treatment: tuple[TREATMENT_POSITION] });
+          accum[splitName] = { conditions: [condition], configurations: {}, trafficTypeName: 'localhost' };
+        }
+      }
+
+      return accum;
+    }, {});
+
+    return splitObjects;
+  }
+
+  // Parse `.yml` or `.yaml` configuration files and return a map of "Split Objects"
+  function readYAMLConfigFile(log, filePath) {
+    let data = '';
+    let yamldoc = null;
+
+    try {
+      data = fs.readFileSync(filePath, 'utf8');
+
+      if (data === previousMock) return false;
+      previousMock = data;
+
+      yamldoc = yaml.safeLoad(data);
+    } catch (e) {
+      log.error(e);
+
+      return {};
+    }
+
+    // Each entry will be mapped to a condition, but we'll also keep the configurations map.
+    const mocksData = (yamldoc).reduce((accum, splitEntry) => {
+      const splitName = Object.keys(splitEntry)[0];
+
+      if (!splitName || !isString(splitEntry[splitName].treatment))
+        log.error(logPrefix + 'Ignoring entry on YAML since the format is incorrect.');
+
+      const mockData = splitEntry[splitName];
+
+      // "Template" for each split accumulated data
+      if (!accum[splitName]) {
+        accum[splitName] = {
+          configurations: {}, conditions: [], treatments: [], trafficTypeName: 'localhost'
+        };
+      }
+
+      // Assign the config if there is one on the mock
+      if (mockData.config) accum[splitName].configurations[mockData.treatment] = mockData.config;
+      // Parse the condition from the entry.
+      const condition = parseCondition(mockData);
+      accum[splitName].conditions[condition.conditionType === 'ROLLOUT' ? 'push' : 'unshift'](condition);
+      // Also keep track of the treatments, will be useful for manager functionality.
+      accum[splitName].treatments.push(mockData.treatment);
+
+      return accum;
+    }, {});
+
+    arrangeConditions(mocksData);
+
+    return mocksData;
+  }
+
+  // Load the content of a configuration file into an Object
+  return function splitsParserFromFile({ features, log }) {
+    const filePath = configFilesPath(features);
+    let mockData;
+
+    // If we have a filePath, it means the extension is correct, choose the parser.
+    if (endsWith(filePath, '.split')) {
+      log.warn(logPrefix + '.split mocks will be deprecated soon in favor of YAML files, which provide more targeting power. Take a look in our documentation.');
+      mockData = readSplitConfigFile(log, filePath);
+    } else {
+      mockData = readYAMLConfigFile(log, filePath);
+    }
+
+    return mockData;
+  };
+
+}


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

Move `js-yaml` dependency from @splitsoftware/splitio-commons to @splitsoftware/splitio, to avoid issues in Node v14 when installing third-party dependencies that also uses js-yaml as a transitive dependency (Related to #662 )

## How do we test the changes introduced in this PR?

Covered by E2E tests already.

Reproduction steps:

```sh
nvm use 14
npm install @splitsoftware/splitio@10.20.1-rc.1 js-yaml@4.0.0
npm uninstall js-yaml
```

## Extra Notes