### PR TITLE
[Breaking change] Fix client `ready()` method when using async/await syntax [ON HOLD]

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,7 @@
     - TypeScript definitions:
        - Removed an overloaded `client` method in the `SplitIO.ISDK` interface that accepted `key` and `trafficType` parameters. This interface corresponds to the SDK factory instance in NodeJS, which, unlike `SplitIO.IBrowserSDK` for the Browser, does not handle multiple client instances based on keys.
        - Updated the `SplitIO.IBrowserSDK` and `SplitIO.IBrowserClient` interfaces to no longer extend the `SplitIO.ISDK` and `SplitIO.IClient` interfaces respectively, as the SDK factory instance in NodeJS or server-side (`SplitIO.ISDK`) has a different API than the SDK client instance in the Browser or client-side (`SplitIO.IBrowserClient`).
+    - Bugfixing - Fixed an issue with the client `ready` method that was causing the returned promise to hang on async/await syntax if the promise was rejected. The fix implies a breaking change, since now the user must handle the promise rejection explicitly or set the `startup.readyTimeout` configuration option to 0 to avoid the timeout and thus the rejection.
 
 10.28.0 (September 6, 2024)
  - Updated @splitsoftware/splitio-commons package to version 1.17.0 that includes minor updates:

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -441,17 +441,7 @@ interface IStatusInterface extends EventEmitter {
   /**
    * Returns a promise that resolves once the SDK has finished loading (`SDK_READY` event emitted) or rejected if the SDK has timedout (`SDK_READY_TIMED_OUT` event emitted).
    * As it's meant to provide similar flexibility to the event approach, given that the SDK might be eventually ready after a timeout event, the `ready` method will return a resolved promise once the SDK is ready.
-   *
-   * Caveats: the method was designed to avoid an unhandled Promise rejection if the rejection case is not handled, so that `onRejected` handler is optional when using promises.
-   * However, when using async/await syntax, the rejection should be explicitly propagated like in the following example:
-   * ```
-   * try {
-   *   await client.ready().catch((e) => { throw e; });
-   *   // SDK is ready
-   * } catch(e) {
-   *   // SDK has timedout
-   * }
-   * ```
+   * You must handle the promise rejection to avoid an unhandled promise rejection error, or you can set the `startup.readyTimeout` configuration option to 0 to avoid the timeout and thus the rejection.
    *
    * @function ready
    * @returns {Promise<void>}


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

## How do we test the changes introduced in this PR?

## Extra Notes