### PR TITLE
Refactor: add `init` method and `onReadyFromCacheCb` param to storage factory [WIP]

### DIFF
--- a/src/__tests__/offline/browser.spec.js
+++ b/src/__tests__/offline/browser.spec.js
@@ -112,8 +112,6 @@ tape('Browser offline mode', function (assert) {
     });
 
     const sdkReadyFromCache = (client) => () => {
-      assert.equal(factory.settings.storage.type, 'MEMORY', 'In localhost mode, storage must fallback to memory storage');
-
       const clientStatus = client.__getStatus();
       assert.equal(clientStatus.isReadyFromCache, true, 'If ready from cache, READY_FROM_CACHE status must be true');
       assert.equal(clientStatus.isReady, false, 'READY status must not be set before READY_FROM_CACHE');

--- a/src/factory/browser.js
+++ b/src/factory/browser.js
@@ -8,7 +8,6 @@ import { sdkManagerFactory } from '@splitsoftware/splitio-commons/src/sdkManager
 import { sdkClientMethodCSFactory } from '@splitsoftware/splitio-commons/src/sdkClient/sdkClientMethodCSWithTT';
 import { impressionObserverCSFactory } from '@splitsoftware/splitio-commons/src/trackers/impressionObserver/impressionObserverCS';
 import { integrationsManagerFactory } from '@splitsoftware/splitio-commons/src/integrations/browser';
-import { __InLocalStorageMockFactory } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/storage/storageCS';
 import { sdkFactory } from '@splitsoftware/splitio-commons/src/sdkFactory';
 import { LOCALHOST_MODE, STORAGE_LOCALSTORAGE } from '@splitsoftware/splitio-commons/src/utils/constants';
 import { createUserConsentAPI } from '@splitsoftware/splitio-commons/src/consent/sdkUserConsent';
@@ -20,10 +19,8 @@ const syncManagerOnlineCSFactory = syncManagerOnlineFactory(pollingManagerCSFact
 
 function getStorage(settings) {
   return settings.storage.type === STORAGE_LOCALSTORAGE ?
-    InLocalStorage(settings.storage)
-    : settings.storage.__originalType === STORAGE_LOCALSTORAGE ?
-      __InLocalStorageMockFactory
-      : InMemoryStorageCSFactory;
+    InLocalStorage(settings.storage) :
+    InMemoryStorageCSFactory;
 }
 
 /**

--- a/src/settings/storage/browser.js
+++ b/src/settings/storage/browser.js
@@ -1,36 +1,23 @@
 import { isLocalStorageAvailable } from '@splitsoftware/splitio-commons/src/utils/env/isLocalStorageAvailable';
-import { LOCALHOST_MODE, STORAGE_MEMORY } from '@splitsoftware/splitio-commons/src/utils/constants';
+import { STORAGE_MEMORY } from '@splitsoftware/splitio-commons/src/utils/constants';
 
 const STORAGE_LOCALSTORAGE = 'LOCALSTORAGE';
 
 export function validateStorage(settings) {
   let {
     log,
-    mode,
     storage: {
       type,
       options = {},
       prefix
     } = { type: STORAGE_MEMORY },
   } = settings;
-  let __originalType;
-
-  const fallbackToMemory = () => {
-    __originalType = type;
-    type = STORAGE_MEMORY;
-  };
-
-  // In localhost mode, fallback to Memory storage and track original type to emit SDK_READY_FROM_CACHE if corresponds.
-  // ATM, other mode settings (e.g., 'consumer') are ignored in client-side API, and so treated as standalone.
-  if (mode === LOCALHOST_MODE && type === STORAGE_LOCALSTORAGE) {
-    fallbackToMemory();
-  }
 
   // If an invalid storage type is provided OR we want to use LOCALSTORAGE and
   // it's not available, fallback into MEMORY
   if (type !== STORAGE_MEMORY && type !== STORAGE_LOCALSTORAGE ||
     type === STORAGE_LOCALSTORAGE && !isLocalStorageAvailable()) {
-    fallbackToMemory();
+    type = STORAGE_MEMORY;
     log.error('Invalid or unavailable storage. Fallback into MEMORY storage');
   }
 
@@ -38,6 +25,5 @@ export function validateStorage(settings) {
     type,
     options,
     prefix,
-    __originalType
   };
 }


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

## How do we test the changes introduced in this PR?

## Extra Notes

- Related to https://github.com/splitio/javascript-commons/pull/352