### PR TITLE
Change JsSdk module declaration to namespace

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,7 +6,7 @@
 
 export = JsSdk;
 
-declare module JsSdk {
+declare namespace JsSdk {
   /**
    * Split.io SDK factory function.
    * The settings parameter should be an object that complies with the SplitIO.INodeAsyncSettings.


### PR DESCRIPTION
https://github.com/microsoft/typescript-go/pull/2760

Typescript 7 has deprecated module syntax, please update your typing to stop it from breaking compilation.