### PR TITLE
Update SDK key validation in NodeJS

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,7 @@
     - Updated the following SDK manager methods to expose flag sets on flag views.
  - Added `defaultTreatment` property to the `SplitView` object returned by the `split` and `splits` methods of the SDK manager (Related to issue https://github.com/splitio/javascript-commons/issues/225).
  - Updated @splitsoftware/splitio-commons package to version 1.11.0 that includes vulnerability fixes, and adds the `defaultTreatment` property to the `SplitView` object.
+ - Bugfixing - Fixed SDK key validation in NodeJS to ensure the SDK_READY_TIMED_OUT event is emitted when a client-side type SDK key is provided instead of a server-side one (Related to issue https://github.com/splitio/javascript-client/issues/768).
 
 10.23.1 (September 22, 2023)
  - Updated @splitsoftware/splitio-commons package to version 1.9.1. This update removes the handler for 'unload' DOM events, that can prevent browsers from being able to put pages in the back/forward cache for faster back and forward loads (Related to issue https://github.com/splitio/javascript-client/issues/759).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "10.23.2-rc.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@splitsoftware/splitio-commons": "1.10.1-rc.3",
+        "@splitsoftware/splitio-commons": "1.10.1-rc.4",
         "@types/google.analytics": "0.0.40",
         "@types/ioredis": "^4.28.0",
         "bloom-filters": "^3.0.0",
@@ -874,9 +874,9 @@
       "dev": true
     },
     "node_modules/@splitsoftware/splitio-commons": {
-      "version": "1.10.1-rc.3",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.10.1-rc.3.tgz",
-      "integrity": "sha512-eqJxAMtqFK7fXFKL8gMGfRsMBdxrYI9tIGUHHpY1NcyeKkn4OWqAOZMhX6z2qLdBArzHi34Li0Lb72o+Bh1Tqg==",
+      "version": "1.10.1-rc.4",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.10.1-rc.4.tgz",
+      "integrity": "sha512-4fYPz6cjW55N1Ah/BI+q1c06zc989chAQQ4tZwh/+MtSLgaZXLdhd/YGeaESwUqbZ3DCgf5bjyQZFDQnluCjiA==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -7111,9 +7111,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tty-browserify": {
       "version": "0.0.1",
@@ -8446,9 +8446,9 @@
       "dev": true
     },
     "@splitsoftware/splitio-commons": {
-      "version": "1.10.1-rc.3",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.10.1-rc.3.tgz",
-      "integrity": "sha512-eqJxAMtqFK7fXFKL8gMGfRsMBdxrYI9tIGUHHpY1NcyeKkn4OWqAOZMhX6z2qLdBArzHi34Li0Lb72o+Bh1Tqg==",
+      "version": "1.10.1-rc.4",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.10.1-rc.4.tgz",
+      "integrity": "sha512-4fYPz6cjW55N1Ah/BI+q1c06zc989chAQQ4tZwh/+MtSLgaZXLdhd/YGeaESwUqbZ3DCgf5bjyQZFDQnluCjiA==",
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -13296,9 +13296,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tty-browserify": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "node": ">=6"
   },
   "dependencies": {
-    "@splitsoftware/splitio-commons": "1.10.1-rc.3",
+    "@splitsoftware/splitio-commons": "1.10.1-rc.4",
     "@types/google.analytics": "0.0.40",
     "@types/ioredis": "^4.28.0",
     "bloom-filters": "^3.0.0",

--- a/src/__tests__/nodeSuites/readiness.spec.js
+++ b/src/__tests__/nodeSuites/readiness.spec.js
@@ -39,12 +39,19 @@ export default function (fetchMock, assert) {
       t.fail('### IS READY - NOT TIMED OUT when it should.');
       t.end();
     });
-    client.once(client.Event.SDK_READY_TIMED_OUT, () => {
+    client.once(client.Event.SDK_READY_TIMED_OUT, async () => {
       t.pass('### SDK TIMED OUT - SegmentChanges requests with client-side SDK key should fail with 403. Timed out.');
 
       t.false(client.track('some_key', 'some_tt', 'some_event_type'), 'since client is flagged as destroyed, client.track returns false');
+      t.equal(client.getTreatment('hierarchical_splits_test'), 'control', 'since client is flagged as destroyed, client.getTreatment returns control');
 
-      client.destroy().then(() => { t.end(); });
+      // ready promise should reject
+      try {
+        await client.ready();
+      } catch (e) {
+        await client.destroy();
+        t.end();
+      }
     });
   });
 

--- a/src/__tests__/nodeSuites/readiness.spec.js
+++ b/src/__tests__/nodeSuites/readiness.spec.js
@@ -1,0 +1,51 @@
+import { SplitFactory } from '../../';
+
+import splitChangesMock1 from '../mocks/splitchanges.since.-1.json';
+import splitChangesMock2 from '../mocks/splitchanges.since.1457552620999.json';
+
+const readyTimeout = 0.1;
+
+const baseConfig = {
+  core: {
+    authorizationKey: '<fake-token>',
+  },
+  startup: {
+    readyTimeout,
+  },
+  streamingEnabled: false
+};
+
+export default function (fetchMock, assert) {
+
+  assert.test(t => { // Timeout test: we provide a client-side SDK key on server-side (403 error)
+    const testUrls = {
+      sdk: 'https://sdk.baseurl/readinessSuite1',
+      events: 'https://events.baseurl/readinessSuite1'
+    };
+
+    fetchMock.getOnce(testUrls.sdk + '/splitChanges?since=-1', { status: 200, body: splitChangesMock1 });
+    fetchMock.getOnce(testUrls.sdk + '/splitChanges?since=1457552620999', { status: 200, body: splitChangesMock2 });
+    fetchMock.get(new RegExp(testUrls.sdk + '/segmentChanges/*'), 403);
+    fetchMock.postOnce(testUrls.events + '/events/bulk', 200);
+
+    const splitio = SplitFactory({
+      ...baseConfig, urls: testUrls
+    });
+    const client = splitio.client();
+
+    t.true(client.track('some_key', 'some_tt', 'some_event_type'), 'since client is not destroyed, client.track returns true');
+
+    client.once(client.Event.SDK_READY, () => {
+      t.fail('### IS READY - NOT TIMED OUT when it should.');
+      t.end();
+    });
+    client.once(client.Event.SDK_READY_TIMED_OUT, () => {
+      t.pass('### SDK TIMED OUT - SegmentChanges requests with client-side SDK key should fail with 403. Timed out.');
+
+      t.false(client.track('some_key', 'some_tt', 'some_event_type'), 'since client is flagged as destroyed, client.track returns false');
+
+      client.destroy().then(() => { t.end(); });
+    });
+  });
+
+}

--- a/src/__tests__/online/node.spec.js
+++ b/src/__tests__/online/node.spec.js
@@ -14,6 +14,7 @@ import expectedTreatmentsSuite from '../nodeSuites/expected-treatments.spec';
 import managerSuite from '../nodeSuites/manager.spec';
 import ipAddressesSetting from '../nodeSuites/ip-addresses-setting.spec';
 import ipAddressesSettingDebug from '../nodeSuites/ip-addresses-setting.debug.spec';
+import readinessSuite from '../nodeSuites/readiness.spec';
 import readyPromiseSuite from '../nodeSuites/ready-promise.spec';
 import { fetchSpecificSplits, fetchSpecificSplitsForFlagSets } from '../nodeSuites/fetch-specific-splits.spec';
 
@@ -77,6 +78,9 @@ tape('## Node JS - E2E CI Tests ##', async function (assert) {
   /* Check IP address and Machine name headers when IP address setting is enabled and disabled */
   assert.test('E2E / IP Addresses Setting', ipAddressesSetting.bind(null, fetchMock));
   assert.test('E2E / IP Addresses Setting Debug', ipAddressesSettingDebug.bind(null, fetchMock));
+
+  /* Validate readiness */
+  assert.test('E2E / Readiness', readinessSuite.bind(null, fetchMock));
 
   /* Validate readiness with ready promises */
   assert.test('E2E / Ready promise', readyPromiseSuite.bind(null, key, fetchMock));


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

Add a test to validate that NodeJS SDK times out when a client-side SDK key is provided.

## How do we test the changes introduced in this PR?

## Extra Notes

Related to issue https://github.com/splitio/javascript-client/issues/768