### PR TITLE
Prepare release v11.0.1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,11 +1,16 @@
+11.0.1 (November 8, 2024)
+ - Bugfixing - Revert removal of TypeScript `SplitIO` namespace at `/types/splitio.d.ts` to allow explicit imports of types from the JavaScript SDK package. E.g., `import type { IBrowserSettings } from '@splitsoftware/splitio/types/splitio';`.
+
 11.0.0 (November 1, 2024)
  - Added support for targeting rules based on large segments for browsers (client-side API).
  - Added `factory.destroy()` method, which invokes the `destroy` method of all clients created by the factory.
  - Updated @splitsoftware/splitio-commons package to version 2.0.0 that includes major updates and updated some transitive dependencies for vulnerability fixes.
  - Renamed distribution folders from `/lib` to `/cjs` for CommonJS build, and `/es` to `/esm` for ECMAScript Modules build.
  - BREAKING CHANGES:
+    - NOTE: Refer to ./MIGRATION-GUIDE.md for instructions on how to migrate your codebase from version 0.x to 1.0.0.
     - Dropped support for Split Proxy below version 5.9.0, when using in the browser (client-side API). The SDK now requires Split Proxy 5.9.0 or above.
     - Dropped support for NodeJS v6. The SDK now requires NodeJS v14 or above.
+    - Removed TypeScript `SplitIO` namespace from `@splitsoftware/splitio/types/splitio`. Reverted in 11.0.1.
     - Removed internal ponyfills for the `Map` and `Set` global objects, dropping support for IE and other outdated browsers. The SDK now requires the runtime environment to support these features natively or provide a polyfill.
     - Removed the deprecated `GOOGLE_ANALYTICS_TO_SPLIT` and `SPLIT_TO_GOOGLE_ANALYTICS` integrations. The `integrations` configuration option has been removed from the SDK factory configuration, along with the associated interfaces in the TypeScript definitions.
     - Removed the `core.trafficType` configuration option (`SplitIO.IBrowserSettings['core']['trafficType]`) and the `trafficType` parameter from the SDK `client()` method in Browser (`SplitIO.IBrowserSDK['client']`). As a result, traffic types can no longer be bound to SDK clients, and the traffic type must be provided in the `track` method.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splitsoftware/splitio",
-      "version": "11.0.0",
+      "version": "11.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@splitsoftware/splitio-commons": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "description": "Split SDK",
   "files": [
     "README.md",

--- a/src/settings/defaults/version.js
+++ b/src/settings/defaults/version.js
@@ -1,1 +1,1 @@
-export const packageVersion = '11.0.0';
+export const packageVersion = '11.0.1';

--- a/ts-tests/index.ts
+++ b/ts-tests/index.ts
@@ -11,9 +11,16 @@
  * @author Nico Zelaya <nicolas.zelaya@split.io>
  */
 
+import type * as SplitTypes from '../types/splitio';
+
 import { SplitFactory } from '../types/index';
 import { SplitFactory as SplitFactoryCS } from '../types/client';
 import { SplitFactory as SplitFactorySS } from '../types/server';
+
+// Validate that the SplitIO namespace is available and matches the types when imported explicitly
+let ambientType: SplitIO.ISDK;
+let importedType: SplitTypes.ISDK;
+ambientType = importedType;
 
 let stringPromise: Promise<string>;
 let splitNamesPromise: Promise<SplitIO.SplitNames>;
@@ -468,6 +475,7 @@ let attr: SplitIO.Attributes = {
   stringArrayAttribute: ['value1', 'value2'],
   numberArrayAttribute: [1, 2]
 }
+let attr2: SplitTypes.Attributes = attr;
 
 stored = browserClient.setAttributes(attr);
 let storedAttr: SplitIO.Attributes = browserClient.getAttributes();

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://www.split.io/
 // Definitions by: Nico Zelaya <https://github.com/NicoZelaya/>
 
-import '@splitsoftware/splitio-commons';
+/// <reference path="./splitio.d.ts" />
 
 export = JsSdk;
 

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -1,0 +1,6 @@
+// Type definitions for JavaScript and NodeJS Split Software SDK
+
+import '@splitsoftware/splitio-commons';
+
+export as namespace SplitIO;
+export = SplitIO;


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

Revert removal of TypeScript `SplitIO` namespace at `/types/splitio.d.ts` to allow explicit imports of types from the JS SDK package. E.g., import type { IBrowserSettings } from '@splitsoftware/splitio/types/splitio';.

## How do we test the changes introduced in this PR?

Added asserts in TS tests.

## Extra Notes